### PR TITLE
feat(wizard): Ollama-Erkennung, Hardware-Empfehlung, Modell-Download, Ollama Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Hinzugefuegt
+- **Einrichtungs-Assistent erkennt Ollama und die Hardware**
+  - Provider-Seite zeigt, ob Ollama installiert ist bzw. laeuft, und prueft die
+    Grafikkarte (nvidia-smi, sonst Registry-Display-Adapter) - `src/utils/hardware.py`
+  - Empfehlung nach Grafikspeicher: gemma3:4b (ab 4 GB), gemma3:12b (ab 10 GB),
+    gemma3:27b (ab 20 GB). Ohne dedizierte Grafikkarte (nur integrierte Grafik /
+    Shared Memory), unter 4 GB oder mit Intel-GPU: Ollama lokal **nicht** empfohlen,
+    stattdessen Ollama Cloud. Die Empfehlung wird vorausgewaehlt, solange noch kein
+    Provider konfiguriert ist.
+  - Ollama-Seite listet die installierten Modelle (`/api/tags`, Server wird bei Bedarf
+    gestartet) und laedt das empfohlene Modell per Klick mit Fortschrittsbalken
+    (`/api/pull`, abbrechbar) - kein Terminal mehr noetig. Gewaehltes Modell wird gespeichert.
+- **Ollama Cloud** als Provider (`ollama_cloud`): dieselbe API wie lokal, aber gegen
+  https://ollama.com mit API-Key (Bearer). Gilt als Cloud-Provider (Einwilligung noetig).
+  Standardmodell gpt-oss:120b; Einstellungen-Dialog mit Modell-Liste, "Modelle
+  aktualisieren" und Verbindungstest.
+- `OllamaProvider` sendet `Authorization: Bearer <key>`, wenn ein API-Key gesetzt ist.
+
 ## [0.15.1] - 2026-08-26
 
 ### Hinzugefuegt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF Sortier Meister
 
-**Gescannte PDFs sortieren, umbenennen und wiederfinden — auf dem eigenen Windows-PC, ohne Server, optional mit KI.**
+**Gescannte PDFs sortieren, umbenennen und wiederfinden — auf dem eigenen Windows-PC, ohne Server, mit lokaler KI.**
 
 [![Release](https://img.shields.io/github/v/release/Josi-create/PDF_Sortier_Meister?label=Download&color=brightgreen)](https://github.com/Josi-create/PDF_Sortier_Meister/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/Josi-create/PDF_Sortier_Meister/total)](https://github.com/Josi-create/PDF_Sortier_Meister/releases)
@@ -73,9 +73,15 @@ Deinstallation wie gewohnt über *Apps & Features*; eine neue Version wird einfa
 - Ohne KI: alles oben funktioniert mit dem lokalen Klassifikator
 - Mit KI: bessere Ordner- und Namensvorschläge, automatische Metadaten-Extraktion und ein
   **Chat über die eigenen Dokumente** (*„Was habe ich 2025 für Strom gezahlt?“* — mit klickbaren Quellen)
-- Anbieter: **Ollama** (lokal, kein API-Key, startet bei Bedarf automatisch), **OpenRouter**,
-  **Anthropic Claude**, **OpenAI**, **Poe**
+- Anbieter: **Ollama** (lokal, kein API-Key, startet bei Bedarf automatisch), **Ollama Cloud**
+  (dieselben Modelle auf ollama.com — für PCs ohne Grafikkarte), **OpenRouter**, **Anthropic Claude**,
+  **OpenAI**, **Poe**
+- Der Einrichtungs-Assistent **prüft die Grafikkarte** und empfiehlt danach: ein passendes lokales
+  Modell (gemma3 4b/12b/27b je nach Grafikspeicher) — oder, ohne dedizierte Grafikkarte, Ollama Cloud.
+  Er erkennt eine vorhandene Ollama-Installation, zeigt die installierten Modelle und lädt das
+  empfohlene Modell per Klick herunter (kein Terminal nötig)
 - Der lokale Klassifikator hat immer Vorrang; die KI wird nur bei niedriger Konfidenz hinzugezogen
+
 
 ---
 
@@ -87,7 +93,7 @@ Das ist ein Desktop-Programm. Ohne konfigurierten Cloud-Anbieter verlässt **nic
 |---|---|
 | Kein KI-Anbieter (Standard) | nichts |
 | **Ollama** (lokal) | nichts — das Modell läuft auf deinem PC |
-| Cloud-Anbieter (OpenRouter, Claude, OpenAI, Poe) | ein **Textauszug** der PDF (einstellbar 500–5000 Zeichen, Standard 1500) — *nur* nach ausdrücklicher Einwilligung in den Einstellungen; die PDF-Datei selbst wird nie hochgeladen |
+| Cloud-Anbieter (Ollama Cloud, OpenRouter, Claude, OpenAI, Poe) | ein **Textauszug** der PDF (einstellbar 500–5000 Zeichen, Standard 1500) — *nur* nach ausdrücklicher Einwilligung in den Einstellungen; die PDF-Datei selbst wird nie hochgeladen |
 
 Alle Daten (Konfiguration, Lernhistorie, Index, Logs) liegen unter `%APPDATA%\PDF_Sortier_Meister\`.
 Es gibt keine Telemetrie und keinen Auto-Update-Mechanismus.

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -107,6 +107,7 @@ class SettingsDialog(QDialog):
             "Poe.com (viele Modelle)",
             "Ollama (lokal, kein API-Key noetig)",
             "OpenRouter (viele Modelle, ein API-Key)",
+            "Ollama Cloud (Ollama-Modelle in der Cloud, API-Key)",
         ])
         self.provider_combo.currentIndexChanged.connect(self._on_provider_changed)
         provider_layout.addRow("Provider:", self.provider_combo)
@@ -825,14 +826,26 @@ class SettingsDialog(QDialog):
             "meta-llama/llama-3.1-70b-instruct (Meta)",
             "mistralai/mistral-small (Mistral)",
         ],
+        "ollama_cloud": [
+            "gpt-oss:120b (OpenAI, gross, empfohlen)",
+            "gpt-oss:20b (OpenAI, schnell)",
+            "qwen3-coder:480b (Alibaba)",
+            "deepseek-v3.1:671b (DeepSeek)",
+            "kimi-k2:1t (Moonshot)",
+            "glm-4.6 (Zhipu)",
+            "minimax-m2 (MiniMax)",
+        ],
     }
 
-    _PROVIDER_NAME_BY_INDEX = {1: "claude", 2: "openai", 3: "poe", 4: "ollama", 5: "openrouter"}
+    _PROVIDER_NAME_BY_INDEX = {
+        1: "claude", 2: "openai", 3: "poe", 4: "ollama", 5: "openrouter", 6: "ollama_cloud",
+    }
     _KEY_PROVIDER_LABELS = {
         "claude": "Anthropic Claude",
         "openai": "OpenAI",
         "poe": "Poe.com",
         "openrouter": "OpenRouter",
+        "ollama_cloud": "Ollama Cloud",
     }
 
     def _stash_api_key(self):
@@ -874,7 +887,7 @@ class SettingsDialog(QDialog):
             self.test_button.setEnabled(False)
             return
 
-        # Provider 1-5: API-/Modell-Felder freischalten (nur Ollama ohne Key)
+        # Provider 1-6: API-/Modell-Felder freischalten (nur Ollama lokal ohne Key)
         self.api_key_input.setEnabled(index != 4)
         self.model_combo.setEnabled(True)
         self.test_button.setEnabled(True)
@@ -892,6 +905,8 @@ class SettingsDialog(QDialog):
             self.api_key_input.setPlaceholderText("Nicht noetig fuer Ollama")
         elif index == 5:
             self.api_key_input.setPlaceholderText("sk-or-... von openrouter.ai/keys")
+        elif index == 6:
+            self.api_key_input.setPlaceholderText("API-Key von ollama.com/settings/keys")
 
     def _update_consent_hint(self):
         """Zeigt an, ob der Cloud-Provider ohne Einwilligung blockiert bleibt."""
@@ -942,6 +957,8 @@ class SettingsDialog(QDialog):
             self.provider_combo.setCurrentIndex(4)
         elif provider == "openrouter":
             self.provider_combo.setCurrentIndex(5)
+        elif provider == "ollama_cloud":
+            self.provider_combo.setCurrentIndex(6)
         else:
             self.provider_combo.setCurrentIndex(0)
         # Explizit aufrufen, falls sich der Index nicht geaendert hat (kein Signal)
@@ -1012,6 +1029,8 @@ class SettingsDialog(QDialog):
             provider = "poe"
         elif provider_index == 5:
             provider = "openrouter"
+        elif provider_index == 6:
+            provider = "ollama_cloud"
         else:
             provider = "ollama"
 
@@ -1165,6 +1184,8 @@ class SettingsDialog(QDialog):
                 self._test_ollama(base_url, model)
             elif provider_index == 5:  # OpenRouter
                 self._test_openrouter(api_key, model)
+            elif provider_index == 6:  # Ollama Cloud
+                self._test_ollama_cloud(api_key, model)
         finally:
             self.test_button.setEnabled(True)
             self.test_button.setText("Verbindung testen")
@@ -1298,6 +1319,35 @@ class SettingsDialog(QDialog):
                 f"Verbindungsfehler: {str(e)}"
             )
 
+    def _test_ollama_cloud(self, api_key: str, model: str):
+        """Testet Ollama Cloud (ollama.com) mit einem Mini-Request."""
+        try:
+            from src.ml.ollama_provider import OllamaCloudProvider
+            from src.ml.llm_provider import LLMConfig
+
+            provider = OllamaCloudProvider(LLMConfig(
+                api_key=api_key,
+                model=model or OllamaCloudProvider.DEFAULT_MODEL,
+                max_tokens=5,
+            ))
+            answer, error = provider._do_chat("Antworte nur mit OK.", "Test")
+            if error:
+                QMessageBox.critical(
+                    self, "Fehler",
+                    f"Ollama Cloud antwortet nicht:\n{error}\n\n"
+                    "Pruefen Sie den API-Key (ollama.com/settings/keys) "
+                    "und den Modellnamen."
+                )
+                return
+            QMessageBox.information(
+                self, "Erfolg",
+                f"Verbindung zu Ollama Cloud erfolgreich!\n"
+                f"Modell: {model or OllamaCloudProvider.DEFAULT_MODEL}\n"
+                f"Antwort: {answer.strip()[:60]}"
+            )
+        except Exception as e:
+            QMessageBox.critical(self, "Fehler", f"Verbindungsfehler: {e}")
+
     def _test_ollama(self, base_url: str, model: str):
         """Testet die Verbindung zu einem lokalen Ollama-Server."""
         try:
@@ -1428,6 +1478,10 @@ class SettingsDialog(QDialog):
                 models = self._fetch_ollama_models(base_url)
             elif provider_index == 5:  # OpenRouter
                 models = self._fetch_openrouter_models(api_key)
+            elif provider_index == 6:  # Ollama Cloud
+                from src.ml.ollama_provider import OllamaCloudProvider
+                from src.ml.llm_provider import LLMConfig
+                models = OllamaCloudProvider(LLMConfig(api_key=api_key, model="")).list_models()
             else:
                 models = []
 

--- a/src/gui/setup_wizard.py
+++ b/src/gui/setup_wizard.py
@@ -4,22 +4,23 @@ Erststart-Wizard fuer PDF Sortier Meister
 Fuehrt den Benutzer beim ersten Start durch:
   1. Begruessung
   2. Scan-Ordner waehlen
-  3. LLM-Provider waehlen
-  4. API-Key eingeben
+  3. LLM-Provider waehlen (mit Hardware-Erkennung und Ollama-Status)
+  4. API-Key eingeben bzw. Ollama einrichten (Modelle anzeigen/herunterladen)
   5. Abschluss
 
 Der Wizard kann auch ueber das Extras-Menue erneut geoeffnet werden.
 """
 
 import sys
+import threading
 
 from PyQt6.QtWidgets import (
     QWizard, QWizardPage, QVBoxLayout, QHBoxLayout,
     QLabel, QLineEdit, QPushButton, QFileDialog,
     QRadioButton, QButtonGroup, QWidget, QCheckBox,
-    QDialog,
+    QDialog, QComboBox, QProgressBar,
 )
-from PyQt6.QtCore import Qt, QUrl
+from PyQt6.QtCore import Qt, QUrl, QThread, pyqtSignal
 from PyQt6.QtGui import QDesktopServices, QFont
 
 from src.utils.config import get_config
@@ -33,13 +34,14 @@ PAGE_API_KEY = 3
 PAGE_DONE = 4
 
 # Provider-Konstanten (Index -> interner Name)
-_PROVIDER_IDS = ["none", "claude", "openai", "poe", "ollama", "openrouter"]
+_PROVIDER_IDS = ["none", "claude", "openai", "poe", "ollama", "ollama_cloud", "openrouter"]
 _PROVIDER_LABELS = [
     "Kein KI-Assistent (nur klassische Erkennung)",
-    "Anthropic Claude (empfohlen)",
+    "Anthropic Claude",
     "OpenAI GPT",
     "Poe.com (viele KI-Modelle, ein Account)",
     "Ollama (lokal auf Ihrem PC, kostenlos)",
+    "Ollama Cloud (Ollama-Modelle in der Cloud, API-Key)",
     "OpenRouter (viele KI-Modelle, ein API-Key)",
 ]
 _PROVIDER_URLS = {
@@ -47,6 +49,7 @@ _PROVIDER_URLS = {
     "openai": "https://platform.openai.com/api-keys",
     "poe":    "https://poe.com/api_key",
     "ollama": "https://ollama.com/download",
+    "ollama_cloud": "https://ollama.com/settings/keys",
     "openrouter": "https://openrouter.ai/keys",
 }
 _PROVIDER_KEY_HINTS = {
@@ -54,8 +57,89 @@ _PROVIDER_KEY_HINTS = {
     "openai": 'Beginnt mit "sk-..."',
     "poe":    "Zu finden auf poe.com/api_key",
     "ollama": "Leer lassen fuer Standard (http://localhost:11434)",
+    "ollama_cloud": "Zu finden auf ollama.com/settings/keys",
     "openrouter": 'Beginnt mit "sk-or-..."',
 }
+
+OLLAMA_LOCAL_URL = "http://localhost:11434"
+OLLAMA_CLOUD_DEFAULT_MODEL = "gpt-oss:120b"
+OLLAMA_FALLBACK_MODEL = "gemma3:4b"
+
+
+def detect_ollama_environment() -> dict:
+    """
+    Ermittelt Ollama-Installation, Serverstatus und Hardware-Empfehlung.
+
+    Laeuft in einem Hintergrund-Thread der Provider-Seite; in Tests wird
+    die Funktion durch eine Attrappe ersetzt.
+    """
+    from src.ml.ollama_launcher import find_ollama_executable, quick_ping
+    from src.utils.hardware import detect_and_recommend
+
+    exe = find_ollama_executable()
+    running = quick_ping(OLLAMA_LOCAL_URL, timeout=0.5)
+    return {
+        "exe": exe,
+        "installed": bool(exe) or running,
+        "running": running,
+        "recommendation": detect_and_recommend(),
+    }
+
+
+def probe_ollama_models() -> tuple[bool, str, list[str]]:
+    """Startet Ollama bei Bedarf und liefert (ok, meldung, modelle)."""
+    from src.ml.ollama_launcher import ensure_running, list_models
+
+    ok, msg = ensure_running(OLLAMA_LOCAL_URL)
+    if not ok:
+        return False, msg, []
+    return True, msg, list_models(OLLAMA_LOCAL_URL)
+
+
+class _DetectThread(QThread):
+    done = pyqtSignal(object)
+
+    def run(self):
+        try:
+            result = detect_ollama_environment()
+        except Exception as e:  # Erkennung darf den Wizard nie blockieren
+            result = {"exe": None, "installed": False, "running": False,
+                      "recommendation": None, "error": str(e)}
+        self.done.emit(result)
+
+
+class _ModelsThread(QThread):
+    done = pyqtSignal(bool, str, object)
+
+    def run(self):
+        try:
+            ok, msg, models = probe_ollama_models()
+        except Exception as e:
+            ok, msg, models = False, str(e), []
+        self.done.emit(ok, msg, models)
+
+
+class _PullThread(QThread):
+    progress = pyqtSignal(int, str)
+    finished_pull = pyqtSignal(bool, str)
+
+    def __init__(self, model: str, parent=None):
+        super().__init__(parent)
+        self._model = model
+        self._cancel = threading.Event()
+
+    def cancel(self):
+        self._cancel.set()
+
+    def run(self):
+        from src.ml.ollama_launcher import pull_model
+
+        ok, msg = pull_model(
+            OLLAMA_LOCAL_URL, self._model,
+            progress_cb=lambda p, s: self.progress.emit(p, s),
+            should_cancel=self._cancel.is_set,
+        )
+        self.finished_pull.emit(ok, msg)
 
 
 class WelcomePage(QWizardPage):
@@ -108,7 +192,7 @@ class ScanFolderPage(QWizardPage):
 
         info = QLabel(
             "Waehlen Sie den Ordner, in den Ihr Scanner die PDFs speichert\n"
-            "(z. B. <i>C:\\Users\\IhrName\\Scans</i> oder ein Netzlaufwerk)."
+            "(z. B. <i>C:\\Users\\IhrName\\Scans</i> oder ein Netzlaufwerk)."
         )
         info.setWordWrap(True)
         layout.addWidget(info)
@@ -151,7 +235,7 @@ class ScanFolderPage(QWizardPage):
 
 
 class ProviderPage(QWizardPage):
-    """Seite 3: LLM-Provider waehlen."""
+    """Seite 3: LLM-Provider waehlen - mit Ollama-Status und Hardware-Empfehlung."""
 
     def __init__(self):
         super().__init__()
@@ -165,25 +249,96 @@ class ProviderPage(QWizardPage):
         layout.setSpacing(6)
 
         self._button_group = QButtonGroup(self)
+        self._radios: list[QRadioButton] = []
 
         for i, label in enumerate(_PROVIDER_LABELS):
             rb = QRadioButton(label)
             self._button_group.addButton(rb, i)
+            self._radios.append(rb)
             layout.addWidget(rb)
             if i == 0:
                 rb.setChecked(True)
+            if _PROVIDER_IDS[i] == "ollama":
+                # Statuszeile direkt unter dem Ollama-Eintrag
+                self.ollama_status_label = QLabel("    Pruefe Ollama-Installation ...")
+                self.ollama_status_label.setStyleSheet("color: gray;")
+                layout.addWidget(self.ollama_status_label)
+
+        self.hardware_label = QLabel("Hardware wird geprueft ...")
+        self.hardware_label.setWordWrap(True)
+        self.hardware_label.setStyleSheet("color: gray;")
+        layout.addWidget(self.hardware_label)
 
         # Bestehenden Wert voreintragen
         config = get_config()
         llm_cfg = config.get_llm_config()
-        provider = llm_cfg.get("provider", "none")
-        if provider in _PROVIDER_IDS:
-            idx = _PROVIDER_IDS.index(provider)
+        self._configured_provider = llm_cfg.get("provider", "none")
+        if self._configured_provider in _PROVIDER_IDS:
+            idx = _PROVIDER_IDS.index(self._configured_provider)
             btn = self._button_group.button(idx)
             if btn:
                 btn.setChecked(True)
 
         layout.addStretch()
+
+        self._detection: dict | None = None
+        self._thread: _DetectThread | None = None
+
+    def initializePage(self):
+        if self._detection is not None or self._thread is not None:
+            return
+        self._thread = _DetectThread(self)
+        self._thread.done.connect(self._on_detected)
+        self._thread.start()
+
+    def _on_detected(self, result: dict):
+        self._detection = result
+        rec = result.get("recommendation")
+
+        # Ollama-Status
+        if result.get("running"):
+            status, color = "✓ Ollama ist installiert und laeuft", "green"
+        elif result.get("installed"):
+            status, color = "✓ Ollama ist installiert", "green"
+        else:
+            status, color = "Ollama ist nicht installiert (Download im naechsten Schritt)", "#b35c00"
+        self.ollama_status_label.setText("    " + status)
+        self.ollama_status_label.setStyleSheet(f"color: {color};")
+
+        # Hardware-Empfehlung
+        recommended_id = None
+        if rec is None:
+            self.hardware_label.setText("Hardware konnte nicht geprueft werden.")
+        elif rec.local_ok:
+            recommended_id = "ollama"
+            self.hardware_label.setText(
+                f"<b>Empfehlung: Ollama lokal.</b> {rec.reason} "
+                f"Ihre Dokumente bleiben dabei auf diesem PC."
+            )
+            self.hardware_label.setStyleSheet("color: #1a6b1a;")
+        else:
+            recommended_id = "ollama_cloud"
+            self.hardware_label.setText(
+                f"<b>Ollama lokal nicht empfohlen.</b> {rec.reason} "
+                f"Empfehlung: <b>Ollama Cloud</b> — dieselben Modelle, nur ein API-Key noetig "
+                f"(Dokumentinhalte werden dabei an ollama.com uebertragen)."
+            )
+            self.hardware_label.setStyleSheet("color: #7a4a00;")
+
+        self._recommended_id = recommended_id
+        if recommended_id:
+            idx = _PROVIDER_IDS.index(recommended_id)
+            self._radios[idx].setText(_PROVIDER_LABELS[idx] + "  (empfohlen)")
+            # Nur vorauswaehlen, wenn noch nichts konfiguriert ist - eine
+            # bestehende Entscheidung des Nutzers wird nicht ueberschrieben.
+            if self._configured_provider == "none" and self.get_provider_id() == "none":
+                self._radios[idx].setChecked(True)
+
+    def get_detection(self) -> dict | None:
+        return self._detection
+
+    def get_recommendation(self):
+        return (self._detection or {}).get("recommendation")
 
     def get_provider_index(self) -> int:
         return self._button_group.checkedId()
@@ -200,7 +355,7 @@ class ProviderPage(QWizardPage):
 
 
 class ApiKeyPage(QWizardPage):
-    """Seite 4: API-Key eingeben."""
+    """Seite 4: API-Key eingeben bzw. Ollama einrichten."""
 
     def __init__(self):
         super().__init__()
@@ -236,6 +391,51 @@ class ApiKeyPage(QWizardPage):
         self._hint_label.setStyleSheet("color: gray; font-size: 10px;")
         layout.addWidget(self._hint_label)
 
+        # --- Ollama-Bereich (nur bei lokalem Ollama sichtbar) ---------------
+        self._ollama_box = QWidget()
+        ollama_layout = QVBoxLayout(self._ollama_box)
+        ollama_layout.setContentsMargins(0, 8, 0, 0)
+        ollama_layout.setSpacing(6)
+
+        self.ollama_warning_label = QLabel()
+        self.ollama_warning_label.setWordWrap(True)
+        self.ollama_warning_label.setStyleSheet("color: #7a4a00;")
+        self.ollama_warning_label.setVisible(False)
+        ollama_layout.addWidget(self.ollama_warning_label)
+
+        models_row = QHBoxLayout()
+        models_row.addWidget(QLabel("Modell:"))
+        self.model_combo = QComboBox()
+        self.model_combo.setEditable(True)
+        models_row.addWidget(self.model_combo, 1)
+        self.refresh_btn = QPushButton("Erneut pruefen")
+        self.refresh_btn.clicked.connect(self._start_probe)
+        models_row.addWidget(self.refresh_btn)
+        ollama_layout.addLayout(models_row)
+
+        self.models_status_label = QLabel()
+        self.models_status_label.setWordWrap(True)
+        self.models_status_label.setStyleSheet("color: gray;")
+        ollama_layout.addWidget(self.models_status_label)
+
+        pull_row = QHBoxLayout()
+        self.pull_btn = QPushButton()
+        self.pull_btn.clicked.connect(self._start_pull)
+        pull_row.addWidget(self.pull_btn, 1)
+        self.cancel_pull_btn = QPushButton("Abbrechen")
+        self.cancel_pull_btn.clicked.connect(self._cancel_pull)
+        self.cancel_pull_btn.setVisible(False)
+        pull_row.addWidget(self.cancel_pull_btn)
+        ollama_layout.addLayout(pull_row)
+
+        self.pull_progress = QProgressBar()
+        self.pull_progress.setRange(0, 100)
+        self.pull_progress.setVisible(False)
+        ollama_layout.addWidget(self.pull_progress)
+
+        layout.addWidget(self._ollama_box)
+        self._ollama_box.setVisible(False)
+
         skip_info = QLabel(
             "<i>Ohne API-Key koennen Sie die App trotzdem nutzen.\n"
             "Klicken Sie einfach auf 'Weiter' ohne etwas einzugeben.\n"
@@ -247,12 +447,23 @@ class ApiKeyPage(QWizardPage):
 
         layout.addStretch()
 
+        self._models_thread: _ModelsThread | None = None
+        self._pull_thread: _PullThread | None = None
+        self._recommended_model = OLLAMA_FALLBACK_MODEL
+        self._recommended_size_gb = 3.3
+        self._ollama_installed = False
+
+    # ------------------------------------------------------------------ #
+    # Seite betreten                                                      #
+    # ------------------------------------------------------------------ #
+
     def initializePage(self):
         """Wird aufgerufen wenn die Seite betreten wird."""
-        # Provider-Auswahl aus Seite 3 lesen
         wizard = self.wizard()
         provider_page = wizard.page(PAGE_PROVIDER)
         self._provider_id = provider_page.get_provider_id()
+        detection = provider_page.get_detection() or {}
+        recommendation = provider_page.get_recommendation()
 
         # Vorhandenen Wert aus Config laden (Key bei Cloud-Providern, URL bei Ollama)
         config = get_config()
@@ -265,34 +476,34 @@ class ApiKeyPage(QWizardPage):
                 existing_value = llm_cfg.get("api_key", "")
         self.key_edit.setText(existing_value)
 
-        # UI an Provider anpassen
         provider_labels = {
             "claude": "Anthropic Claude",
             "openai": "OpenAI GPT",
             "poe":    "Poe.com",
             "ollama": "Ollama",
+            "ollama_cloud": "Ollama Cloud",
             "openrouter": "OpenRouter",
         }
         name = provider_labels.get(self._provider_id, self._provider_id)
 
         is_ollama = (self._provider_id == "ollama")
+        self._ollama_box.setVisible(is_ollama)
 
         if is_ollama:
             self.setTitle("Schritt 3: Ollama einrichten")
             self.setSubTitle(
                 "Ollama laeuft lokal auf Ihrem Rechner. Sie brauchen keinen API-Key,\n"
-                "muessen aber Ollama installieren und ein Modell herunterladen."
+                "nur die Installation und ein Modell - beides erledigen Sie hier."
             )
-            # URL ist nicht geheim - im Klartext anzeigen, kein Show/Hide-Button
             self.key_edit.setEchoMode(QLineEdit.EchoMode.Normal)
             self._show_btn.setVisible(False)
+            self._setup_ollama_section(detection, recommendation)
         else:
             self.setTitle("Schritt 3: API-Key eingeben")
             self.setSubTitle(
                 f"Geben Sie Ihren {name} API-Key ein.\n"
                 "Den Key koennen Sie kostenlos erstellen (ein Account genuegt)."
             )
-            # API-Keys sind geheim - verstecken, Show/Hide-Button anzeigen
             self.key_edit.setEchoMode(QLineEdit.EchoMode.Password)
             self._show_btn.setVisible(True)
             self._show_btn.setChecked(False)
@@ -334,16 +545,14 @@ class ApiKeyPage(QWizardPage):
                 "3. Gehen Sie zu poe.com/api_key und kopieren Sie Ihren Key.\n"
                 "4. Fuegen Sie ihn unten ein."
             ),
-            "ollama": (
-                "So richten Sie Ollama ein:\n"
-                "1. Ollama von ollama.com/download installieren.\n"
-                "2. Terminal/Eingabeaufforderung oeffnen und ein Modell laden, z.B.:\n"
-                "       ollama pull llama3.1\n"
-                "   (Andere gute Modelle: qwen2.5, gemma3, mistral.)\n"
-                "3. Ollama laeuft danach automatisch im Hintergrund.\n"
-                "4. Die Server-URL unten koennen Sie leer lassen — Standard ist\n"
-                "   http://localhost:11434. Modell waehlen Sie spaeter unter\n"
-                "   Extras -> Einstellungen aus."
+            "ollama": self._ollama_info_text(detection),
+            "ollama_cloud": (
+                "Ollama Cloud fuehrt die Ollama-Modelle auf Servern von ollama.com aus -\n"
+                "ideal fuer PCs ohne Grafikkarte. Dokumentinhalte werden dabei uebertragen.\n"
+                "1. Oeffnen Sie den Link unten und melden Sie sich bei ollama.com an.\n"
+                "2. Unter 'Keys' einen API-Key erstellen und kopieren.\n"
+                f"3. Fuegen Sie ihn unten ein. Standardmodell: {OLLAMA_CLOUD_DEFAULT_MODEL}\n"
+                "   (aenderbar unter Extras -> Einstellungen)."
             ),
             "openrouter": (
                 "1. Oeffnen Sie den Link unten (oder gehen Sie zu openrouter.ai).\n"
@@ -354,6 +563,162 @@ class ApiKeyPage(QWizardPage):
             ),
         }
         self._info_label.setText(info_texts.get(self._provider_id, ""))
+
+    # ------------------------------------------------------------------ #
+    # Ollama-Bereich                                                      #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _ollama_info_text(detection: dict) -> str:
+        if detection.get("installed"):
+            return (
+                "Ollama ist installiert. Unten sehen Sie die vorhandenen Modelle;\n"
+                "falls noch keines da ist, laden Sie das empfohlene Modell mit einem Klick.\n"
+                "Die Server-URL koennen Sie leer lassen (Standard: http://localhost:11434)."
+            )
+        return (
+            "Ollama ist noch nicht installiert:\n"
+            "1. Ueber den Link unten Ollama herunterladen und installieren (Standardeinstellungen).\n"
+            "2. Danach hier auf 'Erneut pruefen' klicken.\n"
+            "3. Das empfohlene Modell mit einem Klick herunterladen - fertig."
+        )
+
+    def _setup_ollama_section(self, detection: dict, recommendation) -> None:
+        self._ollama_installed = bool(detection.get("installed"))
+
+        if recommendation is not None and recommendation.local_ok and recommendation.model:
+            self._recommended_model = recommendation.model
+            self._recommended_size_gb = recommendation.model_size_gb
+        else:
+            self._recommended_model = OLLAMA_FALLBACK_MODEL
+            self._recommended_size_gb = 3.3
+
+        if recommendation is not None and not recommendation.local_ok:
+            self.ollama_warning_label.setText(
+                f"Hinweis: {recommendation.reason} Sie koennen Ollama trotzdem lokal "
+                f"nutzen, muessen aber mit langen Wartezeiten rechnen."
+            )
+            self.ollama_warning_label.setVisible(True)
+        else:
+            self.ollama_warning_label.setVisible(False)
+
+        self.pull_btn.setText(
+            f"Empfohlenes Modell herunterladen: {self._recommended_model} "
+            f"(ca. {self._recommended_size_gb:.0f} GB)"
+        )
+        self.pull_progress.setVisible(False)
+        self.cancel_pull_btn.setVisible(False)
+
+        # Bereits konfiguriertes Modell vorbelegen
+        configured_model = get_config().get_llm_config().get("model", "")
+        self.model_combo.clear()
+        if configured_model:
+            self.model_combo.addItem(configured_model)
+
+        if self._ollama_installed:
+            self._start_probe()
+        else:
+            self.models_status_label.setText(
+                "Ollama nicht gefunden - nach der Installation 'Erneut pruefen' klicken."
+            )
+            self.pull_btn.setEnabled(False)
+
+    def _start_probe(self):
+        if self._models_thread is not None and self._models_thread.isRunning():
+            return
+        self.refresh_btn.setEnabled(False)
+        self.models_status_label.setText("Ollama wird gestartet und Modelle werden gelesen ...")
+        self._models_thread = _ModelsThread(self)
+        self._models_thread.done.connect(self._on_models_probed)
+        self._models_thread.start()
+
+    def _on_models_probed(self, ok: bool, msg: str, models: list):
+        self.refresh_btn.setEnabled(True)
+        if not ok:
+            self._ollama_installed = False
+            self.models_status_label.setText(f"Ollama nicht erreichbar: {msg}")
+            self.pull_btn.setEnabled(False)
+            return
+
+        self._ollama_installed = True
+        self.pull_btn.setEnabled(True)
+        self.pull_btn.setText(
+            f"Empfohlenes Modell herunterladen: {self._recommended_model} "
+            f"(ca. {self._recommended_size_gb:.0f} GB)"
+        )
+        current = self.model_combo.currentText().strip()
+        self.model_combo.clear()
+        self.model_combo.addItems(models)
+        if models:
+            # Empfohlenes bzw. bereits gewaehltes Modell aktiv setzen
+            preferred = next(
+                (m for m in models if m.split(":")[0] == self._recommended_model.split(":")[0]
+                 or m == current),
+                models[0],
+            )
+            self.model_combo.setCurrentText(preferred)
+            self.models_status_label.setText(
+                f"{len(models)} Modell(e) installiert. Empfehlung fuer Ihre Hardware: "
+                f"{self._recommended_model}."
+            )
+            if self._is_installed(self._recommended_model, models):
+                self.pull_btn.setText(f"{self._recommended_model} ist bereits installiert")
+                self.pull_btn.setEnabled(False)
+        else:
+            self.model_combo.setCurrentText(current or self._recommended_model)
+            self.models_status_label.setText(
+                "Ollama laeuft, aber es ist noch kein Modell installiert - "
+                "bitte unten herunterladen."
+            )
+
+    @staticmethod
+    def _is_installed(model: str, installed: list[str]) -> bool:
+        """'gemma3:12b' gilt als installiert bei 'gemma3:12b' oder 'gemma3:12b-...'."""
+        return any(m == model or m.startswith(model + "-") for m in installed)
+
+    def _start_pull(self):
+        if self._pull_thread is not None and self._pull_thread.isRunning():
+            return
+        self.pull_btn.setEnabled(False)
+        self.refresh_btn.setEnabled(False)
+        self.cancel_pull_btn.setVisible(True)
+        self.pull_progress.setValue(0)
+        self.pull_progress.setVisible(True)
+        self.models_status_label.setText(f"Lade {self._recommended_model} herunter ...")
+        self._pull_thread = _PullThread(self._recommended_model, self)
+        self._pull_thread.progress.connect(self._on_pull_progress)
+        self._pull_thread.finished_pull.connect(self._on_pull_finished)
+        self._pull_thread.start()
+
+    def _cancel_pull(self):
+        if self._pull_thread is not None:
+            self._pull_thread.cancel()
+            self.cancel_pull_btn.setEnabled(False)
+
+    def _on_pull_progress(self, percent: int, status: str):
+        self.pull_progress.setValue(percent)
+        self.models_status_label.setText(f"{status} ({percent} %)")
+
+    def _on_pull_finished(self, ok: bool, msg: str):
+        self.pull_btn.setEnabled(True)
+        self.refresh_btn.setEnabled(True)
+        self.cancel_pull_btn.setVisible(False)
+        self.cancel_pull_btn.setEnabled(True)
+        if ok:
+            self.pull_progress.setValue(100)
+            self.models_status_label.setText(f"{self._recommended_model}: {msg}")
+            self._start_probe()
+        else:
+            self.pull_progress.setVisible(False)
+            self.models_status_label.setText(f"Download fehlgeschlagen: {msg}")
+
+    def get_selected_model(self) -> str:
+        """Gewaehltes Ollama-Modell (nur bei Provider 'ollama' relevant)."""
+        return self.model_combo.currentText().strip()
+
+    # ------------------------------------------------------------------ #
+    # Allgemein                                                           #
+    # ------------------------------------------------------------------ #
 
     def _open_link(self):
         url = _PROVIDER_URLS.get(self._provider_id, "")
@@ -440,7 +805,7 @@ class SetupWizard(QWizard):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("PDF Sortier Meister einrichten")
-        self.setMinimumSize(550, 420)
+        self.setMinimumSize(600, 520)
         self.setWizardStyle(QWizard.WizardStyle.ModernStyle)
 
         # Kein "?" Hilfe-Button (verwirrt DAUs)
@@ -496,11 +861,19 @@ class SetupWizard(QWizard):
             # API-Key auf leer setzen, damit kein Cloud-Key aus einem
             # vorherigen Setup haengenbleibt.
             llm_cfg["api_key"] = ""
+            model = self._api_key_page.get_selected_model()
+            if model:
+                llm_cfg["model"] = model
             config.set("llm", llm_cfg)
         elif provider_id != "none":
             api_key = self._api_key_page.get_api_key()
             if api_key:
                 config.set_llm_api_key(api_key)
+            if provider_id == "ollama_cloud":
+                llm_cfg = config.get_llm_config()
+                if not llm_cfg.get("model"):
+                    llm_cfg["model"] = OLLAMA_CLOUD_DEFAULT_MODEL
+                    config.set("llm", llm_cfg)
 
         # Explorer-Integration: nur bei "Fertig" (Accepted) anwenden,
         # nicht bei "Spaeter"/Schliessen - dort waere eine Registry-

--- a/src/ml/hybrid_classifier.py
+++ b/src/ml/hybrid_classifier.py
@@ -17,7 +17,7 @@ from src.ml.claude_provider import ClaudeProvider
 from src.ml.openai_provider import OpenAIProvider
 from src.ml.poe_provider import PoeProvider
 from src.ml.openrouter_provider import OpenRouterProvider
-from src.ml.ollama_provider import OllamaProvider
+from src.ml.ollama_provider import OllamaProvider, OllamaCloudProvider
 from src.utils.config import get_config
 
 
@@ -120,6 +120,8 @@ class HybridClassifier:
                 self.llm_provider = OpenRouterProvider(config)
             elif provider_type == "ollama":
                 self.llm_provider = OllamaProvider(config)
+            elif provider_type == "ollama_cloud":
+                self.llm_provider = OllamaCloudProvider(config)
 
             self.llm_enabled = (
                 self.llm_provider is not None
@@ -176,6 +178,7 @@ class HybridClassifier:
             LLMProviderType.POE: "GPT-4o-Mini",
             LLMProviderType.OPENROUTER: OpenRouterProvider.DEFAULT_MODEL,
             LLMProviderType.OLLAMA: OllamaProvider.DEFAULT_MODEL,
+            LLMProviderType.OLLAMA_CLOUD: OllamaCloudProvider.DEFAULT_MODEL,
         }
         config = LLMConfig(
             api_key=api_key,
@@ -194,6 +197,8 @@ class HybridClassifier:
                 self.llm_provider = OpenRouterProvider(config)
             elif provider_type == LLMProviderType.OLLAMA:
                 self.llm_provider = OllamaProvider(config)
+            elif provider_type == LLMProviderType.OLLAMA_CLOUD:
+                self.llm_provider = OllamaCloudProvider(config)
 
             self.llm_enabled = (
                 self.llm_provider is not None
@@ -528,6 +533,8 @@ class HybridClassifier:
             return "OpenAI"
         if isinstance(self.llm_provider, PoeProvider):
             return "Poe"
+        if isinstance(self.llm_provider, OllamaCloudProvider):
+            return "Ollama Cloud"
         if isinstance(self.llm_provider, OllamaProvider):
             return "Ollama"
         return "Unbekannt"

--- a/src/ml/llm_provider.py
+++ b/src/ml/llm_provider.py
@@ -16,7 +16,7 @@ from enum import Enum
 
 
 # Provider, die Dokumenteninhalte an externe (Cloud-)Dienste uebertragen.
-CLOUD_PROVIDERS = frozenset({"claude", "openai", "poe", "openrouter"})
+CLOUD_PROVIDERS = frozenset({"claude", "openai", "poe", "openrouter", "ollama_cloud"})
 
 
 def is_cloud_provider(provider_type: str) -> bool:
@@ -31,6 +31,7 @@ class LLMProviderType(Enum):
     POE = "poe"  # Poe.com - Zugang zu vielen Modellen
     OPENROUTER = "openrouter"  # OpenRouter.ai - viele Modelle, OpenAI-kompatibel
     OLLAMA = "ollama"  # Lokaler Ollama-Server (kein API-Key noetig)
+    OLLAMA_CLOUD = "ollama_cloud"  # Ollama-Modelle in der Cloud (ollama.com, API-Key)
     NONE = "none"  # Kein LLM verwenden
 
 

--- a/src/ml/ollama_launcher.py
+++ b/src/ml/ollama_launcher.py
@@ -14,6 +14,7 @@ Strategie:
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -23,7 +24,7 @@ import time
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 logger = logging.getLogger("pdf_sortier_meister.ollama_launcher")
 
@@ -59,6 +60,77 @@ def quick_ping(base_url: str, timeout: float = 1.0) -> bool:
             return True
     except Exception:
         return False
+
+
+def list_models(base_url: str, timeout: float = 5.0) -> list[str]:
+    """Namen der lokal installierten Modelle (leer bei Fehler)."""
+    url = f"{base_url.rstrip('/')}/api/tags"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return []
+    return [m.get("name", "") for m in data.get("models", []) if m.get("name")]
+
+
+def pull_model(
+    base_url: str,
+    model: str,
+    progress_cb: Optional[Callable[[int, str], None]] = None,
+    should_cancel: Optional[Callable[[], bool]] = None,
+) -> tuple[bool, str]:
+    """
+    Laedt ein Modell ueber ``POST /api/pull`` (Streaming) herunter.
+
+    Args:
+        progress_cb: wird mit (Prozent 0-100, Statustext) aufgerufen
+        should_cancel: liefert True, wenn der Download abgebrochen werden soll
+
+    Returns:
+        (ok, message)
+    """
+    url = f"{base_url.rstrip('/')}/api/pull"
+    body = json.dumps({"name": model, "stream": True}).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return _consume_pull_stream(resp, progress_cb, should_cancel)
+    except urllib.error.HTTPError as e:
+        return False, f"Ollama HTTP {e.code}"
+    except urllib.error.URLError as e:
+        return False, f"Keine Verbindung zu Ollama ({base_url}): {e.reason}"
+    except Exception as e:
+        return False, f"Download-Fehler: {e}"
+
+
+def _consume_pull_stream(stream, progress_cb, should_cancel) -> tuple[bool, str]:
+    """Verarbeitet die NDJSON-Zeilen von /api/pull (auch fuer Tests nutzbar)."""
+    last_status = ""
+    for raw in stream:
+        if should_cancel and should_cancel():
+            return False, "Download abgebrochen."
+        line = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("error"):
+            return False, str(event["error"])
+        status = event.get("status", "")
+        total = event.get("total") or 0
+        completed = event.get("completed") or 0
+        percent = int(completed * 100 / total) if total else (100 if status == "success" else 0)
+        if progress_cb and (status != last_status or total):
+            progress_cb(percent, status)
+        last_status = status
+        if status == "success":
+            return True, "Modell installiert."
+    return False, "Download unvollstaendig (Verbindung beendet)."
 
 
 def _start_server_process(exe_path: str) -> bool:

--- a/src/ml/ollama_provider.py
+++ b/src/ml/ollama_provider.py
@@ -71,6 +71,13 @@ class OllamaProvider(LLMProvider):
         """Gibt den Modellnamen zurueck."""
         return self.config.model.strip() if self.config.model else self.DEFAULT_MODEL
 
+    def _headers(self) -> dict[str, str]:
+        """HTTP-Header; mit Bearer-Token, wenn ein API-Key konfiguriert ist."""
+        headers = {"Content-Type": "application/json"}
+        if self.config.api_key:
+            headers["Authorization"] = f"Bearer {self.config.api_key}"
+        return headers
+
     def is_available(self) -> bool:
         """Prueft, ob Ollama verfuegbar ist."""
         return bool(self._get_base_url())
@@ -78,8 +85,9 @@ class OllamaProvider(LLMProvider):
     def ping(self) -> tuple[bool, str]:
         """Prueft per HTTP-Request, ob der Ollama-Server erreichbar ist."""
         url = f"{self._get_base_url()}/api/version"
+        req = urllib.request.Request(url, headers=self._headers())
         try:
-            with urllib.request.urlopen(url, timeout=5) as resp:
+            with urllib.request.urlopen(req, timeout=5) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
                 return True, data.get("version", "unbekannt")
         except urllib.error.URLError as e:
@@ -90,8 +98,9 @@ class OllamaProvider(LLMProvider):
     def list_models(self) -> list[str]:
         """Holt die Liste der lokal installierten Modelle vom Server."""
         url = f"{self._get_base_url()}/api/tags"
+        req = urllib.request.Request(url, headers=self._headers())
         try:
-            with urllib.request.urlopen(url, timeout=5) as resp:
+            with urllib.request.urlopen(req, timeout=5) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
                 return [m.get("name", "") for m in data.get("models", []) if m.get("name")]
         except Exception:
@@ -153,7 +162,7 @@ class OllamaProvider(LLMProvider):
         req = urllib.request.Request(
             url,
             data=body,
-            headers={"Content-Type": "application/json"},
+            headers=self._headers(),
             method="POST",
         )
 
@@ -331,7 +340,7 @@ class OllamaProvider(LLMProvider):
         req = urllib.request.Request(
             url,
             data=body,
-            headers={"Content-Type": "application/json"},
+            headers=self._headers(),
             method="POST",
         )
         try:
@@ -344,3 +353,44 @@ class OllamaProvider(LLMProvider):
 
         message = data.get("message") or {}
         return message.get("content", "") or ""
+
+class OllamaCloudProvider(OllamaProvider):
+    """
+    Ollama-Modelle in der Cloud (https://ollama.com) - gleiche API wie der
+    lokale Server, aber mit API-Key (Bearer-Token) und ohne eigene Hardware.
+
+    Gedacht fuer Rechner ohne dedizierte Grafikkarte: Dokumentinhalte werden
+    dabei an ollama.com uebertragen, der Provider zaehlt deshalb als
+    Cloud-Provider (Einwilligung noetig).
+    """
+
+    DEFAULT_BASE_URL = "https://ollama.com"
+    DEFAULT_MODEL = "gpt-oss:120b"
+
+    # Bekannte Cloud-Modelle (Stand 2026); die Liste dient als Fallback,
+    # falls /api/tags auf ollama.com nicht erreichbar ist.
+    CLOUD_MODELS = [
+        "gpt-oss:120b",
+        "gpt-oss:20b",
+        "qwen3-coder:480b",
+        "deepseek-v3.1:671b",
+        "kimi-k2:1t",
+        "glm-4.6",
+        "minimax-m2",
+    ]
+
+    def _get_base_url(self) -> str:
+        # Eine in der Config verbliebene lokale URL (Wechsel von Ollama lokal)
+        # darf hier nicht greifen.
+        return self.DEFAULT_BASE_URL
+
+    def is_available(self) -> bool:
+        return bool(self.config.api_key)
+
+    def list_models(self) -> list[str]:
+        models = super().list_models()
+        return models or list(self.CLOUD_MODELS)
+
+    def _chat(self, system_prompt: str, user_prompt: str, json_mode: bool = False):
+        # Kein Auto-Start eines lokalen Servers bei Verbindungsfehlern.
+        return self._do_chat(system_prompt, user_prompt, json_mode=json_mode)

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -65,7 +65,7 @@ class Config:
         "filename_pattern": "",
         # LLM-Konfiguration
         "llm": {
-            "provider": "none",  # "none", "claude", "openai", "poe", "openrouter", "ollama"
+            "provider": "none",  # "none", "claude", "openai", "poe", "openrouter", "ollama", "ollama_cloud"
             "api_key": "",  # Key des aktiven Providers (Spiegel von api_keys)
             "api_keys": {},  # API-Keys pro Provider, z.B. {"poe": "...", "openrouter": "..."}
             "model": "",  # z.B. "haiku", "sonnet", "gpt-4o-mini", "llama3.1"

--- a/src/utils/hardware.py
+++ b/src/utils/hardware.py
@@ -1,0 +1,297 @@
+"""
+Hardware-Erkennung fuer die Ollama-Empfehlung im Einrichtungs-Assistenten.
+
+Ermittelt Grafikkarten (Name, dedizierter Grafikspeicher, integriert oder
+dediziert) und den Arbeitsspeicher und leitet daraus ab, ob Ollama lokal
+sinnvoll ist und welches Modell zur Grafikkarte passt.
+
+Quellen (Windows):
+1. ``nvidia-smi`` - liefert bei NVIDIA-Karten den exakten Speicher.
+2. Registry ``HKLM\\SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-...}``
+   (Display-Adapter): ``DriverDesc`` + ``HardwareInformation.qwMemorySize``.
+   Deckt AMD/Intel ab und dient als Fallback fuer NVIDIA ohne nvidia-smi.
+
+Integrierte GPUs (Intel UHD/Iris, AMD Radeon Graphics in APUs) melden zwar
+einen Speicherwert, teilen sich aber den Arbeitsspeicher - fuer Ollama zaehlt
+das nicht als Grafikspeicher.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+
+@dataclass
+class GpuInfo:
+    name: str
+    vram_mb: int          # dedizierter Grafikspeicher in MB (0 = keiner/unbekannt)
+    dedicated: bool       # False = integrierte Grafik (nutzt den Arbeitsspeicher)
+    vendor: str           # "nvidia" | "amd" | "intel" | "other"
+
+
+@dataclass
+class OllamaRecommendation:
+    local_ok: bool                 # Ollama lokal empfohlen?
+    model: Optional[str]           # empfohlenes lokales Modell (None -> Cloud)
+    model_size_gb: float           # Downloadgroesse des Modells
+    reason: str                    # Begruendung fuer den Nutzer
+    gpu: Optional[GpuInfo]         # die massgebliche Grafikkarte
+
+
+# (min. Grafikspeicher in MB, Modell, Downloadgroesse in GB)
+# Gemma 3 ist mehrsprachig stark (Deutsch) und liefert stabiles JSON.
+MODEL_TIERS = [
+    (20000, "gemma3:27b", 17.0),
+    (10000, "gemma3:12b", 8.1),
+    (4000, "gemma3:4b", 3.3),
+]
+MIN_VRAM_MB = MODEL_TIERS[-1][0]
+
+CLOUD_MODEL = "gpt-oss:120b"
+
+_INTEGRATED_PATTERNS = (
+    r"intel\(r\)\s+(uhd|hd|iris)",
+    r"intel.*(uhd|iris)\s+graphics",
+    r"radeon\(tm\)\s+graphics",
+    r"amd radeon graphics",
+    r"radeon.*vega.*graphics",
+    r"radeon\s+\d{3}m\b",          # Radeon 610M/680M/780M/890M (APUs)
+)
+_IGNORE_PATTERNS = (
+    r"microsoft basic",
+    r"remote display",
+    r"virtual",
+    r"vmware",
+    r"virtualbox",
+    r"parsec",
+    r"displaylink",
+    r"citrix",
+)
+
+
+def classify_gpu_name(name: str) -> tuple[str, bool, bool]:
+    """
+    Ordnet einen Adapternamen ein.
+
+    Returns:
+        (vendor, dedicated, ignore)
+    """
+    low = name.lower()
+    if any(re.search(p, low) for p in _IGNORE_PATTERNS):
+        return "other", False, True
+    if "nvidia" in low or "geforce" in low or "quadro" in low:
+        vendor = "nvidia"
+    elif "amd" in low or "radeon" in low:
+        vendor = "amd"
+    elif "intel" in low:
+        vendor = "intel"
+    else:
+        vendor = "other"
+    integrated = any(re.search(p, low) for p in _INTEGRATED_PATTERNS)
+    return vendor, not integrated, False
+
+
+def parse_nvidia_smi(output: str) -> list[GpuInfo]:
+    """Parst ``nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits``."""
+    gpus = []
+    for line in output.splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) < 2 or not parts[0]:
+            continue
+        try:
+            vram = int(float(parts[1]))
+        except ValueError:
+            continue
+        gpus.append(GpuInfo(name=parts[0], vram_mb=vram, dedicated=True, vendor="nvidia"))
+    return gpus
+
+
+def _nvidia_smi_gpus() -> list[GpuInfo]:
+    try:
+        kwargs = {}
+        if sys.platform == "win32":
+            kwargs["creationflags"] = 0x08000000  # CREATE_NO_WINDOW
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=5, **kwargs,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+    return parse_nvidia_smi(result.stdout)
+
+
+def _registry_value_to_int(value) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (bytes, bytearray)) and value:
+        return int.from_bytes(value, "little", signed=False)
+    return 0
+
+
+def _registry_gpus() -> list[GpuInfo]:
+    """Display-Adapter aus der Windows-Registry (funktioniert ohne Zusatztools)."""
+    if sys.platform != "win32":
+        return []
+    import winreg
+
+    base = r"SYSTEM\CurrentControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}"
+    gpus = []
+    try:
+        root = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, base)
+    except OSError:
+        return []
+    with root:
+        index = 0
+        while True:
+            try:
+                sub = winreg.EnumKey(root, index)
+            except OSError:
+                break
+            index += 1
+            if not re.fullmatch(r"\d{4}", sub):
+                continue
+            try:
+                with winreg.OpenKey(root, sub) as key:
+                    name = winreg.QueryValueEx(key, "DriverDesc")[0]
+                    vram_bytes = 0
+                    for value_name in ("HardwareInformation.qwMemorySize",
+                                       "HardwareInformation.MemorySize"):
+                        try:
+                            vram_bytes = _registry_value_to_int(
+                                winreg.QueryValueEx(key, value_name)[0]
+                            )
+                            if vram_bytes:
+                                break
+                        except OSError:
+                            continue
+            except OSError:
+                continue
+            vendor, dedicated, ignore = classify_gpu_name(name)
+            if ignore:
+                continue
+            gpus.append(GpuInfo(
+                name=name,
+                vram_mb=int(vram_bytes // (1024 * 1024)) if dedicated else 0,
+                dedicated=dedicated,
+                vendor=vendor,
+            ))
+    return gpus
+
+
+def detect_gpus() -> list[GpuInfo]:
+    """Alle Grafikkarten; NVIDIA-Werte aus nvidia-smi haben Vorrang."""
+    gpus = _nvidia_smi_gpus()
+    seen = {g.name.lower() for g in gpus}
+    for g in _registry_gpus():
+        if g.name.lower() in seen:
+            continue
+        seen.add(g.name.lower())
+        gpus.append(g)
+    return gpus
+
+
+def total_ram_mb() -> int:
+    """Physischer Arbeitsspeicher in MB (0, wenn nicht ermittelbar)."""
+    if sys.platform != "win32":
+        return 0
+
+    class _MemStatus(ctypes.Structure):
+        _fields_ = [
+            ("dwLength", ctypes.c_ulong),
+            ("dwMemoryLoad", ctypes.c_ulong),
+            ("ullTotalPhys", ctypes.c_ulonglong),
+            ("ullAvailPhys", ctypes.c_ulonglong),
+            ("ullTotalPageFile", ctypes.c_ulonglong),
+            ("ullAvailPageFile", ctypes.c_ulonglong),
+            ("ullTotalVirtual", ctypes.c_ulonglong),
+            ("ullAvailVirtual", ctypes.c_ulonglong),
+            ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+        ]
+
+    status = _MemStatus()
+    status.dwLength = ctypes.sizeof(_MemStatus)
+    try:
+        if not ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(status)):
+            return 0
+    except Exception:
+        return 0
+    return int(status.ullTotalPhys // (1024 * 1024))
+
+
+def _gb(mb: int) -> str:
+    return f"{mb / 1024:.0f} GB"
+
+
+def recommend(gpus: list[GpuInfo], ram_mb: int = 0) -> OllamaRecommendation:
+    """
+    Leitet aus der Hardware eine Ollama-Empfehlung ab.
+
+    Regeln:
+    - keine dedizierte Grafikkarte (nur integrierte Grafik oder gar keine):
+      lokal nicht empfohlen -> Ollama Cloud
+    - dedizierte Karte mit weniger als 4 GB: ebenfalls Cloud
+    - Intel Arc: von Ollama unter Windows nicht unterstuetzt -> Cloud
+    - sonst: groesstes Gemma-3-Modell, das in den Grafikspeicher passt
+    """
+    dedicated = [g for g in gpus if g.dedicated]
+    best = max(dedicated, key=lambda g: g.vram_mb) if dedicated else None
+
+    if best is None:
+        integrated = next((g for g in gpus if not g.dedicated), None)
+        if integrated:
+            reason = (
+                f"Nur integrierte Grafik erkannt ({integrated.name}), die sich den "
+                f"Arbeitsspeicher teilt. Ein lokales Modell wuerde auf dem Prozessor "
+                f"laufen - pro Dokument dauert das oft eine Minute oder laenger."
+            )
+        else:
+            reason = (
+                "Keine Grafikkarte erkannt. Ein lokales Modell wuerde auf dem "
+                "Prozessor laufen - pro Dokument dauert das oft eine Minute oder laenger."
+            )
+        return OllamaRecommendation(False, None, 0.0, reason, integrated)
+
+    if best.vendor == "intel":
+        return OllamaRecommendation(
+            False, None, 0.0,
+            f"{best.name} erkannt - Intel-Grafikkarten werden von Ollama unter "
+            f"Windows nicht unterstuetzt, das Modell liefe auf dem Prozessor.",
+            best,
+        )
+
+    if best.vram_mb < MIN_VRAM_MB:
+        vram_text = _gb(best.vram_mb) if best.vram_mb else "unbekannt"
+        return OllamaRecommendation(
+            False, None, 0.0,
+            f"{best.name} erkannt, aber mit {vram_text} Grafikspeicher zu wenig fuer "
+            f"ein brauchbares lokales Modell (mindestens {_gb(MIN_VRAM_MB)}).",
+            best,
+        )
+
+    for min_mb, model, size_gb in MODEL_TIERS:
+        if best.vram_mb >= min_mb:
+            reason = (
+                f"{best.name} mit {_gb(best.vram_mb)} Grafikspeicher erkannt - "
+                f"empfohlenes Modell: {model} (Download ca. {size_gb:.0f} GB)."
+            )
+            if best.vendor == "amd":
+                reason += (
+                    " Hinweis: Ollama unterstuetzt unter Windows nur neuere "
+                    "AMD-Karten (Radeon RX 6000/7000/9000)."
+                )
+            return OllamaRecommendation(True, model, size_gb, reason, best)
+
+    # unerreichbar (MIN_VRAM_MB entspricht der kleinsten Stufe), Sicherheitsnetz
+    return OllamaRecommendation(False, None, 0.0, "Keine Empfehlung moeglich.", best)
+
+
+def detect_and_recommend() -> OllamaRecommendation:
+    """Erkennung + Empfehlung in einem Schritt (dauert < 1 s, nvidia-smi inklusive)."""
+    return recommend(detect_gpus(), total_ram_mb())

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -1,0 +1,111 @@
+"""Tests fuer die Hardware-Erkennung und die Ollama-Empfehlung."""
+
+import pytest
+
+from src.utils import hardware
+from src.utils.hardware import GpuInfo, classify_gpu_name, parse_nvidia_smi, recommend
+
+
+def _gpu(name, vram_mb, dedicated=True, vendor="nvidia"):
+    return GpuInfo(name=name, vram_mb=vram_mb, dedicated=dedicated, vendor=vendor)
+
+
+@pytest.mark.parametrize("name,vendor,dedicated,ignore", [
+    ("NVIDIA GeForce RTX 3060", "nvidia", True, False),
+    ("Intel(R) UHD Graphics 770", "intel", False, False),
+    ("Intel(R) Iris(R) Xe Graphics", "intel", False, False),
+    ("Intel(R) Arc(TM) A770 Graphics", "intel", True, False),
+    ("AMD Radeon(TM) Graphics", "amd", False, False),
+    ("AMD Radeon 780M", "amd", False, False),
+    ("AMD Radeon RX 7800 XT", "amd", True, False),
+    ("Microsoft Basic Display Adapter", "other", False, True),
+    ("VMware SVGA 3D", "other", False, True),
+])
+def test_classify_gpu_name(name, vendor, dedicated, ignore):
+    assert classify_gpu_name(name) == (vendor, dedicated, ignore)
+
+
+def test_parse_nvidia_smi():
+    out = "NVIDIA GeForce RTX 4090, 24564\nNVIDIA T400, 2048\n\n"
+    gpus = parse_nvidia_smi(out)
+    assert [(g.name, g.vram_mb) for g in gpus] == [
+        ("NVIDIA GeForce RTX 4090", 24564), ("NVIDIA T400", 2048)
+    ]
+    assert all(g.dedicated and g.vendor == "nvidia" for g in gpus)
+
+
+def test_no_gpu_recommends_cloud():
+    rec = recommend([], ram_mb=32000)
+    assert rec.local_ok is False
+    assert rec.model is None
+    assert "Keine Grafikkarte" in rec.reason
+
+
+def test_integrated_only_recommends_cloud_even_with_much_ram():
+    rec = recommend([_gpu("Intel(R) UHD Graphics 770", 0, dedicated=False, vendor="intel")], ram_mb=65536)
+    assert rec.local_ok is False
+    assert "integrierte Grafik" in rec.reason
+    assert rec.gpu.name.startswith("Intel")
+
+
+def test_small_vram_recommends_cloud():
+    rec = recommend([_gpu("NVIDIA GeForce GTX 1050", 2048)])
+    assert rec.local_ok is False
+    assert "2 GB" in rec.reason
+
+
+def test_intel_arc_recommends_cloud():
+    rec = recommend([_gpu("Intel(R) Arc(TM) A770 Graphics", 16384, vendor="intel")])
+    assert rec.local_ok is False
+    assert "Intel" in rec.reason
+
+
+@pytest.mark.parametrize("vram_mb,model", [
+    (4096, "gemma3:4b"),
+    (8192, "gemma3:4b"),
+    (12288, "gemma3:12b"),
+    (16384, "gemma3:12b"),
+    (24564, "gemma3:27b"),
+])
+def test_model_tier_by_vram(vram_mb, model):
+    rec = recommend([_gpu("NVIDIA GeForce RTX", vram_mb)])
+    assert rec.local_ok is True
+    assert rec.model == model
+    assert rec.model_size_gb > 0
+    assert model in rec.reason
+
+
+def test_best_dedicated_gpu_wins_over_integrated():
+    gpus = [
+        _gpu("Intel(R) UHD Graphics 630", 0, dedicated=False, vendor="intel"),
+        _gpu("NVIDIA GeForce RTX 3080", 10240),
+    ]
+    rec = recommend(gpus)
+    assert rec.local_ok is True
+    assert rec.gpu.name == "NVIDIA GeForce RTX 3080"
+    assert rec.model == "gemma3:12b"
+
+
+def test_amd_gets_support_hint():
+    rec = recommend([_gpu("AMD Radeon RX 7800 XT", 16384, vendor="amd")])
+    assert rec.local_ok is True
+    assert "AMD" in rec.reason
+
+
+def test_detect_gpus_merges_sources(monkeypatch):
+    monkeypatch.setattr(hardware, "_nvidia_smi_gpus",
+                        lambda: [_gpu("NVIDIA GeForce RTX 3060", 12288)])
+    monkeypatch.setattr(hardware, "_registry_gpus", lambda: [
+        _gpu("NVIDIA GeForce RTX 3060", 12000),           # Duplikat -> ignoriert
+        _gpu("Intel(R) UHD Graphics 770", 0, False, "intel"),
+    ])
+    gpus = hardware.detect_gpus()
+    assert [g.name for g in gpus] == ["NVIDIA GeForce RTX 3060", "Intel(R) UHD Graphics 770"]
+    assert gpus[0].vram_mb == 12288  # nvidia-smi hat Vorrang
+
+
+def test_registry_value_conversion():
+    assert hardware._registry_value_to_int(12 * 1024 ** 3) == 12 * 1024 ** 3
+    assert hardware._registry_value_to_int((8 * 1024 ** 3).to_bytes(8, "little")) == 8 * 1024 ** 3
+    assert hardware._registry_value_to_int(b"") == 0
+    assert hardware._registry_value_to_int("x") == 0

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -8,5 +8,6 @@ def test_cloud_providers_set():
     assert is_cloud_provider("openai") is True
     assert is_cloud_provider("poe") is True
     assert is_cloud_provider("openrouter") is True
+    assert is_cloud_provider("ollama_cloud") is True
     assert is_cloud_provider("ollama") is False
     assert is_cloud_provider("none") is False

--- a/tests/test_ollama_pull_and_cloud.py
+++ b/tests/test_ollama_pull_and_cloud.py
@@ -1,0 +1,91 @@
+"""Tests: Modell-Download-Stream (/api/pull) und Ollama-Cloud-Provider."""
+
+import json
+
+from src.ml.llm_provider import LLMConfig, is_cloud_provider
+from src.ml.ollama_launcher import _consume_pull_stream
+from src.ml.ollama_provider import OllamaCloudProvider, OllamaProvider
+
+
+def _stream(events):
+    return [(json.dumps(e) + "\n").encode("utf-8") for e in events]
+
+
+def test_pull_stream_reports_progress_and_success():
+    events = [
+        {"status": "pulling manifest"},
+        {"status": "pulling abc", "total": 1000, "completed": 250},
+        {"status": "pulling abc", "total": 1000, "completed": 1000},
+        {"status": "verifying sha256 digest"},
+        {"status": "success"},
+    ]
+    seen = []
+    ok, msg = _consume_pull_stream(_stream(events), lambda p, s: seen.append((p, s)), None)
+    assert ok is True
+    assert msg == "Modell installiert."
+    assert (25, "pulling abc") in seen
+    assert (100, "pulling abc") in seen
+    assert seen[-1] == (100, "success")
+
+
+def test_pull_stream_error_event():
+    ok, msg = _consume_pull_stream(_stream([{"error": "pull model manifest: file does not exist"}]), None, None)
+    assert ok is False
+    assert "does not exist" in msg
+
+
+def test_pull_stream_cancel():
+    events = [{"status": "pulling manifest"}, {"status": "pulling abc", "total": 10, "completed": 1}]
+    calls = {"n": 0}
+
+    def should_cancel():
+        calls["n"] += 1
+        return calls["n"] > 1
+
+    ok, msg = _consume_pull_stream(_stream(events), None, should_cancel)
+    assert ok is False
+    assert "abgebrochen" in msg
+
+
+def test_pull_stream_truncated():
+    ok, msg = _consume_pull_stream(_stream([{"status": "pulling manifest"}]), None, None)
+    assert ok is False
+    assert "unvollstaendig" in msg
+
+
+def test_ollama_cloud_is_cloud_provider():
+    assert is_cloud_provider("ollama_cloud") is True
+    assert is_cloud_provider("ollama") is False
+
+
+def test_cloud_provider_uses_bearer_and_ignores_local_url():
+    p = OllamaCloudProvider(LLMConfig(api_key="sk-test", model="", base_url="http://localhost:11434"))
+    assert p._get_base_url() == "https://ollama.com"
+    assert p._headers()["Authorization"] == "Bearer sk-test"
+    assert p._get_model_id() == "gpt-oss:120b"
+    assert p.is_available() is True
+    assert OllamaCloudProvider(LLMConfig(api_key="", model="")).is_available() is False
+
+
+def test_local_provider_has_no_auth_header_without_key():
+    p = OllamaProvider(LLMConfig(api_key="", model="llama3.1"))
+    assert "Authorization" not in p._headers()
+
+
+def test_cloud_list_models_falls_back_to_static(monkeypatch):
+    import urllib.request
+
+    def boom(*a, **k):
+        raise OSError("offline")
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    p = OllamaCloudProvider(LLMConfig(api_key="sk", model=""))
+    assert p.list_models() == OllamaCloudProvider.CLOUD_MODELS
+
+
+def test_cloud_chat_does_not_autostart_local_server(monkeypatch):
+    p = OllamaCloudProvider(LLMConfig(api_key="sk", model=""))
+    monkeypatch.setattr(p, "_do_chat", lambda *a, **k: (None, "Keine Verbindung zu Ollama (x)"))
+    import src.ml.ollama_launcher as launcher
+    monkeypatch.setattr(launcher, "ensure_running", lambda *a, **k: (_ for _ in ()).throw(AssertionError("darf nicht")))
+    assert p._chat("s", "u") == (None, "Keine Verbindung zu Ollama (x)")

--- a/tests/test_setup_wizard_ollama_gui.py
+++ b/tests/test_setup_wizard_ollama_gui.py
@@ -1,0 +1,163 @@
+"""GUI-Tests: Ollama-Erkennung, Hardware-Empfehlung und Modell-Seite im Wizard."""
+from __future__ import annotations
+
+import pytest
+
+from src.gui import setup_wizard as wiz
+from src.gui.setup_wizard import SetupWizard, PAGE_PROVIDER, PAGE_API_KEY, _PROVIDER_IDS
+from src.utils.hardware import GpuInfo, OllamaRecommendation
+
+
+@pytest.fixture
+def fresh_config(monkeypatch, tmp_path):
+    from src.utils import config as cfg_mod
+    from tests.conftest import patch_singletons
+
+    fresh = cfg_mod.Config(config_path=tmp_path / "config.json")
+    patch_singletons(monkeypatch, {"get_config": lambda: fresh})
+    return fresh
+
+
+def _rec_local(model="gemma3:12b"):
+    gpu = GpuInfo("NVIDIA GeForce RTX 3060", 12288, True, "nvidia")
+    return OllamaRecommendation(True, model, 8.1, f"RTX 3060 mit 12 GB - empfohlen: {model}.", gpu)
+
+
+def _rec_cloud():
+    gpu = GpuInfo("Intel(R) UHD Graphics 770", 0, False, "intel")
+    return OllamaRecommendation(False, None, 0.0, "Nur integrierte Grafik erkannt.", gpu)
+
+
+def _fake_env(monkeypatch, installed, running, rec):
+    monkeypatch.setattr(wiz, "detect_ollama_environment", lambda: {
+        "exe": r"C:\ollama.exe" if installed else None,
+        "installed": installed, "running": running, "recommendation": rec,
+    })
+
+
+def _wizard_on_provider_page(qtbot):
+    w = SetupWizard()
+    qtbot.addWidget(w)
+    w.show()
+    w.next()  # Welcome -> Scan
+    w.next()  # Scan -> Provider (startet die Erkennung)
+    page = w.page(PAGE_PROVIDER)
+    qtbot.waitUntil(lambda: page.get_detection() is not None, timeout=5000)
+    return w, page
+
+
+def test_local_recommendation_preselects_ollama(qtbot, fresh_config, monkeypatch):
+    _fake_env(monkeypatch, installed=True, running=True, rec=_rec_local())
+    w, page = _wizard_on_provider_page(qtbot)
+
+    assert page.get_provider_id() == "ollama"
+    assert "installiert und laeuft" in page.ollama_status_label.text()
+    assert "Ollama lokal" in page.hardware_label.text()
+    ollama_radio = page._radios[_PROVIDER_IDS.index("ollama")]
+    assert ollama_radio.text().endswith("(empfohlen)")
+
+
+def test_cloud_recommendation_when_no_dedicated_gpu(qtbot, fresh_config, monkeypatch):
+    _fake_env(monkeypatch, installed=False, running=False, rec=_rec_cloud())
+    w, page = _wizard_on_provider_page(qtbot)
+
+    assert page.get_provider_id() == "ollama_cloud"
+    assert "nicht installiert" in page.ollama_status_label.text()
+    assert "nicht empfohlen" in page.hardware_label.text()
+    assert "Ollama Cloud" in page.hardware_label.text()
+    cloud_radio = page._radios[_PROVIDER_IDS.index("ollama_cloud")]
+    assert cloud_radio.text().endswith("(empfohlen)")
+
+
+def test_existing_choice_is_not_overridden(qtbot, fresh_config, monkeypatch):
+    fresh_config.set_llm_provider("claude")
+    _fake_env(monkeypatch, installed=True, running=True, rec=_rec_local())
+    w, page = _wizard_on_provider_page(qtbot)
+    assert page.get_provider_id() == "claude"
+
+
+def test_ollama_page_lists_models_and_saves_choice(qtbot, fresh_config, monkeypatch):
+    _fake_env(monkeypatch, installed=True, running=True, rec=_rec_local("gemma3:12b"))
+    monkeypatch.setattr(wiz, "probe_ollama_models", lambda: (True, "ok", ["llama3.1:latest", "gemma3:12b"]))
+    w, page = _wizard_on_provider_page(qtbot)
+    assert page.get_provider_id() == "ollama"
+
+    w.next()  # -> Ollama-Seite
+    api_page = w.page(PAGE_API_KEY)
+    assert api_page._ollama_box.isVisible()
+    qtbot.waitUntil(lambda: api_page.model_combo.count() == 2, timeout=5000)
+    assert api_page.model_combo.currentText() == "gemma3:12b"  # Empfehlung bevorzugt
+    assert "bereits installiert" in api_page.pull_btn.text()   # Empfehlung schon da
+    assert not api_page.pull_btn.isEnabled()
+    assert not api_page.ollama_warning_label.isVisible()
+
+    w.accept()
+    llm = fresh_config.get_llm_config()
+    assert llm["provider"] == "ollama"
+    assert llm["model"] == "gemma3:12b"
+    assert llm["api_key"] == ""
+
+
+def test_pull_button_active_when_recommended_model_missing(qtbot, fresh_config, monkeypatch):
+    _fake_env(monkeypatch, installed=True, running=True, rec=_rec_local("gemma3:12b"))
+    monkeypatch.setattr(wiz, "probe_ollama_models", lambda: (True, "ok", ["llama3.1:latest"]))
+    w, page = _wizard_on_provider_page(qtbot)
+    w.next()
+    api_page = w.page(PAGE_API_KEY)
+    qtbot.waitUntil(lambda: api_page.model_combo.count() == 1, timeout=5000)
+    assert api_page.pull_btn.isEnabled()
+    assert "gemma3:12b" in api_page.pull_btn.text()
+    assert "8 GB" in api_page.pull_btn.text()
+
+
+def test_ollama_page_without_installation(qtbot, fresh_config, monkeypatch):
+    _fake_env(monkeypatch, installed=False, running=False, rec=_rec_cloud())
+    w, page = _wizard_on_provider_page(qtbot)
+    # Nutzer waehlt trotz Empfehlung Ollama lokal
+    page._radios[_PROVIDER_IDS.index("ollama")].setChecked(True)
+    w.next()
+    api_page = w.page(PAGE_API_KEY)
+    assert not api_page.pull_btn.isEnabled()
+    assert "Erneut pruefen" in api_page.models_status_label.text()
+    assert api_page.ollama_warning_label.isVisible()
+    assert "gemma3:4b" in api_page.pull_btn.text()  # Fallback-Modell
+
+
+def test_pull_progress_updates_ui(qtbot, fresh_config, monkeypatch):
+    _fake_env(monkeypatch, installed=True, running=True, rec=_rec_local("gemma3:4b"))
+    monkeypatch.setattr(wiz, "probe_ollama_models", lambda: (True, "ok", []))
+
+    def fake_pull(base_url, model, progress_cb=None, should_cancel=None):
+        progress_cb(10, "pulling manifest")
+        progress_cb(100, "success")
+        return True, "Modell installiert."
+
+    import src.ml.ollama_launcher as launcher
+    monkeypatch.setattr(launcher, "pull_model", fake_pull)
+
+    w, page = _wizard_on_provider_page(qtbot)
+    w.next()
+    api_page = w.page(PAGE_API_KEY)
+    qtbot.waitUntil(lambda: "kein Modell" in api_page.models_status_label.text(), timeout=5000)
+    assert api_page.model_combo.currentText() == "gemma3:4b"
+
+    api_page._start_pull()
+    qtbot.waitUntil(lambda: "Modell installiert" in api_page.models_status_label.text()
+                    or api_page.pull_progress.value() == 100, timeout=5000)
+    assert api_page.pull_progress.value() == 100
+
+
+def test_ollama_cloud_page_saves_key_and_default_model(qtbot, fresh_config, monkeypatch):
+    _fake_env(monkeypatch, installed=False, running=False, rec=_rec_cloud())
+    w, page = _wizard_on_provider_page(qtbot)
+    assert page.get_provider_id() == "ollama_cloud"
+    w.next()
+    api_page = w.page(PAGE_API_KEY)
+    assert not api_page._ollama_box.isVisible()
+    assert "ollama.com/settings/keys" in api_page._link_btn.text()
+    api_page.key_edit.setText("ol-secret")
+    w.accept()
+    llm = fresh_config.get_llm_config()
+    assert llm["provider"] == "ollama_cloud"
+    assert llm["api_key"] == "ol-secret"
+    assert llm["model"] == "gpt-oss:120b"


### PR DESCRIPTION
Alle drei Stufen aus der Diskussion, plus die Cloud-Regel:

**Stufe 1 – Erkennung:** Die Provider-Seite prüft im Hintergrund, ob Ollama installiert ist und läuft (`find_ollama_executable` + Ping), und zeigt den Status direkt unter dem Ollama-Eintrag.

**Stufe 2 – Modelle ohne Terminal:** Die Ollama-Seite startet den Server bei Bedarf, listet die installierten Modelle (`/api/tags`) und lädt das empfohlene Modell per Klick mit Fortschrittsbalken (`/api/pull`, abbrechbar). Das gewählte Modell wird gespeichert.

**Stufe 3 – Hardware:** `src/utils/hardware.py` erkennt Grafikkarten über `nvidia-smi` und die Registry (Display-Adapter, `HardwareInformation.qwMemorySize`) und unterscheidet dedizierte von integrierter Grafik. Empfehlung nach Grafikspeicher: gemma3:4b (≥ 4 GB), gemma3:12b (≥ 10 GB), gemma3:27b (≥ 20 GB).
**Kein VRAM / nur Shared Memory / < 4 GB / Intel-GPU → Ollama lokal nicht empfohlen, stattdessen Ollama Cloud.** Die Empfehlung wird als „(empfohlen)“ markiert und vorausgewählt, solange noch kein Provider konfiguriert ist.

**Ollama Cloud** als neuer Provider (`ollama_cloud`): gleiche API wie lokal gegen `https://ollama.com` mit API-Key (Bearer). Gilt als Cloud-Provider → Consent-Gate greift. Einstellungsdialog: Combo-Eintrag, Modell-Liste, „Modelle aktualisieren“, Verbindungstest.

Getestet: 428 Tests grün (41 neu). Real auf dem Dev-Rechner: RTX 5080/16 GB → gemma3:12b, Ollama erkannt, 7 Modelle gelistet (Screenshots in der Konversation).

⚠️ Nicht real getestet: Ollama Cloud (kein API-Key vorhanden). Endpunkt/Auth entsprechen der Ollama-Doku (`https://ollama.com/api/chat`, `Authorization: Bearer`), die Modellliste ist ein statischer Fallback, falls `/api/tags` dort nicht antwortet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
