### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-26
+
 ### Hinzugefuegt
 - **Einrichtungs-Assistent erkennt Ollama und die Hardware**
   - Provider-Seite zeigt, ob Ollama installiert ist bzw. laeuft, und prueft die
@@ -223,7 +225,8 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 ### Geaendert
 - `ENTWICKLUNGSSTAND.md` -> v0.11.0
 
-[Unreleased]: https://github.com/Josi-create/PDF_Sortier_Meister/compare/v0.15.1...HEAD
+[Unreleased]: https://github.com/Josi-create/PDF_Sortier_Meister/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/Josi-create/PDF_Sortier_Meister/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/Josi-create/PDF_Sortier_Meister/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/Josi-create/PDF_Sortier_Meister/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/Josi-create/PDF_Sortier_Meister/compare/v0.13.0...v0.14.0

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ python run.py
 - Python 3.10+, Windows 10/11
 - OCR im Quellcode-Betrieb: Tesseract installieren (`winget install UB-Mannheim.TesseractOCR`) — die App
   findet es in den Standardordnern; in den Builds ist es gebündelt
-- Tests: `python -m pytest tests -q` (388 Tests, pytest-qt)
+- Tests: `python -m pytest tests -q` (428 Tests, pytest-qt)
 - Windows-Build: `build.bat` — PyInstaller (`pdf_sortier_meister.spec`), kopiert Tesseract nach `vendor/`
   und baut mit Inno Setup 6 den Installer (`scripts/build_installer.py`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdf-sortier-meister"
-version = "0.15.1"
+version = "0.16.0"
 description = "Ein intelligentes Programm zum Sortieren und Umbenennen von gescannten PDF-Dokumenten"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,7 @@ from src.utils.single_instance import (
 from src.utils.explorer_integration import update_launcher_script
 
 # Versionsnummer zentral definiert
-__version__ = "0.15.1"
+__version__ = "0.16.0"
 
 
 def _extract_path_arg(argv: list[str]) -> str:


### PR DESCRIPTION
Versions-Bump 0.15.1 → 0.16.0, CHANGELOG-Abschnitt für den Ollama-Wizard (PR #43), README-Testzahl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)