### PR TITLE
perf: Verschieben ohne Baum-Neuaufbau, XMP im Hintergrund, Stoppuhren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Geaendert
+- **Verschieben im echten Betrieb (Issue #28, Nachschlag)**
+  - Nach einem Verschieben wird der Zielordner-Baum nicht mehr komplett neu aufgebaut
+    (alle Ordner 3 Ebenen tief listen + PDFs zaehlen, auf OneDrive der teuerste Teil);
+    nur Quell- und Zielordner werden neu gezaehlt (`FolderTreeWidget.refresh_counts`).
+  - XMP-Metadaten werden im Hintergrund in die PDF geschrieben (pikepdf schreibt die
+    Datei komplett neu); Rueckgaengig wartet auf laufende Schreibvorgaenge.
+  - Stoppuhren: `Klick ...` und `Verschieben ...` erscheinen als INFO-Zeilen im Log
+    (`%APPDATA%\PDF_Sortier_Meister\logs`), sobald ein Vorgang >= 100 ms dauert -
+    mit Aufschluesselung pro Schritt (move | cache | metadata | learn | index | tree ...).
+
 ## [0.15.0] - 2026-08-25
 
 ### Geaendert

--- a/src/gui/folder_tree_widget.py
+++ b/src/gui/folder_tree_widget.py
@@ -39,6 +39,7 @@ class FolderTreeWidget(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._root_folders: list[Path] = []
+        self._items: dict[Path, QTreeWidgetItem] = {}  # Pfad -> Item (fuer refresh_counts)
         self._selected_folder: Optional[Path] = None
         self._suggestion_folders: list[Path] = []  # Vorgeschlagene Ordner
         self._drag_hover_item: Optional[QTreeWidgetItem] = None  # Aktuell gehoverte Item beim Drag
@@ -162,6 +163,7 @@ class FolderTreeWidget(QWidget):
     def refresh_tree(self):
         """Aktualisiert die gesamte Baumstruktur."""
         self.tree.clear()
+        self._items.clear()
 
         for root_folder in self._root_folders:
             if root_folder.exists():
@@ -208,6 +210,7 @@ class FolderTreeWidget(QWidget):
         item.setText(0, display_text)
         item.setData(0, Qt.ItemDataRole.UserRole, str(folder_path))
         item.setToolTip(0, str(folder_path))
+        self._items[folder_path] = item
 
         # Styling für Vorschläge
         if folder_path in self._suggestion_folders:
@@ -231,6 +234,35 @@ class FolderTreeWidget(QWidget):
                 pass  # Keine Berechtigung, überspringen
 
         return item
+
+    def has_folder(self, folder: Path) -> bool:
+        """True, wenn der Ordner als Item im Baum vorhanden ist."""
+        return Path(folder) in self._items
+
+    def refresh_counts(self, folders) -> int:
+        """
+        Aktualisiert nur die PDF-Zaehler der angegebenen Ordner (Issue #28).
+
+        Nach einem Verschieben aendern sich nur Quell- und Zielordner - ein
+        kompletter Neuaufbau (alle Ordner 3 Ebenen tief listen) ist auf
+        OneDrive/Netzlaufwerken der teuerste Teil des Vorgangs.
+
+        Returns:
+            Anzahl der aktualisierten Items
+        """
+        updated = 0
+        for folder in folders:
+            item = self._items.get(Path(folder))
+            if item is None:
+                continue
+            folder_path = Path(folder)
+            pdf_count = self._count_pdfs(folder_path)
+            if pdf_count > 0:
+                item.setText(0, f"📁 {folder_path.name}  [{pdf_count}]")
+            else:
+                item.setText(0, f"📁 {folder_path.name}")
+            updated += 1
+        return updated
 
     def _count_pdfs(self, folder: Path) -> int:
         """Zählt PDFs in einem Ordner (nicht rekursiv)."""

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -37,6 +37,7 @@ from src.utils.config import get_config
 from src.utils.database import get_database
 from src.gui.pdf_thumbnail import PDFThumbnailWidget
 from src.gui.folder_tile import FolderTileWidget
+from src.utils.timing import StepTimer
 from src.gui.folder_widget import FolderWidget
 from src.gui.folder_tree_widget import FolderTreeWidget
 from src.gui.rename_dialog import RenameDialog, RenameSuggestion, generate_rename_suggestions
@@ -106,6 +107,8 @@ class MainWindow(QMainWindow):
         self.pdf_cache.llm_suggestions_ready.connect(self._on_llm_suggestions_ready)
         self.pdf_cache.llm_suggestions_failed.connect(self._on_llm_suggestions_failed)
         self._last_llm_error: Optional[tuple[str, str]] = None  # (pdf_name, fehler)
+        # Laufende Hintergrund-Schreibvorgaenge (XMP-Metadaten) je Zielpfad
+        self._pending_metadata_writes: dict[Path, "threading.Thread"] = {}
 
         # Initial laden
         QTimer.singleShot(100, self.initial_load)
@@ -720,6 +723,41 @@ class MainWindow(QMainWindow):
 
                 break
 
+    def _refresh_after_move(self, target_folder: Path, *source_folders: Path):
+        """Aktualisiert nach einem Verschieben nur die betroffenen Zaehler (Issue #28).
+
+        Der Scan-Ordner (Quelle) ist meist kein Zielordner und daher nicht im
+        Baum - das ist kein Grund fuer einen Voll-Neuaufbau. Nur wenn der
+        Zielordner selbst fehlt (z.B. gerade neu angelegt), wird neu geladen.
+        """
+        target_folder = Path(target_folder)
+        if not self.folder_tree.has_folder(target_folder):
+            self.load_folders()
+            return
+        self.folder_tree.refresh_counts({target_folder, *(Path(f) for f in source_folders if f)})
+
+    def _write_pdf_metadata_async(self, pdf_path: Path, new_name: str,
+                                  keywords: list[str] = None, dialog_metadata: dict = None):
+        """Schreibt XMP-Metadaten im Hintergrund; Undo wartet ggf. darauf."""
+        import threading
+
+        def _run():
+            try:
+                self._write_pdf_metadata(pdf_path, new_name, keywords, dialog_metadata)
+            finally:
+                self._pending_metadata_writes.pop(pdf_path, None)
+
+        t = threading.Thread(target=_run, name="pdf-metadata-write", daemon=True)
+        self._pending_metadata_writes[pdf_path] = t
+        t.start()
+
+    def _wait_for_metadata_writes(self, paths, timeout: float = 15.0):
+        """Wartet, bis Hintergrund-Schreibvorgaenge fuer diese Pfade fertig sind."""
+        for p in paths:
+            t = self._pending_metadata_writes.get(Path(p))
+            if t is not None:
+                t.join(timeout)
+
     def load_folders(self):
         """Lädt die Zielordner in die Baumansicht."""
         # Ordner laden
@@ -1140,7 +1178,10 @@ class MainWindow(QMainWindow):
         self.statusbar.showMessage(f"Ausgewählt: {pdf_path.name}")
 
         # PDF analysieren und Vorschläge aktualisieren
+        self._click_timer = StepTimer("Klick")
         self.update_suggestions_for_pdf(pdf_path)
+        self._click_timer.step("vorschlaege+detail")
+        self._click_timer.done()
 
     def on_pdf_ctrl_clicked(self, pdf_path: Path):
         """Wird aufgerufen wenn eine PDF mit Ctrl angeklickt wird (Mehrfachauswahl)."""
@@ -1309,6 +1350,7 @@ class MainWindow(QMainWindow):
                 else:
                     detected_date = str(first_date)
 
+            timer = getattr(self, "_click_timer", None) or StepTimer("Vorschlaege")
             # Vorschläge mit hierarchischen Pfaden holen
             suggestions = self.classifier.suggest_with_subfolders(
                 text=self.selected_pdf_text,
@@ -1317,16 +1359,20 @@ class MainWindow(QMainWindow):
                 root_folders=self.folder_manager.target_folders,
                 max_suggestions=self.config.get("max_suggestions", 5),
             )
+            timer.step("suggest")
 
             # Vorschläge anzeigen (alte grüne Buttons)
             self.display_suggestions(suggestions)
+            timer.step("buttons")
 
             # Vorgeschlagene Ordner in der Baumansicht hervorheben
             suggested_folders = [s.folder_path for s in suggestions]
             self.folder_tree.set_suggestion_folders(suggested_folders)
+            timer.step("baum")
 
             # Detail-Panel befüllen (3-Spalten-Layout)
             self._populate_detail_panel(pdf_path, result, detected_date)
+            timer.step("detail")
 
             if suggestions:
                 self.statusbar.showMessage(
@@ -1481,22 +1527,27 @@ class MainWindow(QMainWindow):
         if reply != QMessageBox.StandardButton.Yes:
             return
 
+        timer = StepTimer("Verschieben")
         try:
             # Datei verschieben (mit optionalem neuen Namen)
             new_path = self.file_manager.move_file(pdf_path, folder_path, new_name=new_name)
+            timer.step("move")
 
             # Cache-Eintrag migrieren
             self.pdf_cache.migrate_cache_entry(pdf_path, new_path)
+            timer.step("cache")
 
-            # Metadaten in PDF schreiben
+            # Metadaten in PDF schreiben (pikepdf schreibt die Datei komplett neu
+            # -> auf OneDrive/Netzlaufwerken langsam, daher im Hintergrund)
             if metadata:
-                self._write_pdf_metadata(new_path, new_path.name,
-                                         self.selected_pdf_keywords, metadata)
+                self._write_pdf_metadata_async(new_path, new_path.name,
+                                               self.selected_pdf_keywords, metadata)
                 # Korrespondent-Zuordnung lernen
                 if metadata.get("korrespondent"):
                     self.db.learn_korrespondent_metadata(
                         metadata["korrespondent"], metadata
                     )
+            timer.step("metadata")
 
             # Undo-Eintrag
             desc = f"{pdf_path.name} → {relative_path}"
@@ -1517,6 +1568,7 @@ class MainWindow(QMainWindow):
                     keywords=self.selected_pdf_keywords,
                     relative_path=relative_path,
                 )
+            timer.step("learn")
 
             # Umbenennung lernen (falls Name geändert)
             if name_changed:
@@ -1549,6 +1601,7 @@ class MainWindow(QMainWindow):
                 zusammenfassung=metadata.get("description", "") if metadata else "",
                 target_folder=relative_path,
             )
+            timer.step("index")
 
             # Status
             training_count = self.classifier.get_training_count()
@@ -1564,13 +1617,18 @@ class MainWindow(QMainWindow):
             self.config.add_to_last_used(folder_path)
             self.remove_pdf_widget(pdf_path)
             self.detail_panel.clear()
-            self.load_folders()
+            timer.step("ui")
+            self._refresh_after_move(folder_path, pdf_path.parent)
+            timer.step("tree")
             # Phase 21: Automation-Regeln (Vorschlag im Statusbar)
             self._check_automation_rules(
                 pdf_path, metadata=self.detail_panel.get_metadata()
             )
+            timer.step("rules")
             # Phase 20: Korrespondenten aus Historie in Verwaltungstabelle sammeln
             self._auto_collect_korrespondenten()
+            timer.step("korrespondenten")
+            timer.done()
 
         except Exception as e:
             QMessageBox.critical(self, "Fehler", f"Verschieben fehlgeschlagen:\n{e}")
@@ -1637,7 +1695,7 @@ class MainWindow(QMainWindow):
                 self.remove_pdf_widget(pdf_path)
 
                 # Ordneransicht aktualisieren (um PDF-Zähler zu aktualisieren)
-                self.load_folders()
+                self._refresh_after_move(folder_path, pdf_path.parent)
 
                 # Phase 21: Automation-Regeln (Vorschlag im Statusbar)
                 self._check_automation_rules(pdf_path)
@@ -1733,7 +1791,7 @@ class MainWindow(QMainWindow):
         self.config.add_to_last_used(folder_path)
 
         # Ordneransicht aktualisieren
-        self.load_folders()
+        self._refresh_after_move(folder_path, *{p.parent for p in pdf_paths})
 
         # Vorschläge leeren
         self.clear_suggestions()
@@ -2138,7 +2196,7 @@ class MainWindow(QMainWindow):
                 # Nur das verschobene PDF-Widget entfernen
                 self.remove_pdf_widget(pdf_path)
                 # Ordneransicht aktualisieren
-                self.load_folders()
+                self._refresh_after_move(folder_path, pdf_path.parent)
                 # Phase 21: Automation-Regeln (Vorschlag im Statusbar)
                 self._check_automation_rules(pdf_path)
                 # Phase 20: Korrespondenten aus Historie sammeln
@@ -2347,6 +2405,9 @@ class MainWindow(QMainWindow):
         """Macht eine Verschiebe-Aktion rückgängig."""
         moves = entry["moves"]
         desc = entry["description"]
+
+        # Laufende Hintergrund-Schreibvorgaenge (XMP) erst abschliessen lassen
+        self._wait_for_metadata_writes([dest for _, dest in moves])
 
         # Prüfen ob alle Dateien noch existieren (am Zielort)
         missing = [dest for _, dest in moves if not dest.exists()]
@@ -2861,7 +2922,7 @@ class MainWindow(QMainWindow):
         self.config.add_to_last_used(folder_path)
 
         # Ordneransicht aktualisieren (um PDF-Zähler zu aktualisieren)
-        self.load_folders()
+        self._refresh_after_move(folder_path, *{p.parent for p in pdfs_to_move})
 
     def on_folder_remove(self, folder_path: Path):
         """Wird aufgerufen wenn ein Ordner aus der Liste entfernt werden soll."""

--- a/src/utils/timing.py
+++ b/src/utils/timing.py
@@ -1,0 +1,50 @@
+"""
+Stoppuhr fuer mehrstufige Ablaeufe (Issue #28).
+
+    timer = StepTimer("Verschieben")
+    ...; timer.step("move")
+    ...; timer.step("metadata")
+    timer.done()   # -> INFO-Log: "Verschieben 812 ms: move 120 | metadata 450 | ..."
+
+Loggt nur, wenn die Gesamtdauer ueber ``threshold_ms`` liegt, damit das Log
+im Normalfall ruhig bleibt.
+
+GPL-3.0-or-later - Copyright (c) 2026
+"""
+
+import logging
+import time
+
+logger = logging.getLogger("pdf_sortier_meister.timing")
+
+
+class StepTimer:
+    def __init__(self, label: str, threshold_ms: float = 100.0):
+        self.label = label
+        self.threshold_ms = threshold_ms
+        self._t0 = time.perf_counter()
+        self._last = self._t0
+        self.steps: list[tuple[str, float]] = []
+
+    def step(self, name: str) -> float:
+        now = time.perf_counter()
+        ms = (now - self._last) * 1000.0
+        self._last = now
+        self.steps.append((name, ms))
+        return ms
+
+    @property
+    def total_ms(self) -> float:
+        return (time.perf_counter() - self._t0) * 1000.0
+
+    def summary(self) -> str:
+        parts = " | ".join(f"{n} {ms:.0f}" for n, ms in self.steps)
+        return f"{self.label} {self.total_ms:.0f} ms: {parts}"
+
+    def done(self) -> str:
+        text = self.summary()
+        if self.total_ms >= self.threshold_ms:
+            logger.info(text)
+        else:
+            logger.debug(text)
+        return text

--- a/tests/test_folder_tree_refresh_counts.py
+++ b/tests/test_folder_tree_refresh_counts.py
@@ -1,0 +1,36 @@
+"""FolderTreeWidget.refresh_counts: nur betroffene Ordner neu zaehlen (Issue #28)."""
+from src.gui.folder_tree_widget import FolderTreeWidget
+
+
+def test_refresh_counts_updates_only_known_items(qtbot, tmp_path):
+    root = tmp_path / "Ziel"; sub = root / "Steuer 2026"; sub.mkdir(parents=True)
+    w = FolderTreeWidget(); qtbot.addWidget(w)
+    w.set_root_folders([root])
+    item = w._items[sub]
+    assert item.text(0) == "📁 Steuer 2026"
+
+    (sub / "a.pdf").write_bytes(b"%PDF"); (sub / "b.pdf").write_bytes(b"%PDF")
+    assert w.refresh_counts([sub, tmp_path / "unbekannt"]) == 1
+    assert item.text(0) == "📁 Steuer 2026  [2]"
+
+    (sub / "a.pdf").unlink(); (sub / "b.pdf").unlink()
+    w.refresh_counts([sub])
+    assert item.text(0) == "📁 Steuer 2026"
+
+
+def test_items_index_rebuilt_on_refresh_tree(qtbot, tmp_path):
+    root = tmp_path / "Ziel"; root.mkdir()
+    w = FolderTreeWidget(); qtbot.addWidget(w)
+    w.set_root_folders([root])
+    assert set(w._items) == {root}
+    (root / "Neu").mkdir()
+    w.refresh_tree()
+    assert set(w._items) == {root, root / "Neu"}
+
+
+def test_has_folder(qtbot, tmp_path):
+    root = tmp_path / "Ziel"; (root / "A").mkdir(parents=True)
+    w = FolderTreeWidget(); qtbot.addWidget(w)
+    w.set_root_folders([root])
+    assert w.has_folder(root / "A")
+    assert not w.has_folder(tmp_path / "Scan")

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,21 @@
+"""StepTimer (Issue #28 Stoppuhren)."""
+import logging
+
+
+def test_step_timer_collects_steps_and_logs_above_threshold(caplog):
+    from src.utils.timing import StepTimer
+    t = StepTimer("Test", threshold_ms=0)
+    t.step("a"); t.step("b")
+    with caplog.at_level(logging.INFO, logger="pdf_sortier_meister.timing"):
+        text = t.done()
+    assert text.startswith("Test ") and "a " in text and "| b " in text
+    assert any("Test " in r.message for r in caplog.records)
+
+
+def test_step_timer_quiet_below_threshold(caplog):
+    from src.utils.timing import StepTimer
+    t = StepTimer("Leise", threshold_ms=10_000)
+    t.step("x")
+    with caplog.at_level(logging.INFO, logger="pdf_sortier_meister.timing"):
+        t.done()
+    assert not [r for r in caplog.records if r.levelno >= logging.INFO]


### PR DESCRIPTION
Nachschlag zu #28 nach Rueckmeldung aus dem echten Betrieb (OneDrive-Scan-Ordner).

- Zielordner-Baum wird nach dem Verschieben nicht mehr komplett neu aufgebaut; nur Quell-/Zielordner werden neu gezaehlt. Gemessen mit 395 Ordnern: 163 ms -> 1 ms (SSD; auf OneDrive entsprechend mehr Ersparnis).
- XMP-Metadaten werden im Hintergrund geschrieben; Rueckgaengig wartet darauf.
- Stoppuhren im Log: `Klick ...` / `Verschieben ...` mit Aufschluesselung pro Schritt, sobald >= 100 ms.

Verschieben im UI-Thread: 206 ms -> 40 ms. Tests: 375 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)