### PR TITLE
ux: erster Klick wartet sichtbar statt einzufrieren; Warm-up nach Start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 ## [Unreleased]
 
 ### Geaendert
+- **Erster Klick nach dem Start**: blockiert nicht mehr, bis das KI-Modell geladen ist.
+  Stattdessen Wartecursor + Statusmeldung "KI-Modell wird geladen, Vorschlaege folgen
+  gleich..."; die Vorschlaege werden automatisch nachgezogen. pikepdf und die
+  sklearn-Aehnlichkeitssuche werden direkt nach dem Start im Hintergrund vorgewaermt.
+- Verzoegerte Timer (Pre-Caching, Modell-Warteschleife) sind an das Fenster gebunden
+  und feuern nicht mehr nach dessen Schliessen.
 - **Verschieben im echten Betrieb (Issue #28, Nachschlag)**
   - Nach einem Verschieben wird der Zielordner-Baum nicht mehr komplett neu aufgebaut
     (alle Ordner 3 Ebenen tief listen + PDFs zaehlen, auf OneDrive der teuerste Teil);

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -112,6 +112,7 @@ class MainWindow(QMainWindow):
 
         # Initial laden
         QTimer.singleShot(100, self.initial_load)
+        QTimer.singleShot(300, self._start_warmup)
 
     def setup_ui(self):
         """Initialisiert die Haupt-UI-Komponenten."""
@@ -554,7 +555,7 @@ class MainWindow(QMainWindow):
             self._pending_thumbnails = 0
             self._thumbnails_signal_emitted = True
             self.thumbnails_loaded.emit()
-            QTimer.singleShot(500, lambda: self._start_pre_caching([]))
+            self._schedule_pre_caching([])
             return
 
         # Thumbnail-Ladetracking initialisieren
@@ -594,7 +595,22 @@ class MainWindow(QMainWindow):
 
         # Pre-Caching starten: PDFs im Hintergrund analysieren
         # Verzögert starten damit UI erstmal fertig geladen wird
-        QTimer.singleShot(500, lambda: self._start_pre_caching(pdf_files))
+        self._schedule_pre_caching(pdf_files)
+
+    def _schedule_pre_caching(self, pdf_files: list[Path], delay_ms: int = 500):
+        """Startet das Pre-Caching verzoegert ueber einen fenstergebundenen Timer.
+
+        Ein freies QTimer.singleShot(lambda) wuerde auch nach dem Schliessen des
+        Fensters noch feuern und auf geloeschte Widgets zugreifen.
+        """
+        if not hasattr(self, "_precache_timer"):
+            self._precache_timer = QTimer(self)
+            self._precache_timer.setSingleShot(True)
+            self._precache_timer.timeout.connect(
+                lambda: self._start_pre_caching(self._precache_pending or [])
+            )
+        self._precache_pending = list(pdf_files)
+        self._precache_timer.start(delay_ms)
 
     def _start_pre_caching(self, pdf_files: list[Path]):
         """Startet das Pre-Caching für alle PDFs im Hintergrund."""
@@ -722,6 +738,50 @@ class MainWindow(QMainWindow):
                     self.selected_pdfs.append(new_path)
 
                 break
+
+    def _start_warmup(self):
+        """Laedt teure Module im Hintergrund vor, damit der erste Klick nicht wartet."""
+        import threading
+
+        def _run():
+            try:
+                import pikepdf  # noqa: F401  (Detail-Panel liest Metadaten aus der PDF)
+                import sklearn.metrics.pairwise  # noqa: F401  (erste Aehnlichkeitssuche)
+            except Exception:
+                pass
+
+        threading.Thread(target=_run, name="warmup", daemon=True).start()
+
+    def _wait_for_model_then_apply(self, pdf_path: Path, result: PDFAnalysisResult):
+        """
+        Der Klassifikator laedt nach dem Start noch im Hintergrund. Statt den
+        UI-Thread zu blockieren: Wartecursor + Statusmeldung, und sobald das
+        Modell da ist, werden die Vorschlaege nachgezogen.
+        """
+        if self.selected_pdf != pdf_path:
+            self._end_model_wait()
+            return
+        if self.classifier.is_model_ready():
+            self._end_model_wait()
+            self._apply_analysis_result(pdf_path, result)
+            return
+        if not getattr(self, "_model_wait_active", False):
+            self._model_wait_active = True
+            QApplication.setOverrideCursor(Qt.CursorShape.BusyCursor)
+            self.statusbar.showMessage("KI-Modell wird geladen, Vorschläge folgen gleich…")
+        if not hasattr(self, "_model_wait_timer"):
+            self._model_wait_timer = QTimer(self)
+            self._model_wait_timer.setSingleShot(True)
+            self._model_wait_timer.timeout.connect(
+                lambda: self._wait_for_model_then_apply(*self._model_wait_args)
+            )
+        self._model_wait_args = (pdf_path, result)
+        self._model_wait_timer.start(100)
+
+    def _end_model_wait(self):
+        if getattr(self, "_model_wait_active", False):
+            self._model_wait_active = False
+            QApplication.restoreOverrideCursor()
 
     def _refresh_after_move(self, target_folder: Path, *source_folders: Path):
         """Aktualisiert nach einem Verschieben nur die betroffenen Zaehler (Issue #28).
@@ -1335,6 +1395,9 @@ class MainWindow(QMainWindow):
 
     def _apply_analysis_result(self, pdf_path: Path, result: PDFAnalysisResult):
         """Wendet ein Analyse-Ergebnis an und zeigt Vorschläge."""
+        if not self.classifier.is_model_ready():
+            self._wait_for_model_then_apply(pdf_path, result)
+            return
         try:
             # Ergebnisse speichern
             self.selected_pdf_text = result.extracted_text

--- a/src/ml/classifier.py
+++ b/src/ml/classifier.py
@@ -94,6 +94,10 @@ class PDFClassifier:
     def training_entries(self, value):
         self._model = (self._model[0], self._model[1], value)
 
+    def is_model_ready(self) -> bool:
+        """True, sobald das Hintergrund-Laden des Modells abgeschlossen ist."""
+        return self._model_ready.is_set()
+
     def _ensure_model(self):
         """Wartet, bis das Hintergrund-Laden des Modells abgeschlossen ist."""
         if not self._model_ready.is_set():

--- a/tests/test_main_window_gui.py
+++ b/tests/test_main_window_gui.py
@@ -269,3 +269,50 @@ def test_breadcrumb_lists_path_segments(main_window, fresh_singletons):
     assert [b.text() for b in buttons][-2:] == ["Dokumente", "FrischGescannt"]
     assert not buttons[-1].isEnabled()  # aktueller Ordner nicht klickbar
     assert buttons[-2].isEnabled()
+
+
+
+# --------------------------------------------------------------------- #
+# Erster Klick nach dem Start: nicht blockieren, sondern nachziehen
+# --------------------------------------------------------------------- #
+
+
+def test_click_before_model_ready_defers_and_applies_later(main_window, fresh_singletons, qtbot, monkeypatch):
+    from src.core.pdf_cache import PDFAnalysisResult
+    from PyQt6.QtWidgets import QApplication
+
+    pdf = fresh_singletons["tmp_path"] / "x.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    main_window.selected_pdf = pdf
+    result = PDFAnalysisResult(pdf_path=pdf, extracted_text="rechnung", keywords=["rechnung"])
+
+    ready = {"v": False}
+    monkeypatch.setattr(main_window.classifier, "is_model_ready", lambda: ready["v"])
+    applied = []
+    monkeypatch.setattr(main_window, "display_suggestions", lambda s: applied.append(s))
+
+    main_window._apply_analysis_result(pdf, result)
+    assert applied == []                      # noch nichts angewendet ...
+    assert main_window._model_wait_active     # ... aber Wartezustand aktiv
+    assert QApplication.overrideCursor() is not None
+    assert "geladen" in main_window.statusbar.currentMessage()
+
+    ready["v"] = True
+    qtbot.waitUntil(lambda: bool(applied), timeout=2000)
+    assert not main_window._model_wait_active
+    assert QApplication.overrideCursor() is None
+
+
+def test_model_wait_cancelled_when_selection_changes(main_window, fresh_singletons, qtbot, monkeypatch):
+    from src.core.pdf_cache import PDFAnalysisResult
+    from PyQt6.QtWidgets import QApplication
+
+    pdf = fresh_singletons["tmp_path"] / "y.pdf"; pdf.write_bytes(b"%PDF-1.4")
+    main_window.selected_pdf = pdf
+    monkeypatch.setattr(main_window.classifier, "is_model_ready", lambda: False)
+    main_window._apply_analysis_result(pdf, PDFAnalysisResult(pdf_path=pdf))
+    assert main_window._model_wait_active
+
+    main_window.selected_pdf = None  # Nutzer hat abgewaehlt
+    qtbot.waitUntil(lambda: not main_window._model_wait_active, timeout=2000)
+    assert QApplication.overrideCursor() is None


### PR DESCRIPTION
- Erster Klick nach dem Start blockierte den UI-Thread, bis das KI-Modell geladen war (sklearn-Import + Pickle, ~1,5 s). Jetzt: Wartecursor + Statusmeldung, Vorschlaege werden nachgezogen, sobald das Modell bereit ist; Abwaehlen bricht das Warten ab.
- Warm-up-Thread 300 ms nach Start (pikepdf, sklearn.metrics.pairwise).
- Verzoegerte Timer sind fenstergebunden (latenter Fehler: singleShot-Lambdas feuerten nach dem Schliessen).

Tests: 377 passed (2 neue GUI-Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)