### PR TITLE
fix(#50): Kachel 'uebergeordneter Ordner' reagiert auf Einfachklick

### DIFF
--- a/src/gui/folder_tile.py
+++ b/src/gui/folder_tile.py
@@ -19,6 +19,7 @@ from PyQt6.QtWidgets import QFrame, QLabel, QVBoxLayout
 class FolderTileWidget(QFrame):
     """Kachel für einen Ordner im Scan-Bereich."""
 
+    clicked = pyqtSignal(Path)  # Einfachklick (nur fuer ".." verbunden, Issue #50)
     double_clicked = pyqtSignal(Path)  # In den Ordner wechseln
     pdf_dropped = pyqtSignal(Path, Path)  # (pdf_path, folder_path)
 
@@ -78,12 +79,16 @@ class FolderTileWidget(QFrame):
         layout.addWidget(self.count_label)
         layout.addStretch()
 
-        tip = (
-            f"Übergeordneter Ordner: {self.folder_path}"
-            if self.is_parent
-            else str(self.folder_path)
-        )
-        self.setToolTip(f"{tip}\nDoppelklick öffnet den Ordner, PDFs hierher ziehen verschiebt sie.")
+        if self.is_parent:
+            self.setToolTip(
+                f"Übergeordneter Ordner: {self.folder_path}\n"
+                "Klick wechselt nach oben, PDFs hierher ziehen verschiebt sie."
+            )
+        else:
+            self.setToolTip(
+                f"{self.folder_path}\n"
+                "Doppelklick öffnet den Ordner, PDFs hierher ziehen verschiebt sie."
+            )
 
     def _count_text(self) -> str:
         if self.is_parent:
@@ -93,6 +98,14 @@ class FolderTileWidget(QFrame):
         return f"{self._pdf_count} {'PDF' if self._pdf_count == 1 else 'PDFs'}"
 
     # --- Maus -----------------------------------------------------------
+
+    def mouseReleaseEvent(self, event):
+        if (
+            event.button() == Qt.MouseButton.LeftButton
+            and self.rect().contains(event.position().toPoint())
+        ):
+            self.clicked.emit(self.folder_path)
+        super().mouseReleaseEvent(event)
 
     def mouseDoubleClickEvent(self, event):
         if event.button() == Qt.MouseButton.LeftButton:

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -2,6 +2,7 @@
 Hauptfenster der PDF Sortier Meister Anwendung
 """
 
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -544,6 +545,9 @@ class MainWindow(QMainWindow):
                 is_parent=is_parent,
             )
             tile.double_clicked.connect(self.on_folder_tile_double_clicked)
+            if is_parent:
+                # Die ".."-Kachel wirkt wie eine Schaltflaeche -> Einfachklick (Issue #50)
+                tile.clicked.connect(self.on_parent_tile_clicked)
             tile.pdf_dropped.connect(self.on_pdf_dropped_on_folder)
             idx = len(self.folder_tiles)
             self.pdf_layout.addWidget(tile, idx // 3, idx % 3)
@@ -2835,6 +2839,20 @@ class MainWindow(QMainWindow):
         # Wenn eine PDF ausgewählt ist, diese verschieben
         if self.selected_pdf:
             self.move_selected_pdf_to_folder(folder_path)
+
+    def on_parent_tile_clicked(self, folder_path: Path):
+        """Einfachklick auf die ".."-Kachel: eine Ebene nach oben (Issue #50).
+
+        Zeitfenster-Guard: Nach dem Wechsel wird das Raster neu aufgebaut und
+        die neue ".."-Kachel liegt an derselben Stelle - der zweite Klick eines
+        Doppelklicks wuerde sonst gleich zwei Ebenen nach oben springen.
+        """
+        now = time.monotonic()
+        last = getattr(self, "_last_parent_tile_click", 0.0)
+        if (now - last) * 1000 < QApplication.doubleClickInterval():
+            return
+        self._last_parent_tile_click = now
+        self.on_folder_tile_double_clicked(folder_path)
 
     def on_folder_tile_double_clicked(self, folder_path: Path):
         """Doppelklick auf eine Ordner-Kachel im Scan-Bereich: hineinwechseln."""

--- a/tests/test_folder_tile_gui.py
+++ b/tests/test_folder_tile_gui.py
@@ -53,6 +53,17 @@ def test_double_click_emits_folder(qtbot, tmp_path):
     assert blocker.args == [tmp_path]
 
 
+def test_single_click_emits_clicked(qtbot, tmp_path):
+    """Issue #50: Einfachklick loest das clicked-Signal aus (fuer die ".."-Kachel)."""
+    from PyQt6.QtCore import Qt
+    tile = FolderTileWidget(tmp_path, is_parent=True)
+    qtbot.addWidget(tile)
+    tile.show()
+    with qtbot.waitSignal(tile.clicked, timeout=1000) as blocker:
+        qtbot.mouseClick(tile, Qt.MouseButton.LeftButton)
+    assert blocker.args == [tmp_path]
+
+
 def test_drop_emits_only_pdfs(qtbot, tmp_path):
     tile = FolderTileWidget(tmp_path)
     qtbot.addWidget(tile)


### PR DESCRIPTION
## Zusammenfassung
Quick-Win aus dem Beta-Feedback von WiddyNCE (#50): Die "übergeordneter Ordner"-Kachel wirkt wie eine Schaltfläche, brauchte aber einen Doppelklick.

- Einfachklick auf die `..`-Kachel wechselt jetzt eine Ebene nach oben
- Normale Ordner-Kacheln behalten den Doppelklick (Explorer-Verhalten, wie am 2026-08-25 entschieden)
- Zeitfenster-Guard (`doubleClickInterval`) verhindert, dass der zweite Klick eines Doppelklicks nach dem Grid-Neuaufbau die neue `..`-Kachel trifft und zwei Ebenen springt
- Tooltip der `..`-Kachel entsprechend angepasst

**Nicht Teil dieses PRs** (bleibt in #50 offen): Layout-Probleme bei 1920×1080 mit 125% Windows-Skalierung, fehlendes horizontales Scrollen, Splashscreen-Dauer.

## Tests
- Neuer GUI-Test `test_single_click_emits_clicked`
- Gesamte Suite: 429 passed

Teil von #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)