### PR TITLE
perf: OneDrive-Wartezeiten aus dem UI-Thread (XMP async, Ordner-Cache, Baum-Scan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 ## [Unreleased]
 
 ### Geaendert
+- **OneDrive-Wartezeiten aus dem UI-Thread geholt (Log-Analyse 25./26.08.)**
+  - XMP-Metadaten der angeklickten PDF werden im Hintergrund gelesen und nachgetragen
+    ("Files On-Demand" laedt die Datei erst beim ersten Zugriff: 2-8 s pro Klick)
+  - Ordner-Cache des Klassifikators (rglob ueber alle Zielordner, 16,8 s beim ersten
+    Klick) wird nach dem Start vorgewaermt und bei Aenderungen im Hintergrund neu gebaut
+  - Zielordner-Baum wird in einem Worker gescannt und erst dann befuellt (Start und
+    Neuaufbau blockieren nicht mehr); neue Zielordner werden inkrementell eingehaengt
 - **Erster Klick nach dem Start**: blockiert nicht mehr, bis das KI-Modell geladen ist.
   Stattdessen Wartecursor + Statusmeldung "KI-Modell wird geladen, Vorschlaege folgen
   gleich..."; die Vorschlaege werden automatisch nachgezogen. pikepdf und die

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -9,7 +9,7 @@ und klickt rechts auf einen Zielordner zum Verschieben+Umbenennen.
 from pathlib import Path
 from typing import Optional
 
-from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtCore import Qt, pyqtSignal, QThread
 from PyQt6.QtGui import QFont
 from PyQt6.QtWidgets import (
     QWidget,
@@ -28,6 +28,29 @@ from PyQt6.QtWidgets import (
 )
 
 from src.gui.rename_dialog import RenameSuggestion
+
+
+class _PdfMetadataReader(QThread):
+    """Liest XMP-Metadaten einer PDF im Hintergrund.
+
+    Der Lesezugriff kann auf OneDrive ("Files On-Demand") mehrere Sekunden
+    dauern, weil die Datei erst heruntergeladen wird - das darf den Klick
+    nicht blockieren (Issue #28).
+    """
+
+    finished_meta = pyqtSignal(object, object)  # (pdf_path, PDFMetadata | None)
+
+    def __init__(self, pdf_path: Path, parent=None):
+        super().__init__(parent)
+        self._pdf_path = pdf_path
+
+    def run(self):
+        try:
+            from src.core.pdf_metadata import read_metadata
+            meta = read_metadata(self._pdf_path)
+        except Exception:
+            meta = None
+        self.finished_meta.emit(self._pdf_path, meta)
 
 
 class DetailPanel(QWidget):
@@ -316,9 +339,11 @@ class DetailPanel(QWidget):
         # Metadaten vorbefüllen
         self._metadata = {}
 
-        # 1. Bereits gespeicherte XMP-Metadaten aus der PDF laden (höchste Priorität als Basis)
-        self.load_metadata_from_pdf(pdf_path)
-        pdf_had_data = bool(self._saved_metadata_snapshot)
+        # 1. Gespeicherte XMP-Metadaten werden im Hintergrund gelesen und danach
+        #    nachgetragen (siehe _on_pdf_metadata_read). Bis dahin: Basis aus Analyse.
+        self._saved_metadata_snapshot = {}
+        pdf_had_data = False
+        self._start_metadata_reader(pdf_path)
 
         # 2. Nur wenn keine PDF-Metadaten vorhanden: Basis aus Analyse
         if not pdf_had_data:
@@ -509,14 +534,35 @@ class DetailPanel(QWidget):
         """Gibt den Pfad der aktuell angezeigten PDF zurück."""
         return self._current_pdf
 
+    def _start_metadata_reader(self, pdf_path: Path):
+        """Startet das Hintergrund-Lesen der XMP-Metadaten fuer pdf_path."""
+        reader = _PdfMetadataReader(pdf_path, self)
+        reader.finished_meta.connect(self._on_pdf_metadata_read)
+        reader.finished.connect(reader.deleteLater)
+        self._metadata_reader = reader
+        reader.start()
+
+    def _on_pdf_metadata_read(self, pdf_path: Path, pdf_meta):
+        """Traegt gelesene PDF-Metadaten nach - nur, wenn die PDF noch ausgewaehlt ist."""
+        if self._current_pdf != pdf_path:
+            return
+        if self._metadata_source == "user":
+            return  # Nutzer hat inzwischen editiert - nicht ueberschreiben
+        self._apply_pdf_metadata(pdf_meta)
+        if self._saved_metadata_snapshot:
+            self.metadata_group.setTitle("Metadaten (aus PDF gelesen, werden in PDF gespeichert)")
+
     def load_metadata_from_pdf(self, pdf_path: Path):
-        """Liest XMP-Metadaten aus der PDF und befüllt die Felder. Setzt Quelle auf 'pdf'."""
+        """Liest XMP-Metadaten synchron aus der PDF und befüllt die Felder (Tests/Sonderfaelle)."""
         try:
             from src.core.pdf_metadata import read_metadata
             pdf_meta = read_metadata(pdf_path)
         except Exception:
             pdf_meta = None
+        self._apply_pdf_metadata(pdf_meta)
 
+    def _apply_pdf_metadata(self, pdf_meta):
+        """Uebertraegt PDFMetadata in die Felder und setzt Quelle auf 'pdf'."""
         if pdf_meta is None or not pdf_meta.has_any_data():
             self._saved_metadata_snapshot = {}
             return

--- a/src/gui/folder_tree_widget.py
+++ b/src/gui/folder_tree_widget.py
@@ -7,10 +7,11 @@ Unterstützt Unterordner und zeigt PDF-Anzahlen an.
 MIT License - Copyright (c) 2026
 """
 
+import os
 from pathlib import Path
 from typing import Optional
 
-from PyQt6.QtCore import Qt, pyqtSignal, QTimer
+from PyQt6.QtCore import Qt, pyqtSignal, QTimer, QThread
 from PyQt6.QtGui import QDragEnterEvent, QDropEvent
 from PyQt6.QtWidgets import (
     QTreeWidget,
@@ -27,6 +28,51 @@ from PyQt6.QtWidgets import (
 )
 
 
+class _TreeScanThread(QThread):
+    """Listet die Zielordner-Hierarchie im Hintergrund (Issue #28).
+
+    Auf OneDrive/Netzlaufwerken dauert das Listen aller Ordner 3 Ebenen tief
+    inkl. PDF-Zaehlung viele Sekunden - im UI-Thread friert dabei alles ein.
+    Ergebnis: Liste von (folder_path, parent_path | None, pdf_count).
+    """
+
+    scanned = pyqtSignal(int, list)  # (generation, entries)
+
+    def __init__(self, roots: list[Path], generation: int, max_depth: int = 3, parent=None):
+        super().__init__(parent)
+        self._roots = roots
+        self._generation = generation
+        self._max_depth = max_depth
+
+    def run(self):
+        entries: list[tuple[Path, Optional[Path], int]] = []
+
+        def scan(folder: Path, parent: Optional[Path], depth: int):
+            pdf_count = 0
+            subfolders = []
+            try:
+                with os.scandir(folder) as it:
+                    for entry in it:
+                        try:
+                            if entry.is_file() and entry.name.lower().endswith('.pdf'):
+                                pdf_count += 1
+                            elif entry.is_dir() and not entry.name.startswith('.'):
+                                subfolders.append(Path(entry.path))
+                        except OSError:
+                            continue
+            except (PermissionError, OSError):
+                pass
+            entries.append((folder, parent, pdf_count))
+            if depth < self._max_depth:
+                for sub in sorted(subfolders):
+                    scan(sub, folder, depth + 1)
+
+        for root in self._roots:
+            if root.exists():
+                scan(root, None, 0)
+        self.scanned.emit(self._generation, entries)
+
+
 class FolderTreeWidget(QWidget):
     """Widget zur hierarchischen Anzeige von Zielordnern."""
 
@@ -35,11 +81,15 @@ class FolderTreeWidget(QWidget):
     folder_double_clicked = pyqtSignal(Path)  # Ordner wurde doppelgeklickt
     pdf_dropped = pyqtSignal(Path, Path)  # PDF auf Ordner gezogen (pdf_path, folder_path)
     folder_removed = pyqtSignal(Path)  # Ordner aus Liste entfernt
+    scan_finished = pyqtSignal()  # Baum wurde (neu) befuellt
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self._root_folders: list[Path] = []
         self._items: dict[Path, QTreeWidgetItem] = {}  # Pfad -> Item (fuer refresh_counts)
+        self._scan_generation = 0  # verwirft Ergebnisse veralteter Scans
+        self._scan_thread: Optional[_TreeScanThread] = None
+        self.async_scan = True  # Tests koennen synchron scannen
         self._selected_folder: Optional[Path] = None
         self._suggestion_folders: list[Path] = []  # Vorgeschlagene Ordner
         self._drag_hover_item: Optional[QTreeWidgetItem] = None  # Aktuell gehoverte Item beim Drag
@@ -161,16 +211,72 @@ class FolderTreeWidget(QWidget):
         self._update_item_styles()
 
     def refresh_tree(self):
-        """Aktualisiert die gesamte Baumstruktur."""
+        """Baut den Baum neu auf - das Verzeichnis-Listing laeuft im Hintergrund."""
+        self._scan_generation += 1
+        roots = [r for r in self._root_folders if r.exists()]
+        if not self.async_scan:
+            thread = _TreeScanThread(roots, self._scan_generation)
+            thread.scanned.connect(self._on_scan_finished)
+            thread.run()  # synchron, im aktuellen Thread
+            return
+
+        # Sofort etwas zeigen: Wurzeln ohne Zaehler, Rest folgt nach dem Scan
         self.tree.clear()
         self._items.clear()
+        for root in roots:
+            item = QTreeWidgetItem(self.tree)
+            item.setText(0, f"📁 {root.name}  …")
+            item.setData(0, Qt.ItemDataRole.UserRole, str(root))
+            item.setToolTip(0, f"{root}\nOrdner werden geladen…")
+            self._items[root] = item
 
-        for root_folder in self._root_folders:
-            if root_folder.exists():
-                self._add_folder_item(root_folder, None)
+        thread = _TreeScanThread(roots, self._scan_generation, parent=self)
+        thread.scanned.connect(self._on_scan_finished)
+        thread.finished.connect(thread.deleteLater)
+        self._scan_thread = thread
+        thread.start()
+
+    def _on_scan_finished(self, generation: int, entries: list):
+        """Befuellt den Baum aus dem Scan-Ergebnis (UI-Thread)."""
+        if generation != self._scan_generation:
+            return  # veralteter Scan
+        self.tree.clear()
+        self._items.clear()
+        for folder_path, parent_path, pdf_count in entries:
+            parent_item = self._items.get(parent_path) if parent_path else None
+            if parent_path is not None and parent_item is None:
+                continue
+            item = QTreeWidgetItem(self.tree) if parent_item is None else QTreeWidgetItem(parent_item)
+            item.setText(0, self._item_text(folder_path, pdf_count))
+            item.setData(0, Qt.ItemDataRole.UserRole, str(folder_path))
+            item.setToolTip(0, str(folder_path))
+            if folder_path in self._suggestion_folders:
+                item.setBackground(0, Qt.GlobalColor.green)
+            self._items[folder_path] = item
 
         # Alle Einträge expandieren (erste Ebene)
         self.tree.expandToDepth(0)
+        self.scan_finished.emit()
+
+    @staticmethod
+    def _item_text(folder_path: Path, pdf_count: int) -> str:
+        return f"📁 {folder_path.name}  [{pdf_count}]" if pdf_count > 0 else f"📁 {folder_path.name}"
+
+    def add_folder_incremental(self, folder_path: Path) -> bool:
+        """Fuegt einen einzelnen Ordner unter seinem (vorhandenen) Elternteil ein."""
+        folder_path = Path(folder_path)
+        if folder_path in self._items:
+            return True
+        parent_item = self._items.get(folder_path.parent)
+        if parent_item is None:
+            return False
+        item = QTreeWidgetItem(parent_item)
+        item.setText(0, self._item_text(folder_path, self._count_pdfs(folder_path)))
+        item.setData(0, Qt.ItemDataRole.UserRole, str(folder_path))
+        item.setToolTip(0, str(folder_path))
+        self._items[folder_path] = item
+        parent_item.sortChildren(0, Qt.SortOrder.AscendingOrder)
+        return True
 
     def _add_folder_item(
         self,
@@ -256,11 +362,7 @@ class FolderTreeWidget(QWidget):
             if item is None:
                 continue
             folder_path = Path(folder)
-            pdf_count = self._count_pdfs(folder_path)
-            if pdf_count > 0:
-                item.setText(0, f"📁 {folder_path.name}  [{pdf_count}]")
-            else:
-                item.setText(0, f"📁 {folder_path.name}")
+            item.setText(0, self._item_text(folder_path, self._count_pdfs(folder_path)))
             updated += 1
         return updated
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -747,6 +747,8 @@ class MainWindow(QMainWindow):
             try:
                 import pikepdf  # noqa: F401  (Detail-Panel liest Metadaten aus der PDF)
                 import sklearn.metrics.pairwise  # noqa: F401  (erste Aehnlichkeitssuche)
+                # Ordner-Cache des Klassifikators (rglob ueber alle Zielordner) vorab
+                self.classifier.warm_folder_cache()
             except Exception:
                 pass
 
@@ -792,8 +794,11 @@ class MainWindow(QMainWindow):
         """
         target_folder = Path(target_folder)
         if not self.folder_tree.has_folder(target_folder):
-            self.load_folders()
-            return
+            # Neuer Ordner: unter dem Elternteil einhaengen; nur wenn auch der
+            # fehlt, den Baum neu scannen (laeuft im Hintergrund, blockiert nicht)
+            if not self.folder_tree.add_folder_incremental(target_folder):
+                self.folder_tree.refresh_tree()
+                return
         self.folder_tree.refresh_counts({target_folder, *(Path(f) for f in source_folders if f)})
 
     def _write_pdf_metadata_async(self, pdf_path: Path, new_name: str,

--- a/src/ml/classifier.py
+++ b/src/ml/classifier.py
@@ -54,6 +54,8 @@ class PDFClassifier:
         self._retrain_timer: Optional[threading.Timer] = None
         self._retrain_lock = threading.Lock()
         self._retrain_pending = False
+        self._folder_cache_lock = threading.Lock()
+        self._folder_cache_building = False
 
         # Modell-Pfad
         self.model_path = self.config.model_dir / "classifier.pkl"
@@ -132,30 +134,69 @@ class PDFClassifier:
         if not target_folders:
             return None
 
-        # Cache invalidieren wenn Zielordner sich geändert haben
+        # Cache veraltet (Zielordner geaendert)? Dann im Hintergrund neu aufbauen.
+        # Der rglob ueber alle Zielordner kann auf OneDrive viele Sekunden dauern
+        # (Issue #28: 16,8 s beim ersten Klick) - hier wird nie blockiert.
         if self._folder_cache_roots != target_folders:
-            self._folder_cache = {}
-            self._folder_cache_roots = target_folders.copy()
-            self._build_folder_cache(target_folders)
+            self._start_folder_cache_build(target_folders)
+            return None
 
         return self._folder_cache.get(folder_name.lower())
 
-    def _build_folder_cache(self, root_folders: list[Path]):
-        """Baut den Ordner-Cache für schnelle Suche auf."""
-        self._folder_cache = {}
+    def _start_folder_cache_build(self, target_folders: list[Path]):
+        with self._folder_cache_lock:
+            if self._folder_cache_building:
+                return
+            self._folder_cache_building = True
+        roots = [Path(f) for f in target_folders]
+
+        def _run():
+            try:
+                cache = self._scan_folder_cache(roots)
+                self._folder_cache = cache
+                self._folder_cache_roots = roots.copy()
+            except Exception as e:
+                logger.error(f"Ordner-Cache konnte nicht aufgebaut werden: {e}")
+            finally:
+                with self._folder_cache_lock:
+                    self._folder_cache_building = False
+
+        threading.Thread(target=_run, name="folder-cache", daemon=True).start()
+
+    def warm_folder_cache(self):
+        """Baut den Ordner-Cache synchron auf (fuer den Warm-up-Thread nach dem Start)."""
+        roots = [Path(f) for f in self.config.get_target_folders()]
+        with self._folder_cache_lock:
+            if self._folder_cache_building:
+                return
+            self._folder_cache_building = True
+        try:
+            self._folder_cache = self._scan_folder_cache(roots)
+            self._folder_cache_roots = roots.copy()
+        finally:
+            with self._folder_cache_lock:
+                self._folder_cache_building = False
+
+    @staticmethod
+    def _scan_folder_cache(root_folders: list[Path]) -> dict[str, Path]:
+        """Sammelt alle Ordnernamen (lowercase) unterhalb der Zielordner."""
+        cache: dict[str, Path] = {}
         for root_folder in root_folders:
             if not root_folder.exists():
                 continue
             try:
-                # Root-Ordner selbst auch hinzufügen
-                self._folder_cache[root_folder.name.lower()] = root_folder
-                # Alle Unterordner
+                cache[root_folder.name.lower()] = root_folder
                 for folder in root_folder.rglob("*"):
                     if folder.is_dir() and not folder.name.startswith('.'):
-                        # Lowercase für case-insensitive Matching
-                        self._folder_cache[folder.name.lower()] = folder
-            except PermissionError:
+                        cache[folder.name.lower()] = folder
+            except (PermissionError, OSError):
                 pass
+        return cache
+
+    def _build_folder_cache(self, root_folders: list[Path]):
+        """Synchroner Aufbau (Tests/Kompatibilitaet)."""
+        self._folder_cache = self._scan_folder_cache([Path(f) for f in root_folders])
+        self._folder_cache_roots = [Path(f) for f in root_folders]
 
     def _resolve_folder_path(self, learned_folder: str, learned_name: str) -> Optional[Path]:
         """

--- a/tests/test_detail_panel_metadata_async.py
+++ b/tests/test_detail_panel_metadata_async.py
@@ -1,0 +1,29 @@
+"""DetailPanel liest XMP-Metadaten im Hintergrund und traegt sie nach."""
+from pathlib import Path
+
+
+def test_metadata_applied_after_background_read(qtbot, tmp_path, monkeypatch):
+    from src.gui import detail_panel as dp
+    from src.core.pdf_metadata import PDFMetadata
+
+    meta = PDFMetadata(); meta.korrespondent = "Stadtwerke"; meta.steuerjahr = "2026"
+    monkeypatch.setattr("src.core.pdf_metadata.read_metadata", lambda p: meta)
+
+    panel = dp.DetailPanel(); qtbot.addWidget(panel)
+    pdf = tmp_path / "a.pdf"; pdf.write_bytes(b"%PDF")
+    panel.set_pdf(pdf_path=pdf, suggestions=[], extracted_text="x", keywords=["rechnung"])
+    assert panel._current_pdf == pdf
+    qtbot.waitUntil(lambda: panel._metadata_source == "pdf", timeout=5000)
+    assert panel.get_metadata().get("korrespondent") == "Stadtwerke"
+
+
+def test_stale_result_for_other_pdf_is_ignored(qtbot, tmp_path):
+    from src.gui import detail_panel as dp
+    from src.core.pdf_metadata import PDFMetadata
+
+    panel = dp.DetailPanel(); qtbot.addWidget(panel)
+    a = tmp_path / "a.pdf"; a.write_bytes(b"%PDF")
+    panel._current_pdf = tmp_path / "b.pdf"
+    meta = PDFMetadata(); meta.korrespondent = "Alt"
+    panel._on_pdf_metadata_read(a, meta)  # gehoert zu a, ausgewaehlt ist b
+    assert panel.get_metadata().get("korrespondent") in (None, "")

--- a/tests/test_folder_cache_async.py
+++ b/tests/test_folder_cache_async.py
@@ -1,0 +1,34 @@
+"""Classifier-Ordner-Cache blockiert nie (Issue #28: 16,8 s rglob auf OneDrive)."""
+import time
+from pathlib import Path
+
+
+def _classifier(tmp_path, monkeypatch, roots):
+    from src.utils import config as cfg_mod, database as db_mod
+    from src.ml import classifier as cl_mod
+    from tests.conftest import patch_singletons
+    cfg = cfg_mod.Config(config_path=tmp_path / "config.json")
+    for r in roots:
+        cfg.add_target_folder(r)
+    db = db_mod.Database(db_path=str(tmp_path / "history.db"))
+    patch_singletons(monkeypatch, {"get_config": lambda: cfg, "get_database": lambda: db})
+    c = cl_mod.PDFClassifier(); c._ensure_model()
+    return c
+
+
+def test_find_folder_returns_none_until_cache_built_then_resolves(tmp_path, monkeypatch):
+    root = tmp_path / "Ziel"; (root / "Steuer 2026" / "Banken").mkdir(parents=True)
+    c = _classifier(tmp_path, monkeypatch, [root])
+    first = c._find_folder_by_name("banken")  # startet Hintergrund-Aufbau
+    assert first is None
+    deadline = time.time() + 5
+    while time.time() < deadline and c._find_folder_by_name("banken") is None:
+        time.sleep(0.05)
+    assert c._find_folder_by_name("banken") == root / "Steuer 2026" / "Banken"
+
+
+def test_warm_folder_cache_is_synchronous(tmp_path, monkeypatch):
+    root = tmp_path / "Ziel"; (root / "Briefe 2026").mkdir(parents=True)
+    c = _classifier(tmp_path, monkeypatch, [root])
+    c.warm_folder_cache()
+    assert c._find_folder_by_name("briefe 2026") == root / "Briefe 2026"

--- a/tests/test_folder_tree_click_guard_gui.py
+++ b/tests/test_folder_tree_click_guard_gui.py
@@ -7,6 +7,7 @@ def _tree_with_folder(qtbot, tmp_path):
     root.mkdir()
     w = FolderTreeWidget()
     qtbot.addWidget(w)
+    w.async_scan = False
     w.set_root_folders([root])
     item = w.tree.topLevelItem(0)
     assert item is not None

--- a/tests/test_folder_tree_refresh_counts.py
+++ b/tests/test_folder_tree_refresh_counts.py
@@ -4,7 +4,7 @@ from src.gui.folder_tree_widget import FolderTreeWidget
 
 def test_refresh_counts_updates_only_known_items(qtbot, tmp_path):
     root = tmp_path / "Ziel"; sub = root / "Steuer 2026"; sub.mkdir(parents=True)
-    w = FolderTreeWidget(); qtbot.addWidget(w)
+    w = FolderTreeWidget(); qtbot.addWidget(w); w.async_scan = False
     w.set_root_folders([root])
     item = w._items[sub]
     assert item.text(0) == "📁 Steuer 2026"
@@ -20,7 +20,7 @@ def test_refresh_counts_updates_only_known_items(qtbot, tmp_path):
 
 def test_items_index_rebuilt_on_refresh_tree(qtbot, tmp_path):
     root = tmp_path / "Ziel"; root.mkdir()
-    w = FolderTreeWidget(); qtbot.addWidget(w)
+    w = FolderTreeWidget(); qtbot.addWidget(w); w.async_scan = False
     w.set_root_folders([root])
     assert set(w._items) == {root}
     (root / "Neu").mkdir()
@@ -30,7 +30,27 @@ def test_items_index_rebuilt_on_refresh_tree(qtbot, tmp_path):
 
 def test_has_folder(qtbot, tmp_path):
     root = tmp_path / "Ziel"; (root / "A").mkdir(parents=True)
-    w = FolderTreeWidget(); qtbot.addWidget(w)
+    w = FolderTreeWidget(); qtbot.addWidget(w); w.async_scan = False
     w.set_root_folders([root])
     assert w.has_folder(root / "A")
     assert not w.has_folder(tmp_path / "Scan")
+
+
+def test_async_scan_fills_tree_after_thread(qtbot, tmp_path):
+    root = tmp_path / "Ziel"; (root / "A" / "B").mkdir(parents=True)
+    (root / "A" / "x.pdf").write_bytes(b"%PDF")
+    w = FolderTreeWidget(); qtbot.addWidget(w)
+    with qtbot.waitSignal(w.scan_finished, timeout=5000):
+        w.set_root_folders([root])
+    assert set(w._items) == {root, root / "A", root / "A" / "B"}
+    assert w._items[root / "A"].text(0) == "📁 A  [1]"
+
+
+def test_add_folder_incremental(qtbot, tmp_path):
+    root = tmp_path / "Ziel"; (root / "A").mkdir(parents=True)
+    w = FolderTreeWidget(); qtbot.addWidget(w); w.async_scan = False
+    w.set_root_folders([root])
+    new = root / "A" / "Neu"; new.mkdir()
+    assert w.add_folder_incremental(new) is True
+    assert w.has_folder(new)
+    assert w.add_folder_incremental(tmp_path / "fremd" / "x") is False


### PR DESCRIPTION
Aus der Log-Analyse der Sitzung vom 25./26.08. (Scan-Ordner auf OneDrive):

| Ausreisser im Log | Ursache | Fix |
|---|---|---|
| `detail` 2-8 s (10x) | pikepdf liest XMP; OneDrive laedt die Datei erst beim ersten Zugriff | Lesen im QThread, Felder werden nachgetragen |
| `suggest` 16,8 s (1. Klick) | `_build_folder_cache`: rglob ueber alle Zielordner | Warm-up nach Start, Neuaufbau im Hintergrund, nie blockierend |
| `tree` 9,5 s | Voll-Neuaufbau des Zielordner-Baums | Scan im Worker, inkrementelles Einhaengen neuer Ordner |

Tests: 383 passed (6 neue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)