### PR TITLE
Sprint 1: Explorer-Gefuehl im Scan-Bereich (#29, #26, #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Hinzugefuegt
+- **Explorer-Gefuehl im Scan-Bereich (Sprint 1, Issues #29/#26/#23)**
+  - Ordner-Kacheln im PDF-Raster: ".." (uebergeordneter Ordner) und alle Unterordner
+    mit PDF-Anzahl; Doppelklick wechselt hinein, PDFs lassen sich per Drag & Drop
+    direkt in eine Kachel verschieben
+  - Klickbarer Breadcrumb-Pfad unter der Kopfzeile; Menue Ansicht -> "Uebergeordneter
+    Ordner" (Alt+Up), wie im Windows-Explorer
+  - Zielordner-Baum: Doppelklick oeffnet den Ordner links, ohne vorher die selektierte
+    PDF zu verschieben (Einfachklick wird erst nach dem Doppelklick-Intervall ausgefuehrt);
+    Kontextmenue "Ordner links oeffnen"
+  - Versteckte Ordner (., $, ~) werden ausgeblendet, Unterordner alphabetisch sortiert
+
+### Tests
+- `tests/conftest.py`: `patch_singletons()` ersetzt Singleton-Fabriken in allen src-Modulen
+  (GUI-Tests liefen je nach Import-Reihenfolge gegen die echte Nutzer-Config)
+
 ## [0.14.0] - 2026-08-25
 
 ### Hinzugefuegt

--- a/ENTWICKLUNGSSTAND.md
+++ b/ENTWICKLUNGSSTAND.md
@@ -1,7 +1,7 @@
 # PDF Sortier Meister - Entwicklungsstand
 
 **Datum:** 25.08.2026
-**Aktuelle Version:** 0.14.0
+**Aktuelle Version:** 0.14.0 (+ Sprint 1 Explorer-Gefuehl in Entwicklung)
 
 > **Was ist neu in v0.13.0?** Siehe [Changelog v0.13.0](#changelog-v0130) am Ende des Dokuments.
 

--- a/src/core/file_manager.py
+++ b/src/core/file_manager.py
@@ -451,6 +451,17 @@ class FolderManager:
             "parent": str(folder.parent),
         }
 
+    def count_pdfs(self, folder: Path | str) -> int:
+        """Anzahl der PDFs direkt in einem Ordner (ohne Unterordner)."""
+        folder = Path(folder)
+        try:
+            return sum(
+                1 for p in folder.iterdir()
+                if p.is_file() and p.suffix.lower() == ".pdf"
+            )
+        except (PermissionError, OSError):
+            return 0
+
     def get_subfolders(self, parent: Path | str) -> list[Path]:
         """
         Gibt alle Unterordner eines Ordners zurück.
@@ -466,7 +477,15 @@ class FolderManager:
         if not parent.exists():
             return []
 
-        return [p for p in parent.iterdir() if p.is_dir()]
+        try:
+            folders = [
+                p for p in parent.iterdir()
+                if p.is_dir() and not p.name.startswith((".", "$", "~"))
+            ]
+        except (PermissionError, OSError):
+            return []
+        folders.sort(key=lambda p: p.name.lower())
+        return folders
 
     def get_all_subfolders_recursive(
         self,

--- a/src/gui/folder_tile.py
+++ b/src/gui/folder_tile.py
@@ -1,0 +1,138 @@
+"""
+Ordner-Kachel für den Scan-Bereich (Explorer-Gefühl, Issue #29)
+
+Zeigt einen Unterordner (oder ".." für den übergeordneten Ordner) als Kachel
+im selben Raster wie die PDF-Thumbnails. Doppelklick wechselt in den Ordner,
+PDFs können per Drag & Drop hineingeschoben werden.
+
+GPL-3.0-or-later - Copyright (c) 2026
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QCursor, QDragEnterEvent, QDropEvent
+from PyQt6.QtWidgets import QFrame, QLabel, QVBoxLayout
+
+
+class FolderTileWidget(QFrame):
+    """Kachel für einen Ordner im Scan-Bereich."""
+
+    double_clicked = pyqtSignal(Path)  # In den Ordner wechseln
+    pdf_dropped = pyqtSignal(Path, Path)  # (pdf_path, folder_path)
+
+    _STYLE_NORMAL = (
+        "FolderTileWidget { background-color: #fbf8ec; border: 1px solid #d8cfae; "
+        "border-radius: 4px; }"
+    )
+    _STYLE_HOVER = (
+        "FolderTileWidget { background-color: #fff3cd; border: 1px solid #daa520; "
+        "border-radius: 4px; }"
+    )
+    _STYLE_DROP = (
+        "FolderTileWidget { background-color: #d9f2d9; border: 2px solid #4caf50; "
+        "border-radius: 4px; }"
+    )
+
+    def __init__(
+        self,
+        folder_path: Path,
+        pdf_count: Optional[int] = None,
+        is_parent: bool = False,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.folder_path = Path(folder_path)
+        self.is_parent = is_parent
+        self._pdf_count = pdf_count
+        self._setup_ui()
+
+    def _setup_ui(self):
+        # Gleiche Masse wie PDFThumbnailWidget, damit das Raster buendig bleibt
+        self.setMinimumSize(160, 230)
+        self.setMaximumSize(180, 260)
+        self.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
+        self.setAcceptDrops(True)
+        self.setStyleSheet(self._STYLE_NORMAL)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(4)
+        layout.addStretch()
+
+        icon = QLabel("⬆📁" if self.is_parent else "📁")
+        icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        icon.setStyleSheet("font-size: 48px; background: transparent;")
+        layout.addWidget(icon)
+
+        self.name_label = QLabel(".." if self.is_parent else self.folder_path.name)
+        self.name_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.name_label.setWordWrap(True)
+        self.name_label.setStyleSheet("font-size: 12px; font-weight: bold; background: transparent;")
+        layout.addWidget(self.name_label)
+
+        self.count_label = QLabel(self._count_text())
+        self.count_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.count_label.setStyleSheet("font-size: 11px; color: #777; background: transparent;")
+        layout.addWidget(self.count_label)
+        layout.addStretch()
+
+        tip = (
+            f"Übergeordneter Ordner: {self.folder_path}"
+            if self.is_parent
+            else str(self.folder_path)
+        )
+        self.setToolTip(f"{tip}\nDoppelklick öffnet den Ordner, PDFs hierher ziehen verschiebt sie.")
+
+    def _count_text(self) -> str:
+        if self.is_parent:
+            return "übergeordneter Ordner"
+        if self._pdf_count is None:
+            return ""
+        return f"{self._pdf_count} {'PDF' if self._pdf_count == 1 else 'PDFs'}"
+
+    # --- Maus -----------------------------------------------------------
+
+    def mouseDoubleClickEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.double_clicked.emit(self.folder_path)
+        super().mouseDoubleClickEvent(event)
+
+    def enterEvent(self, event):
+        self.setStyleSheet(self._STYLE_HOVER)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        self.setStyleSheet(self._STYLE_NORMAL)
+        super().leaveEvent(event)
+
+    # --- Drag & Drop ------------------------------------------------------
+
+    @staticmethod
+    def _pdf_paths(mime) -> list[Path]:
+        if not mime.hasUrls():
+            return []
+        paths = [Path(url.toLocalFile()) for url in mime.urls()]
+        return [p for p in paths if p.suffix.lower() == ".pdf"]
+
+    def dragEnterEvent(self, event: QDragEnterEvent):
+        if self._pdf_paths(event.mimeData()):
+            self.setStyleSheet(self._STYLE_DROP)
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dragLeaveEvent(self, event):
+        self.setStyleSheet(self._STYLE_NORMAL)
+        super().dragLeaveEvent(event)
+
+    def dropEvent(self, event: QDropEvent):
+        self.setStyleSheet(self._STYLE_NORMAL)
+        pdfs = self._pdf_paths(event.mimeData())
+        if not pdfs:
+            event.ignore()
+            return
+        for pdf in pdfs:
+            self.pdf_dropped.emit(pdf, self.folder_path)
+        event.acceptProposedAction()

--- a/src/gui/folder_tree_widget.py
+++ b/src/gui/folder_tree_widget.py
@@ -10,7 +10,7 @@ MIT License - Copyright (c) 2026
 from pathlib import Path
 from typing import Optional
 
-from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtCore import Qt, pyqtSignal, QTimer
 from PyQt6.QtGui import QDragEnterEvent, QDropEvent
 from PyQt6.QtWidgets import (
     QTreeWidget,
@@ -42,6 +42,15 @@ class FolderTreeWidget(QWidget):
         self._selected_folder: Optional[Path] = None
         self._suggestion_folders: list[Path] = []  # Vorgeschlagene Ordner
         self._drag_hover_item: Optional[QTreeWidgetItem] = None  # Aktuell gehoverte Item beim Drag
+
+        # Einfachklick verzoegert ausfuehren, damit ein Doppelklick (Navigation)
+        # nicht vorher die selektierte PDF verschiebt (Issue #23/#26).
+        self._pending_click_item: Optional[QTreeWidgetItem] = None
+        self._click_timer = QTimer(self)
+        self._click_timer.setSingleShot(True)
+        from PyQt6.QtWidgets import QApplication
+        self._click_timer.setInterval(QApplication.doubleClickInterval())
+        self._click_timer.timeout.connect(self._fire_pending_click)
 
         self.setup_ui()
 
@@ -249,13 +258,24 @@ class FolderTreeWidget(QWidget):
             update_recursive(self.tree.topLevelItem(i))
 
     def _on_item_clicked(self, item: QTreeWidgetItem, column: int):
-        """Behandelt Klicks auf Items."""
+        """Merkt den Klick vor; ausgefuehrt wird er erst, wenn kein Doppelklick folgt."""
+        self._pending_click_item = item
+        self._click_timer.start()
+
+    def _fire_pending_click(self):
+        """Fuehrt den vorgemerkten Einfachklick aus (Auswahl -> PDF verschieben)."""
+        item = self._pending_click_item
+        self._pending_click_item = None
+        if item is None:
+            return
         folder_path = Path(item.data(0, Qt.ItemDataRole.UserRole))
         self._selected_folder = folder_path
         self.folder_selected.emit(folder_path)
 
     def _on_item_double_clicked(self, item: QTreeWidgetItem, column: int):
-        """Behandelt Doppelklicks auf Items."""
+        """Doppelklick = Ordner links oeffnen; der vorgemerkte Klick verfaellt."""
+        self._click_timer.stop()
+        self._pending_click_item = None
         folder_path = Path(item.data(0, Qt.ItemDataRole.UserRole))
         self.folder_double_clicked.emit(folder_path)
 
@@ -268,8 +288,12 @@ class FolderTreeWidget(QWidget):
         folder_path = Path(item.data(0, Qt.ItemDataRole.UserRole))
         menu = QMenu(self)
 
+        # Links im Scan-Bereich oeffnen (wie Doppelklick)
+        goto_action = menu.addAction("📁 Ordner links öffnen")
+        goto_action.triggered.connect(lambda: self.folder_double_clicked.emit(folder_path))
+
         # Im Explorer öffnen
-        open_action = menu.addAction("📂 Im Explorer öffnen")
+        open_action = menu.addAction("📂 Im Windows-Explorer öffnen")
         open_action.triggered.connect(lambda: self._open_in_explorer(folder_path))
 
         menu.addSeparator()

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -36,6 +36,7 @@ from PyQt6.QtWidgets import (
 from src.utils.config import get_config
 from src.utils.database import get_database
 from src.gui.pdf_thumbnail import PDFThumbnailWidget
+from src.gui.folder_tile import FolderTileWidget
 from src.gui.folder_widget import FolderWidget
 from src.gui.folder_tree_widget import FolderTreeWidget
 from src.gui.rename_dialog import RenameDialog, RenameSuggestion, generate_rename_suggestions
@@ -207,7 +208,7 @@ class MainWindow(QMainWindow):
         # Nach-oben-Button (ein Verzeichnis höher)
         self.navigate_up_btn = QPushButton("⬆")
         self.navigate_up_btn.setFixedSize(28, 28)
-        self.navigate_up_btn.setToolTip("Ein Verzeichnis nach oben (übergeordneter Ordner)")
+        self.navigate_up_btn.setToolTip("Ein Verzeichnis nach oben (Alt+Up)")
         self.navigate_up_btn.clicked.connect(self.on_navigate_up)
         header_layout.addWidget(self.navigate_up_btn)
 
@@ -225,6 +226,13 @@ class MainWindow(QMainWindow):
         header_layout.addWidget(self.pdf_folder_count_label)
 
         layout.addLayout(header_layout)
+
+        # Breadcrumb: klickbarer Pfad zum aktuellen Scan-Ordner (Explorer-Gefuehl)
+        self.breadcrumb_layout = QHBoxLayout()
+        self.breadcrumb_layout.setContentsMargins(6, 0, 6, 2)
+        self.breadcrumb_layout.setSpacing(2)
+        self.breadcrumb_layout.addStretch()
+        layout.addLayout(self.breadcrumb_layout)
 
         # Info-Label für leeren Ordner
         self.empty_label = QLabel(
@@ -488,10 +496,16 @@ class MainWindow(QMainWindow):
                 item.widget().deleteLater()
         self.pdf_widgets.clear()
 
-        # PDFs laden
+        # PDFs und Unterordner laden (Explorer-Gefuehl, Issue #29)
         pdf_files = self.file_manager.get_pdf_files()
+        scan_folder = self.file_manager.scan_folder
+        subfolders = self.folder_manager.get_subfolders(scan_folder) if scan_folder else []
+        parent_folder = None
+        if scan_folder and scan_folder.parent != scan_folder and scan_folder.parent.exists():
+            parent_folder = scan_folder.parent
+        self._update_breadcrumb(scan_folder)
 
-        if not pdf_files:
+        if not pdf_files and not subfolders and parent_folder is None:
             self.empty_label.setText(
                 "Keine PDFs im Scan-Ordner gefunden.\n\n"
                 f"Ordner: {self.file_manager.scan_folder}"
@@ -509,7 +523,36 @@ class MainWindow(QMainWindow):
         self.pdf_header.setText(f"PDFs in: {self.file_manager.scan_folder.name}")
         self.pdf_header.setToolTip(str(self.file_manager.scan_folder))
         count = len(pdf_files)
-        self.pdf_folder_count_label.setText(f"{count} {'Datei' if count == 1 else 'Dateien'}")
+        count_text = f"{count} {'Datei' if count == 1 else 'Dateien'}"
+        if subfolders:
+            count_text += f" · {len(subfolders)} {'Ordner' if len(subfolders) == 1 else 'Ordner'}"
+        self.pdf_folder_count_label.setText(count_text)
+
+        # Ordner-Kacheln zuerst (".." und Unterordner), dann die PDFs
+        self.folder_tiles = []
+        tile_folders = ([(parent_folder, True)] if parent_folder else []) + [
+            (f, False) for f in subfolders
+        ]
+        for folder, is_parent in tile_folders:
+            tile = FolderTileWidget(
+                folder,
+                pdf_count=None if is_parent else self.folder_manager.count_pdfs(folder),
+                is_parent=is_parent,
+            )
+            tile.double_clicked.connect(self.on_folder_tile_double_clicked)
+            tile.pdf_dropped.connect(self.on_pdf_dropped_on_folder)
+            idx = len(self.folder_tiles)
+            self.pdf_layout.addWidget(tile, idx // 3, idx % 3)
+            self.folder_tiles.append(tile)
+        tile_offset = len(self.folder_tiles)
+
+        if not pdf_files:
+            self.pdf_count_label.setText("PDFs: 0")
+            self._pending_thumbnails = 0
+            self._thumbnails_signal_emitted = True
+            self.thumbnails_loaded.emit()
+            QTimer.singleShot(500, lambda: self._start_pre_caching([]))
+            return
 
         # Thumbnail-Ladetracking initialisieren
         self._pending_thumbnails = len(pdf_files)
@@ -532,8 +575,8 @@ class MainWindow(QMainWindow):
             # Thumbnail-Ladetracking
             widget.thumbnail_ready.connect(self._on_thumbnail_loaded)
 
-            row = i // 3
-            col = i % 3
+            row = (i + tile_offset) // 3
+            col = (i + tile_offset) % 3
             self.pdf_layout.addWidget(widget, row, col)
             self.pdf_widgets.append(widget)
 
@@ -886,6 +929,12 @@ class MainWindow(QMainWindow):
         back_action.setToolTip("Zum vorherigen Scan-Ordner zurückkehren")
         back_action.triggered.connect(self.on_navigate_back)
         view_menu.addAction(back_action)
+
+        up_action = QAction("Übergeordneter Ordner", self)
+        up_action.setShortcut("Alt+Up")
+        up_action.setToolTip("Ein Verzeichnis nach oben (wie im Windows-Explorer)")
+        up_action.triggered.connect(self.on_navigate_up)
+        view_menu.addAction(up_action)
 
         view_menu.addSeparator()
 
@@ -2651,6 +2700,53 @@ class MainWindow(QMainWindow):
         # Wenn eine PDF ausgewählt ist, diese verschieben
         if self.selected_pdf:
             self.move_selected_pdf_to_folder(folder_path)
+
+    def on_folder_tile_double_clicked(self, folder_path: Path):
+        """Doppelklick auf eine Ordner-Kachel im Scan-Bereich: hineinwechseln."""
+        if not folder_path.exists():
+            self.statusbar.showMessage(f"Ordner existiert nicht mehr: {folder_path}", 3000)
+            self.load_pdfs()
+            return
+        self._navigate_to_folder(folder_path)
+        self.statusbar.showMessage(f"Ordner geöffnet: {folder_path.name}", 3000)
+
+    def _update_breadcrumb(self, folder: Optional[Path]):
+        """Baut den klickbaren Pfad zum aktuellen Scan-Ordner neu auf."""
+        while self.breadcrumb_layout.count() > 1:  # letzter Eintrag ist der Stretch
+            item = self.breadcrumb_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+        if not folder:
+            return
+        parts = list(Path(folder).parts)
+        max_parts = 5
+        start = max(0, len(parts) - max_parts)
+        pos = 0
+        if start > 0:
+            ellipsis = QLabel("…")
+            ellipsis.setStyleSheet("color: #888; padding: 0 2px;")
+            self.breadcrumb_layout.insertWidget(pos, ellipsis)
+            pos += 1
+        for i in range(start, len(parts)):
+            target = Path(*parts[: i + 1])
+            is_last = i == len(parts) - 1
+            btn = QToolButton()
+            btn.setAutoRaise(True)
+            btn.setText(parts[i].rstrip("\\/") or parts[i])
+            btn.setToolTip(str(target))
+            btn.setEnabled(not is_last)
+            btn.setStyleSheet(
+                "QToolButton { padding: 1px 4px; font-size: 11px; }"
+                + (" QToolButton:disabled { color: #222; font-weight: bold; }" if is_last else "")
+            )
+            btn.clicked.connect(lambda _=False, p=target: self.on_folder_tile_double_clicked(p))
+            self.breadcrumb_layout.insertWidget(pos, btn)
+            pos += 1
+            if not is_last:
+                sep = QLabel("›")
+                sep.setStyleSheet("color: #999;")
+                self.breadcrumb_layout.insertWidget(pos, sep)
+                pos += 1
 
     def on_folder_double_clicked(self, folder_path: Path):
         """Wird aufgerufen wenn ein Ordner doppelgeklickt wird."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+"""Gemeinsame Test-Helfer.
+
+Die Module unter ``src`` importieren ihre Singleton-Fabriken (``get_config``,
+``get_database``, ...) auf Modulebene (``from src.utils.config import get_config``).
+Ein Patch nur im Ursprungsmodul greift daher nicht - jedes importierende Modul
+haelt seine eigene Referenz, und zwar die, die beim *ersten* Import gebunden
+wurde. Ohne diesen Helfer laufen GUI-Tests je nach Import-Reihenfolge gegen die
+echte Nutzer-Config in %APPDATA% oder gegen die Temp-Config eines frueheren Tests.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+# Module, die Singleton-Fabriken auf Modulebene importieren. Werden vor dem
+# Patchen importiert, damit ihre Referenzen sicher ersetzt werden.
+_MODULES_WITH_FACTORY_IMPORTS = (
+    "src.utils.database",
+    "src.ml.classifier",
+    "src.ml.hybrid_classifier",
+    "src.core.pdf_cache",
+    "src.gui.setup_wizard",
+    "src.gui.settings_dialog",
+    "src.gui.main_window",
+)
+
+
+def patch_singletons(monkeypatch: pytest.MonkeyPatch, factories: dict[str, object]) -> None:
+    """Ersetzt Fabrik-Funktionen (z.B. ``get_config``) in *allen* src-Modulen.
+
+    Args:
+        monkeypatch: pytest-MonkeyPatch (macht die Patches nach dem Test rueckgaengig)
+        factories: {"get_config": lambda: cfg, "get_database": lambda: db, ...}
+    """
+    for name in _MODULES_WITH_FACTORY_IMPORTS:
+        importlib.import_module(name)
+
+    for mod_name, mod in list(sys.modules.items()):
+        if mod is None or not mod_name.startswith("src"):
+            continue
+        for attr, factory in factories.items():
+            if hasattr(mod, attr):
+                monkeypatch.setattr(mod, attr, factory)
+
+
+@pytest.fixture
+def fresh_config(monkeypatch, tmp_path):
+    """Frische Config in tmp_path, in allen Modulen als ``get_config`` verdrahtet."""
+    from src.utils import config as cfg_mod
+
+    cfg = cfg_mod.Config(config_path=tmp_path / "config.json")
+    patch_singletons(monkeypatch, {"get_config": lambda: cfg})
+    return cfg

--- a/tests/test_folder_tile_gui.py
+++ b/tests/test_folder_tile_gui.py
@@ -1,0 +1,73 @@
+"""GUI-Tests fuer FolderTileWidget (Explorer-Gefuehl, Issue #29)."""
+from pathlib import Path
+
+from PyQt6.QtCore import QUrl, QMimeData
+
+from src.gui.folder_tile import FolderTileWidget
+
+
+class _FakeDropEvent:
+    def __init__(self, mime):
+        self._mime = mime
+        self.accepted = None
+
+    def mimeData(self):
+        return self._mime
+
+    def acceptProposedAction(self):
+        self.accepted = True
+
+    def ignore(self):
+        self.accepted = False
+
+
+def _mime(*paths):
+    m = QMimeData()
+    m.setUrls([QUrl.fromLocalFile(str(p)) for p in paths])
+    return m
+
+
+def test_tile_shows_name_and_count(qtbot, tmp_path):
+    folder = tmp_path / "Steuer 2026"
+    folder.mkdir()
+    tile = FolderTileWidget(folder, pdf_count=3)
+    qtbot.addWidget(tile)
+    assert tile.name_label.text() == "Steuer 2026"
+    assert tile.count_label.text() == "3 PDFs"
+
+
+def test_parent_tile_shows_dots(qtbot, tmp_path):
+    tile = FolderTileWidget(tmp_path, is_parent=True)
+    qtbot.addWidget(tile)
+    assert tile.name_label.text() == ".."
+    assert tile.is_parent
+
+
+def test_double_click_emits_folder(qtbot, tmp_path):
+    from PyQt6.QtCore import Qt
+    tile = FolderTileWidget(tmp_path)
+    qtbot.addWidget(tile)
+    tile.show()
+    with qtbot.waitSignal(tile.double_clicked, timeout=1000) as blocker:
+        qtbot.mouseDClick(tile, Qt.MouseButton.LeftButton)
+    assert blocker.args == [tmp_path]
+
+
+def test_drop_emits_only_pdfs(qtbot, tmp_path):
+    tile = FolderTileWidget(tmp_path)
+    qtbot.addWidget(tile)
+    received = []
+    tile.pdf_dropped.connect(lambda pdf, folder: received.append((pdf, folder)))
+
+    ev = _FakeDropEvent(_mime(tmp_path / "a.pdf", tmp_path / "b.txt", tmp_path / "C.PDF"))
+    tile.dropEvent(ev)
+    assert ev.accepted is True
+    assert received == [(tmp_path / "a.pdf", tmp_path), (tmp_path / "C.PDF", tmp_path)]
+
+
+def test_drop_without_pdfs_is_ignored(qtbot, tmp_path):
+    tile = FolderTileWidget(tmp_path)
+    qtbot.addWidget(tile)
+    ev = _FakeDropEvent(_mime(tmp_path / "b.txt"))
+    tile.dropEvent(ev)
+    assert ev.accepted is False

--- a/tests/test_folder_tree_click_guard_gui.py
+++ b/tests/test_folder_tree_click_guard_gui.py
@@ -1,0 +1,34 @@
+"""Doppelklick im Zielordner-Baum darf die selektierte PDF nicht verschieben (Issue #23/#26)."""
+from src.gui.folder_tree_widget import FolderTreeWidget
+
+
+def _tree_with_folder(qtbot, tmp_path):
+    root = tmp_path / "Ziel"
+    root.mkdir()
+    w = FolderTreeWidget()
+    qtbot.addWidget(w)
+    w.set_root_folders([root])
+    item = w.tree.topLevelItem(0)
+    assert item is not None
+    return w, root, item
+
+
+def test_single_click_selects_after_interval(qtbot, tmp_path):
+    w, root, item = _tree_with_folder(qtbot, tmp_path)
+    with qtbot.waitSignal(w.folder_selected, timeout=2000) as blocker:
+        w._on_item_clicked(item, 0)
+    assert blocker.args == [root]
+
+
+def test_double_click_cancels_pending_single_click(qtbot, tmp_path):
+    w, root, item = _tree_with_folder(qtbot, tmp_path)
+    selected = []
+    w.folder_selected.connect(lambda p: selected.append(p))
+
+    w._on_item_clicked(item, 0)  # erster Klick des Doppelklicks
+    with qtbot.waitSignal(w.folder_double_clicked, timeout=1000) as blocker:
+        w._on_item_double_clicked(item, 0)
+    assert blocker.args == [root]
+
+    qtbot.wait(w._click_timer.interval() + 100)
+    assert selected == []  # kein Verschieben ausgeloest

--- a/tests/test_main_window_gui.py
+++ b/tests/test_main_window_gui.py
@@ -43,16 +43,20 @@ def fresh_singletons(monkeypatch, tmp_path):
     from src.ml import hybrid_classifier as hc_mod
     from src.core import pdf_cache as pc_mod
 
-    # Frische Config-Instanz pro Test
+    # Frische Config-Instanz pro Test. Die Fabriken werden in ALLEN src-Modulen
+    # ersetzt (siehe conftest.patch_singletons) - sonst haengt es von der
+    # Import-Reihenfolge ab, welche Config MainWindow tatsaechlich sieht.
+    from tests.conftest import patch_singletons
     fresh_config = cfg_mod.Config(config_path=tmp_path / "config.json")
-    monkeypatch.setattr(cfg_mod, "get_config", lambda: fresh_config)
-    monkeypatch.setattr(db_mod, "get_database",
-                        lambda: db_mod.Database(db_path=str(db_path)))
-    monkeypatch.setattr(cl_mod, "get_classifier", cl_mod.PDFClassifier)
-    monkeypatch.setattr(hc_mod, "get_hybrid_classifier",
-                        hc_mod.HybridClassifier)
-    # PDFCache: parameterlose Fabrik, liest Pfad aus Config
-    monkeypatch.setattr(pc_mod, "get_pdf_cache", pc_mod.PDFCache)
+    fresh_config.set("persist_pdf_cache", False)
+    monkeypatch.setattr(pc_mod.PDFCache, "_instance", None)
+    patch_singletons(monkeypatch, {
+        "get_config": lambda: fresh_config,
+        "get_database": lambda: db_mod.Database(db_path=str(db_path)),
+        "get_classifier": cl_mod.PDFClassifier,
+        "get_hybrid_classifier": hc_mod.HybridClassifier,
+        "get_pdf_cache": pc_mod.PDFCache,
+    })
 
     return {"config": fresh_config, "tmp_path": tmp_path}
 
@@ -209,3 +213,59 @@ def test_main_window_handles_multiple_construction(qtbot, fresh_singletons):
     qtbot.addWidget(win2)
     # Beide haben unabhängige Tab-Widgets
     assert win1.center_tabs is not win2.center_tabs
+
+
+# --------------------------------------------------------------------- #
+# Explorer-Gefuehl (Sprint 1, Issues #29/#26): Ordner-Kacheln + Breadcrumb
+# --------------------------------------------------------------------- #
+
+
+def _scan_tree(tmp_path):
+    scan = tmp_path / "Dokumente" / "FrischGescannt"
+    (scan / "Steuer 2026").mkdir(parents=True)
+    (scan / "Banken").mkdir()
+    (scan / ".versteckt").mkdir()
+    (scan / "Banken" / "kontoauszug.pdf").write_bytes(b"%PDF-1.4\n%%EOF\n")
+    return scan
+
+
+def test_load_pdfs_shows_parent_and_subfolder_tiles(main_window, fresh_singletons):
+    scan = _scan_tree(fresh_singletons["tmp_path"])
+    main_window._navigate_to_folder(scan)
+
+    tiles = main_window.folder_tiles
+    assert [t.name_label.text() for t in tiles] == ["..", "Banken", "Steuer 2026"]
+    assert tiles[0].is_parent and tiles[0].folder_path == scan.parent
+    assert tiles[1].count_label.text() == "1 PDF"
+    assert main_window.pdf_scroll_area.isVisibleTo(main_window)  # trotz 0 PDFs sichtbar
+    assert "2 Ordner" in main_window.pdf_folder_count_label.text()
+
+
+def test_tile_double_click_navigates_into_folder(main_window, fresh_singletons):
+    scan = _scan_tree(fresh_singletons["tmp_path"])
+    main_window._navigate_to_folder(scan)
+
+    banken = next(t for t in main_window.folder_tiles if t.name_label.text() == "Banken")
+    banken.double_clicked.emit(banken.folder_path)
+
+    assert fresh_singletons["config"].get_scan_folder() == scan / "Banken"
+    assert len(main_window.pdf_widgets) == 1
+    assert main_window._folder_history[-1] == scan
+    # ".." fuehrt wieder nach oben
+    assert main_window.folder_tiles[0].is_parent
+    assert main_window.folder_tiles[0].folder_path == scan
+
+
+def test_breadcrumb_lists_path_segments(main_window, fresh_singletons):
+    from PyQt6.QtWidgets import QToolButton
+    scan = _scan_tree(fresh_singletons["tmp_path"])
+    main_window._navigate_to_folder(scan)
+
+    buttons = [
+        main_window.breadcrumb_layout.itemAt(i).widget()
+        for i in range(main_window.breadcrumb_layout.count())
+        if isinstance(main_window.breadcrumb_layout.itemAt(i).widget(), QToolButton)
+    ]
+    assert [b.text() for b in buttons][-2:] == ["Dokumente", "FrischGescannt"]
+    assert not buttons[-1].isEnabled()  # aktueller Ordner nicht klickbar
+    assert buttons[-2].isEnabled()

--- a/tests/test_settings_api_keys_gui.py
+++ b/tests/test_settings_api_keys_gui.py
@@ -14,18 +14,18 @@ def fresh_config(monkeypatch, tmp_path):
     from src.ml import hybrid_classifier as hc_mod
     from src.core import pdf_cache as pc_mod
 
-    from src.gui import settings_dialog as sd_mod
+    from tests.conftest import patch_singletons
 
     fresh = cfg_mod.Config(config_path=tmp_path / "config.json")
-    monkeypatch.setattr(cfg_mod, "get_config", lambda: fresh)
-    # SettingsDialog hat get_config auf Modulebene importiert -> dort patchen,
-    # sonst laeuft der Test gegen die echte Nutzer-Config in %APPDATA%.
-    monkeypatch.setattr(sd_mod, "get_config", lambda: fresh)
-    monkeypatch.setattr(db_mod, "get_database",
-                        lambda: db_mod.Database(db_path=str(tmp_path / "t.db")))
-    monkeypatch.setattr(cl_mod, "get_classifier", cl_mod.PDFClassifier)
-    monkeypatch.setattr(hc_mod, "get_hybrid_classifier", hc_mod.HybridClassifier)
-    monkeypatch.setattr(pc_mod, "get_pdf_cache", pc_mod.PDFCache)
+    fresh.set("persist_pdf_cache", False)
+    monkeypatch.setattr(pc_mod.PDFCache, "_instance", None)
+    patch_singletons(monkeypatch, {
+        "get_config": lambda: fresh,
+        "get_database": lambda: db_mod.Database(db_path=str(tmp_path / "t.db")),
+        "get_classifier": cl_mod.PDFClassifier,
+        "get_hybrid_classifier": hc_mod.HybridClassifier,
+        "get_pdf_cache": pc_mod.PDFCache,
+    })
     return fresh
 
 

--- a/tests/test_settings_rules_tab_gui.py
+++ b/tests/test_settings_rules_tab_gui.py
@@ -30,14 +30,17 @@ def fresh_singletons(monkeypatch, tmp_path):
     from src.ml import hybrid_classifier as hc_mod
     from src.core import pdf_cache as pc_mod
 
+    from tests.conftest import patch_singletons
     fresh_config = cfg_mod.Config(config_path=tmp_path / "config.json")
-    monkeypatch.setattr(cfg_mod, "get_config", lambda: fresh_config)
-    monkeypatch.setattr(db_mod, "get_database",
-                        lambda: db_mod.Database(db_path=str(db_path)))
-    monkeypatch.setattr(cl_mod, "get_classifier", cl_mod.PDFClassifier)
-    monkeypatch.setattr(hc_mod, "get_hybrid_classifier",
-                        hc_mod.HybridClassifier)
-    monkeypatch.setattr(pc_mod, "get_pdf_cache", pc_mod.PDFCache)
+    fresh_config.set("persist_pdf_cache", False)
+    monkeypatch.setattr(pc_mod.PDFCache, "_instance", None)
+    patch_singletons(monkeypatch, {
+        "get_config": lambda: fresh_config,
+        "get_database": lambda: db_mod.Database(db_path=str(db_path)),
+        "get_classifier": cl_mod.PDFClassifier,
+        "get_hybrid_classifier": hc_mod.HybridClassifier,
+        "get_pdf_cache": pc_mod.PDFCache,
+    })
     return {"config": fresh_config, "tmp_path": tmp_path}
 
 

--- a/tests/test_subfolders.py
+++ b/tests/test_subfolders.py
@@ -1,0 +1,24 @@
+"""FolderManager.get_subfolders / count_pdfs (Explorer-Gefuehl)."""
+from src.core.file_manager import FolderManager
+
+
+def test_subfolders_sorted_and_hidden_skipped(tmp_path):
+    for name in ["zebra", "Alpha", ".git", "$RECYCLE.BIN", "mitte"]:
+        (tmp_path / name).mkdir()
+    (tmp_path / "datei.pdf").write_bytes(b"%PDF")
+    fm = FolderManager()
+    assert [p.name for p in fm.get_subfolders(tmp_path)] == ["Alpha", "mitte", "zebra"]
+
+
+def test_subfolders_missing_parent(tmp_path):
+    assert FolderManager().get_subfolders(tmp_path / "nope") == []
+
+
+def test_count_pdfs(tmp_path):
+    (tmp_path / "a.pdf").write_bytes(b"%PDF")
+    (tmp_path / "B.PDF").write_bytes(b"%PDF")
+    (tmp_path / "c.txt").write_bytes(b"x")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "d.pdf").write_bytes(b"%PDF")
+    assert FolderManager().count_pdfs(tmp_path) == 2
+    assert FolderManager().count_pdfs(tmp_path / "missing") == 0


### PR DESCRIPTION
## Was
- Linkes Panel als Dateimanager: Ordner-Kacheln (".." + Unterordner mit PDF-Anzahl) im PDF-Raster, Doppelklick wechselt hinein, Drag & Drop einer PDF auf eine Kachel verschiebt sie
- Klickbarer Breadcrumb-Pfad; Ansicht -> "Uebergeordneter Ordner" (Alt+Up)
- Rechts (Zielordner-Baum): Doppelklick oeffnet den Ordner links, ohne vorher die selektierte PDF zu verschieben; Kontextmenue "Ordner links oeffnen"
- Entscheidung aus #23: Verhalten wie Windows-Explorer, kein Umschalter; Vorschlaege bleiben oben

## Tests
356 passed. Neu: FolderTileWidget, Klick/Doppelklick-Schutz, get_subfolders/count_pdfs, MainWindow-Kacheln/Breadcrumb, `tests/conftest.py` (patch_singletons).

Closes #29, closes #26, closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)