### PR TITLE
feat(#42): Dateiname aus Ordnerstruktur beim Verschieben

### DIFF
--- a/src/core/folder_naming.py
+++ b/src/core/folder_naming.py
@@ -1,0 +1,136 @@
+"""
+Dateinamen aus der Ordnerstruktur aufbauen (Issue #42).
+
+Beim Verschieben einer PDF wird der Dateiname nach einer konfigurierbaren
+Vorlage aus dem Zielordner-Pfad neu aufgebaut, z.B.
+"JK 069-03-05-20260512-Rechnung.pdf" fuer die Struktur
+"JK 069-Umbau/JK 069-03-Firmen/JK 069-03-05-Rohbau".
+
+Unterstuetzte Platzhalter:
+    {initialen}      Initialen aus den Einstellungen (z.B. "JK")
+    {ordnernummern}  Nummernkette aus dem Zielordner-Namen (z.B. "069-03-05")
+    {ordnerpfad}     Ordnernamen des relativen Pfads, mit "-" verbunden
+    {datum}          Dokumentdatum als YYYYMMDD (z.B. "20260512")
+    {datum_iso}      Dokumentdatum als YYYY-MM-DD
+    {text}           Bisheriger Dateiname ohne Datums-Praefix und Endung
+
+GPL-3.0-or-later - Copyright (c) 2026
+"""
+
+import re
+from datetime import date, datetime
+from pathlib import PurePath
+from typing import Any, Optional
+
+DEFAULT_TEMPLATE = "{initialen} {ordnernummern}-{datum}-{text}"
+
+# Windows-verbotene Zeichen in Dateinamen
+_FORBIDDEN_CHARS = re.compile(r'[<>:"/\\|?*]')
+
+# Fuehrende Datumsangabe im Dateinamen: "2026-05-12_..." oder "20260512-..."
+_LEADING_DATE = re.compile(
+    r"^(?P<date>(?P<y1>\d{4})-(?P<m1>\d{2})-(?P<d1>\d{2})|(?P<y2>\d{4})(?P<m2>\d{2})(?P<d2>\d{2}))[-_ ]*"
+)
+
+# Nummernkette in einem Ordnernamen: erste Folge von Zahlengruppen mit "-",
+# z.B. "JK 069-03-05-Rohbau" -> "069-03-05"
+_NUMBER_CHAIN = re.compile(r"\d+(?:-\d+)*")
+
+
+def extract_folder_numbers(folder_name: str) -> str:
+    """Extrahiert die Nummernkette aus einem Ordnernamen.
+
+    "JK 069-03-05-Rohbau" -> "069-03-05"; "" wenn keine Zahlen vorkommen.
+    """
+    match = _NUMBER_CHAIN.search(folder_name)
+    return match.group(0) if match else ""
+
+
+def coerce_date(value: Any) -> Optional[date]:
+    """Wandelt datetime/date in ein date um; alles andere ergibt None."""
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    return None
+
+
+def split_leading_date(name_stem: str) -> tuple[Optional[date], str]:
+    """Trennt ein fuehrendes Datum vom restlichen Dateinamen.
+
+    "2026-05-12_Rechnung Meier" -> (date(2026,5,12), "Rechnung Meier")
+    """
+    match = _LEADING_DATE.match(name_stem)
+    if not match:
+        return None, name_stem
+    y = match.group("y1") or match.group("y2")
+    m = match.group("m1") or match.group("m2")
+    d = match.group("d1") or match.group("d2")
+    try:
+        parsed = date(int(y), int(m), int(d))
+    except ValueError:
+        return None, name_stem
+    return parsed, name_stem[match.end():]
+
+
+def _collapse_separators(name: str) -> str:
+    """Entfernt doppelte/haengende Trenner, die durch leere Platzhalter entstehen."""
+    name = re.sub(r"-{2,}", "-", name)
+    name = re.sub(r"_{2,}", "_", name)
+    name = re.sub(r" {2,}", " ", name)
+    name = re.sub(r"[-_ ]*-[-_ ]*", "-", name)
+    return name.strip(" -_")
+
+
+def build_folder_based_name(
+    current_name: str,
+    target_folder: PurePath,
+    relative_path: str,
+    template: str = DEFAULT_TEMPLATE,
+    initials: str = "",
+    fallback_date: Optional[date] = None,
+) -> str:
+    """Baut den Dateinamen nach der Vorlage aus der Ordnerstruktur auf.
+
+    Args:
+        current_name: Bisheriger Dateiname (mit oder ohne ".pdf"), liefert
+            {text} und - falls vorhanden - das Datum.
+        target_folder: Zielordner (der tiefste Ordner liefert {ordnernummern}).
+        relative_path: Relativer Pfad des Zielordners (fuer {ordnerpfad}).
+        template: Vorlage mit Platzhaltern.
+        initials: Wert fuer {initialen}.
+        fallback_date: Datum falls der Dateiname keins enthaelt (z.B. aus dem
+            Dokument erkannt). Ohne jedes Datum bleibt {datum} leer.
+
+    Returns:
+        Der neue Dateiname mit ".pdf"-Endung.
+    """
+    stem = current_name[:-4] if current_name.lower().endswith(".pdf") else current_name
+    doc_date, text = split_leading_date(stem)
+    if doc_date is None:
+        doc_date = fallback_date
+
+    folder_numbers = extract_folder_numbers(PurePath(target_folder).name)
+    path_parts = [p for p in PurePath(relative_path).parts if p not in (".", "")]
+    folder_path_text = "-".join(path_parts)
+
+    values = {
+        "initialen": initials.strip(),
+        "ordnernummern": folder_numbers,
+        "ordnerpfad": folder_path_text,
+        "datum": doc_date.strftime("%Y%m%d") if doc_date else "",
+        "datum_iso": doc_date.isoformat() if doc_date else "",
+        "text": text.strip(),
+    }
+
+    try:
+        name = template.format(**values)
+    except (KeyError, IndexError, ValueError):
+        # Unbekannter Platzhalter / kaputte Vorlage: Namen unveraendert lassen
+        return stem + ".pdf" if stem else current_name
+
+    name = _FORBIDDEN_CHARS.sub("", name)
+    name = _collapse_separators(name)
+    if not name:
+        return stem + ".pdf" if stem else current_name
+    return name + ".pdf"

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -46,6 +46,7 @@ from src.gui.settings_dialog import SettingsDialog
 from src.gui.setup_wizard import SetupWizard
 from src.gui.korrespondent_sidebar import KorrespondentSidebar
 from src.core.file_manager import FileManager, FolderManager
+from src.core.folder_naming import DEFAULT_TEMPLATE, build_folder_based_name, coerce_date
 from src.core.pdf_cache import get_pdf_cache, PDFAnalysisResult
 from src.ml.classifier import get_classifier, Suggestion
 from src.ml.hybrid_classifier import get_hybrid_classifier
@@ -1574,6 +1575,21 @@ class MainWindow(QMainWindow):
         else:
             new_name = self.detail_panel.get_new_name()
             metadata = self.detail_panel.get_metadata()
+
+            # Dateiname aus Ordnerstruktur aufbauen (Issue #42, Opt-in)
+            if self.config.get("folder_naming_enabled", False):
+                fallback_date = (
+                    coerce_date(self.selected_pdf_dates[0])
+                    if self.selected_pdf_dates else None
+                )
+                new_name = build_folder_based_name(
+                    new_name or pdf_path.name,
+                    folder_path,
+                    relative_path,
+                    template=self.config.get("folder_naming_template", "") or DEFAULT_TEMPLATE,
+                    initials=self.config.get("folder_naming_initials", ""),
+                    fallback_date=fallback_date,
+                )
 
         # Prüfen ob umbenannt wird
         name_changed = new_name and new_name != pdf_path.name

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -304,6 +304,49 @@ class SettingsDialog(QDialog):
         hint_label.setStyleSheet("color: gray;")
         layout.addWidget(hint_label)
 
+        # Dateiname aus Ordnerstruktur (Issue #42)
+        folder_group = QGroupBox("Dateiname aus Ordnerstruktur (beim Verschieben)")
+        folder_layout = QVBoxLayout(folder_group)
+
+        self.folder_naming_check = QCheckBox(
+            "Dateinamen beim Verschieben aus dem Zielordner-Pfad aufbauen"
+        )
+        folder_layout.addWidget(self.folder_naming_check)
+
+        folder_form = QFormLayout()
+        self.folder_naming_initials_input = QLineEdit()
+        self.folder_naming_initials_input.setPlaceholderText("z.B. JK")
+        folder_form.addRow("Initialen:", self.folder_naming_initials_input)
+
+        self.folder_naming_template_input = QLineEdit()
+        self.folder_naming_template_input.setPlaceholderText(
+            "{initialen} {ordnernummern}-{datum}-{text}"
+        )
+        folder_form.addRow("Vorlage:", self.folder_naming_template_input)
+        folder_layout.addLayout(folder_form)
+
+        folder_info = QLabel(
+            "Platzhalter: {initialen}, {ordnernummern} (Nummernkette aus dem "
+            "Zielordner-Namen, z.B. \"069-03-05\"), {ordnerpfad} (Ordnernamen "
+            "mit \"-\" verbunden), {datum} (JJJJMMTT), {datum_iso} (JJJJ-MM-TT), "
+            "{text} (bisheriger Name ohne Datum).\n"
+            "Beispiel: Ordner \"JK 069-03-05-Auftrag\" ergibt "
+            "\"JK 069-03-05-20260512-Rechnung.pdf\"."
+        )
+        folder_info.setWordWrap(True)
+        folder_info.setStyleSheet("color: #555; font-size: 11px;")
+        folder_layout.addWidget(folder_info)
+
+        layout.addWidget(folder_group)
+
+        # Eingabefelder nur bei aktivierter Funktion bedienbar
+        self.folder_naming_check.toggled.connect(
+            self.folder_naming_initials_input.setEnabled
+        )
+        self.folder_naming_check.toggled.connect(
+            self.folder_naming_template_input.setEnabled
+        )
+
         layout.addStretch()
         return tab
 
@@ -996,6 +1039,18 @@ class SettingsDialog(QDialog):
         # Dateinamen-Muster
         self._load_filename_pattern()
 
+        # Dateiname aus Ordnerstruktur (Issue #42)
+        folder_naming_enabled = self.config.get("folder_naming_enabled", False)
+        self.folder_naming_check.setChecked(folder_naming_enabled)
+        self.folder_naming_initials_input.setText(
+            self.config.get("folder_naming_initials", "")
+        )
+        self.folder_naming_template_input.setText(
+            self.config.get("folder_naming_template", "")
+        )
+        self.folder_naming_initials_input.setEnabled(folder_naming_enabled)
+        self.folder_naming_template_input.setEnabled(folder_naming_enabled)
+
         # Cache-Einstellungen
         self.persist_cache_checkbox.setChecked(self.config.get("persist_pdf_cache", True))
         self.llm_precache_checkbox.setChecked(self.config.get("llm_precache_enabled", True))
@@ -1087,6 +1142,18 @@ class SettingsDialog(QDialog):
 
         # Dateinamen-Muster speichern
         self.config.set("filename_pattern", self._collect_filename_pattern())
+
+        # Dateiname aus Ordnerstruktur speichern (Issue #42)
+        self.config.set("folder_naming_enabled", self.folder_naming_check.isChecked())
+        self.config.set(
+            "folder_naming_initials",
+            self.folder_naming_initials_input.text().strip(),
+        )
+        template = self.folder_naming_template_input.text().strip()
+        self.config.set(
+            "folder_naming_template",
+            template or self.config.DEFAULTS["folder_naming_template"],
+        )
 
         # Explorer-Integration nur bei Aenderung anwenden.
         if sys.platform == "win32":

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -63,6 +63,10 @@ class Config:
         # Benutzerdefiniertes Dateinamen-Muster (leer = LLM-Default).
         # Wird als Few-Shot-Hinweis in den Filename-Prompt eingeflochten.
         "filename_pattern": "",
+        # Dateiname aus Ordnerstruktur beim Verschieben (Issue #42), Opt-in.
+        "folder_naming_enabled": False,
+        "folder_naming_template": "{initialen} {ordnernummern}-{datum}-{text}",
+        "folder_naming_initials": "",
         # LLM-Konfiguration
         "llm": {
             "provider": "none",  # "none", "claude", "openai", "poe", "openrouter", "ollama", "ollama_cloud"

--- a/tests/test_folder_naming.py
+++ b/tests/test_folder_naming.py
@@ -1,0 +1,144 @@
+"""Issue #42: Dateiname aus der Ordnerstruktur aufbauen."""
+from datetime import date, datetime
+from pathlib import PurePath
+
+from src.core.folder_naming import (
+    DEFAULT_TEMPLATE,
+    build_folder_based_name,
+    coerce_date,
+    extract_folder_numbers,
+    split_leading_date,
+)
+
+
+# --- extract_folder_numbers -----------------------------------------------
+
+def test_extract_folder_numbers_chain():
+    assert extract_folder_numbers("JK 069-03-05-Auftrag") == "069-03-05"
+    assert extract_folder_numbers("JK 069-Umbau Kellermannstrasse") == "069"
+
+
+def test_extract_folder_numbers_without_numbers():
+    assert extract_folder_numbers("Steuer Unterlagen") == ""
+
+
+# --- split_leading_date ---------------------------------------------------
+
+def test_split_leading_date_iso():
+    d, text = split_leading_date("2026-05-12_Rechnung Elektro Meier")
+    assert d == date(2026, 5, 12)
+    assert text == "Rechnung Elektro Meier"
+
+
+def test_split_leading_date_compact():
+    d, text = split_leading_date("20260512-Rechnung")
+    assert d == date(2026, 5, 12)
+    assert text == "Rechnung"
+
+
+def test_split_leading_date_none():
+    d, text = split_leading_date("Rechnung Elektro Meier")
+    assert d is None
+    assert text == "Rechnung Elektro Meier"
+
+
+def test_split_leading_date_invalid_date_kept_as_text():
+    d, text = split_leading_date("2026-13-99_Rechnung")
+    assert d is None
+    assert text == "2026-13-99_Rechnung"
+
+
+# --- coerce_date ----------------------------------------------------------
+
+def test_coerce_date():
+    assert coerce_date(datetime(2026, 5, 12, 8, 30)) == date(2026, 5, 12)
+    assert coerce_date(date(2026, 5, 12)) == date(2026, 5, 12)
+    assert coerce_date("2026-05-12") is None
+    assert coerce_date(None) is None
+
+
+# --- build_folder_based_name ----------------------------------------------
+
+def test_issue_example_format():
+    """Das Beispiel aus Issue #42: JK 069-03-05-09-20260512-Rechnung."""
+    name = build_folder_based_name(
+        "2026-05-12_Rechnung.pdf",
+        PurePath("C:/Ablage/JK 069-Umbau/JK 069-03-05-09-Auftrag"),
+        "JK 069-Umbau/JK 069-03-05-09-Auftrag",
+        template=DEFAULT_TEMPLATE,
+        initials="JK",
+    )
+    assert name == "JK 069-03-05-09-20260512-Rechnung.pdf"
+
+
+def test_fallback_date_used_when_name_has_none():
+    name = build_folder_based_name(
+        "Rechnung.pdf",
+        PurePath("JK 069-01-Firmen"),
+        "JK 069-01-Firmen",
+        initials="JK",
+        fallback_date=date(2026, 5, 12),
+    )
+    assert name == "JK 069-01-20260512-Rechnung.pdf"
+
+
+def test_missing_date_collapses_separators():
+    name = build_folder_based_name(
+        "Rechnung.pdf",
+        PurePath("JK 069-01-Firmen"),
+        "JK 069-01-Firmen",
+        initials="JK",
+    )
+    assert name == "JK 069-01-Rechnung.pdf"
+
+
+def test_folder_without_numbers_collapses_separators():
+    name = build_folder_based_name(
+        "2026-05-12_Rechnung.pdf",
+        PurePath("Steuer/Banken"),
+        "Steuer/Banken",
+        initials="JK",
+    )
+    assert name == "JK-20260512-Rechnung.pdf"
+
+
+def test_ordnerpfad_placeholder():
+    name = build_folder_based_name(
+        "2026-05-12_Rechnung.pdf",
+        PurePath("Steuer 2026/Banken"),
+        "Steuer 2026/Banken",
+        template="{initialen}-{datum_iso}-{ordnerpfad}-{text}",
+        initials="JK",
+    )
+    assert name == "JK-2026-05-12-Steuer 2026-Banken-Rechnung.pdf"
+
+
+def test_forbidden_characters_removed():
+    name = build_folder_based_name(
+        "2026-05-12_Rechnung: Meier?.pdf",
+        PurePath("JK 069-01-Firmen"),
+        "JK 069-01-Firmen",
+        initials="JK",
+    )
+    assert name == "JK 069-01-20260512-Rechnung Meier.pdf"
+
+
+def test_broken_template_keeps_original_name():
+    name = build_folder_based_name(
+        "2026-05-12_Rechnung.pdf",
+        PurePath("JK 069-01-Firmen"),
+        "JK 069-01-Firmen",
+        template="{unbekannt}-{text}",
+        initials="JK",
+    )
+    assert name == "2026-05-12_Rechnung.pdf"
+
+
+def test_name_without_pdf_extension():
+    name = build_folder_based_name(
+        "2026-05-12_Rechnung",
+        PurePath("JK 069-01-Firmen"),
+        "JK 069-01-Firmen",
+        initials="JK",
+    )
+    assert name == "JK 069-01-20260512-Rechnung.pdf"


### PR DESCRIPTION
## Zusammenfassung
Neue **Opt-in-Einstellung** (Tab "Dateinamen-Muster"): Beim Verschieben wird der Dateiname nach einer frei konfigurierbaren Vorlage aus dem Zielordner-Pfad aufgebaut.

- Default-Vorlage: `{initialen} {ordnernummern}-{datum}-{text}` → z.B. **`JK 069-03-05-20260512-Rechnung.pdf`** (Format aus dem Issue-Kommentar)
- Platzhalter: `{initialen}`, `{ordnernummern}` (Nummernkette aus dem Zielordner-Namen), `{ordnerpfad}`, `{datum}` (JJJJMMTT), `{datum_iso}`, `{text}`
- Einstellung ist persistent (`config.json`), standardmäßig **aus**
- Greift im 3-Spalten-Workflow vor dem Bestätigungsdialog (dort sieht man den neuen Namen); im Move-Only-Modus bewusst nicht

## Umsetzung
- `src/core/folder_naming.py`: reine Namenslogik (Nummernketten-Extraktion, Datums-Erkennung im bisherigen Namen, Sanitisierung, Trenner-Kollaps bei leeren Platzhaltern)
- `main_window._move_rename_and_learn`: Anwendung mit Dokumentdatum als Fallback
- Einstellungs-Dialog: neue Gruppe mit Checkbox, Initialen und Vorlage

## Tests
- 15 neue Unit-Tests (`tests/test_folder_naming.py`), u.a. das exakte Beispiel aus dem Issue
- Gesamte Suite: 443 passed

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)