### PR TITLE
feat(#51): Tooltips fuer Kern-Workflow + Erste-Schritte-Hinweis

### DIFF
--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -126,6 +126,9 @@ class DetailPanel(QWidget):
 
         self.suggestions_list = QListWidget()
         self.suggestions_list.setMaximumHeight(120)
+        self.suggestions_list.setToolTip(
+            "Vorschlag anklicken, um Namen und Metadaten in die Felder unten zu übernehmen."
+        )
         self.suggestions_list.itemClicked.connect(self._on_suggestion_clicked)
         suggestions_layout.addWidget(self.suggestions_list)
 
@@ -137,6 +140,9 @@ class DetailPanel(QWidget):
 
         self.name_input = QLineEdit()
         self.name_input.setPlaceholderText("Neuen Dateinamen eingeben...")
+        self.name_input.setToolTip(
+            "Neuer Dateiname für die PDF - wird beim Klick auf einen Zielordner übernommen."
+        )
         self.name_input.textChanged.connect(self._update_preview)
         font = QFont()
         font.setPointSize(11)
@@ -182,6 +188,19 @@ class DetailPanel(QWidget):
             ("steuerjahr", "Steuerjahr"),
             ("description", "Zusammenfassung"),
         ]
+        # Kurze Erklärung je Feld (Issue #51) - hilft neuen Nutzern, die
+        # Bedeutung der Metadaten-Felder ohne Nachfragen zu verstehen.
+        field_tooltips = {
+            "subject": "Kategorie des Dokuments (z.B. Rechnung, Vertrag).",
+            "korrespondent": "Absender oder Firma des Dokuments.",
+            "betrag_netto": "Rechnungsbetrag ohne MwSt.",
+            "betrag_brutto": "Rechnungsbetrag inkl. MwSt.",
+            "waehrung": "Währung des Betrags (z.B. EUR).",
+            "mwst_satz": "Mehrwertsteuersatz in Prozent (z.B. 19).",
+            "iban": "IBAN, falls im Dokument vorhanden.",
+            "steuerjahr": "Steuerjahr, dem dieses Dokument zugeordnet wird.",
+            "description": "Kurze Zusammenfassung des Dokumentinhalts.",
+        }
 
         for field_key, field_label in metadata_fields:
             row = QHBoxLayout()
@@ -201,6 +220,9 @@ class DetailPanel(QWidget):
                 input_field = QLineEdit()
                 input_field.setPlaceholderText(f"{field_label}...")
                 input_field.setStyleSheet("font-size: 10px; padding: 2px;")
+            tooltip = field_tooltips.get(field_key)
+            if tooltip:
+                input_field.setToolTip(tooltip)
             row.addWidget(input_field)
 
             if isinstance(input_field, QPlainTextEdit):
@@ -241,6 +263,9 @@ class DetailPanel(QWidget):
         btn_row.addWidget(self.rename_and_save_btn)
 
         self.llm_btn = QPushButton("KI-Metadaten neu generieren")
+        self.llm_btn.setToolTip(
+            "Metadaten und Dateinamen per KI erneut aus dem PDF-Text vorschlagen lassen"
+        )
         self.llm_btn.setStyleSheet(
             "QPushButton { background-color: #7b1fa2; color: white; "
             "padding: 3px 10px; border: none; border-radius: 3px; font-size: 10px; }"
@@ -303,6 +328,7 @@ class DetailPanel(QWidget):
 
         self.search_results_list = QListWidget()
         self.search_results_list.setStyleSheet("font-size: 11px;")
+        self.search_results_list.setToolTip("Doppelklick öffnet das Dokument im Standardprogramm.")
         self.search_results_list.itemDoubleClicked.connect(self._on_search_result_double_clicked)
         search_layout.addWidget(self.search_results_list)
 

--- a/src/gui/folder_tree_widget.py
+++ b/src/gui/folder_tree_widget.py
@@ -76,6 +76,13 @@ class _TreeScanThread(QThread):
 class FolderTreeWidget(QWidget):
     """Widget zur hierarchischen Anzeige von Zielordnern."""
 
+    # Zusatztext fuer die Tooltips einzelner Ordner-Items: erklaert den
+    # Kern-Workflow, der sonst fuer neue Nutzer unsichtbar ist (Issue #51).
+    _CLICK_HINT = (
+        "\n\nEinfachklick: ausgewaehlte PDF hierher verschieben.\n"
+        "Doppelklick: als Scan-Ordner links oeffnen (Navigation)."
+    )
+
     # Signale
     folder_selected = pyqtSignal(Path)  # Ordner wurde ausgewählt
     folder_double_clicked = pyqtSignal(Path)  # Ordner wurde doppelgeklickt
@@ -136,6 +143,11 @@ class FolderTreeWidget(QWidget):
         self.tree.setDragDropMode(QAbstractItemView.DragDropMode.DropOnly)
         self.tree.setAcceptDrops(True)
         self.tree.setDropIndicatorShown(True)
+        self.tree.setToolTip(
+            "Einfachklick auf einen Ordner: ausgewaehlte PDF hierher verschieben.\n"
+            "Doppelklick: Ordner links als Scan-Ordner oeffnen (Navigation).\n"
+            "PDFs koennen auch per Drag & Drop hierher gezogen werden."
+        )
 
         # Styling
         self.tree.setStyleSheet("""
@@ -249,7 +261,7 @@ class FolderTreeWidget(QWidget):
             item = QTreeWidgetItem(self.tree) if parent_item is None else QTreeWidgetItem(parent_item)
             item.setText(0, self._item_text(folder_path, pdf_count))
             item.setData(0, Qt.ItemDataRole.UserRole, str(folder_path))
-            item.setToolTip(0, str(folder_path))
+            item.setToolTip(0, str(folder_path) + self._CLICK_HINT)
             if folder_path in self._suggestion_folders:
                 item.setBackground(0, Qt.GlobalColor.green)
             self._items[folder_path] = item
@@ -273,7 +285,7 @@ class FolderTreeWidget(QWidget):
         item = QTreeWidgetItem(parent_item)
         item.setText(0, self._item_text(folder_path, self._count_pdfs(folder_path)))
         item.setData(0, Qt.ItemDataRole.UserRole, str(folder_path))
-        item.setToolTip(0, str(folder_path))
+        item.setToolTip(0, str(folder_path) + self._CLICK_HINT)
         self._items[folder_path] = item
         parent_item.sortChildren(0, Qt.SortOrder.AscendingOrder)
         return True
@@ -315,7 +327,7 @@ class FolderTreeWidget(QWidget):
 
         item.setText(0, display_text)
         item.setData(0, Qt.ItemDataRole.UserRole, str(folder_path))
-        item.setToolTip(0, str(folder_path))
+        item.setToolTip(0, str(folder_path) + self._CLICK_HINT)
         self._items[folder_path] = item
 
         # Styling für Vorschläge

--- a/src/gui/folder_widget.py
+++ b/src/gui/folder_widget.py
@@ -72,6 +72,10 @@ class FolderWidget(QFrame):
         self.name_label.setText(name)
         self.name_label.setToolTip(str(self.folder_path))
 
+        # Standard-Tooltip für die ganze Kachel (main_window.py setzt bei
+        # Vorschlägen einen ausführlicheren Tooltip, der diesen ersetzt).
+        self.setToolTip(f"{self.folder_path}\nAnklicken verschiebt die ausgewählte PDF hierher.")
+
         layout.addWidget(self.name_label)
 
         # PDF-Anzahl

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -168,6 +168,9 @@ class MainWindow(QMainWindow):
         splitter.setSizes([300, 400, 300])
 
         self.center_tabs.addTab(preview_container, "Vorschau")
+        self.center_tabs.setTabToolTip(
+            0, "3-Spalten-Ansicht: PDF auswählen, Details prüfen, Zielordner anklicken"
+        )
 
         # Tab "Chat": RAG-Chat (Phase 19 / M2)
         self.chat_view = ChatView(
@@ -177,6 +180,7 @@ class MainWindow(QMainWindow):
         )
         self.chat_view.open_pdf_requested.connect(self._open_pdf_external)
         self.center_tabs.addTab(self.chat_view, "Chat")
+        self.center_tabs.setTabToolTip(1, "Fragen zu Ihren sortierten Dokumenten per KI beantworten lassen")
 
         # LLM-Status aktualisieren, wenn der Chat-Tab gewaehlt wird
         self.center_tabs.currentChanged.connect(self._on_center_tab_changed)
@@ -362,6 +366,9 @@ class MainWindow(QMainWindow):
         ft_layout.addWidget(self.folder_container)
 
         self.right_panel_tabs.addTab(folder_tree_container, "Zielordner")
+        self.right_panel_tabs.setTabToolTip(
+            0, "Zielordner-Baum: hier klicken, um die ausgewählte PDF zu verschieben"
+        )
 
         # --- Tab "Korrespondenten" (Phase 20 / Issue #21) ---
         self.korrespondent_sidebar = KorrespondentSidebar(self.db, parent=self)
@@ -369,6 +376,9 @@ class MainWindow(QMainWindow):
             self._on_korrespondent_sidebar_selected
         )
         self.right_panel_tabs.addTab(self.korrespondent_sidebar, "Korrespondenten")
+        self.right_panel_tabs.setTabToolTip(
+            1, "Bekannte Korrespondenten - anklicken filtert die Dokumente danach"
+        )
 
         layout.addWidget(self.right_panel_tabs, stretch=1)
 
@@ -1081,6 +1091,11 @@ class MainWindow(QMainWindow):
         # Hilfe-Menü
         help_menu = menubar.addMenu("Hilfe")
 
+        first_steps_action = QAction("Erste Schritte", self)
+        first_steps_action.setToolTip("Zeigt die Kurzanleitung zum 3-Spalten-Workflow erneut an")
+        first_steps_action.triggered.connect(lambda: self.show_first_steps_hint(force=True))
+        help_menu.addAction(first_steps_action)
+
         about_action = QAction("Über PDF Sortier Meister", self)
         about_action.triggered.connect(self.show_about)
         help_menu.addAction(about_action)
@@ -1531,7 +1546,8 @@ class MainWindow(QMainWindow):
             # Tooltip mit vollständigem Pfad, Begründung und Konfidenz
             tooltip = f"Pfad: {suggestion.relative_path or suggestion.folder_name}\n"
             tooltip += f"{suggestion.reason}\n"
-            tooltip += f"Konfidenz: {int(suggestion.confidence * 100)}%"
+            tooltip += f"Konfidenz: {int(suggestion.confidence * 100)}%\n"
+            tooltip += "Anklicken verschiebt die ausgewählte PDF hierher."
             widget.setToolTip(tooltip)
 
             # Konfidenz im Namen anzeigen
@@ -3066,27 +3082,32 @@ class MainWindow(QMainWindow):
         self.filter_steuerjahr = QComboBox()
         self.filter_steuerjahr.addItem("Alle")
         self.filter_steuerjahr.setMinimumWidth(90)
+        self.filter_steuerjahr.setToolTip("Nur Dokumente aus diesem Steuerjahr anzeigen")
         layout.addWidget(self.filter_steuerjahr, 0, 1)
 
         layout.addWidget(QLabel("Kategorie:"), 0, 2)
         self.filter_kategorie = QComboBox()
         self.filter_kategorie.addItem("Alle")
         self.filter_kategorie.setMinimumWidth(130)
+        self.filter_kategorie.setToolTip("Nur Dokumente dieser Kategorie anzeigen")
         layout.addWidget(self.filter_kategorie, 0, 3)
 
         layout.addWidget(QLabel("Korrespondent:"), 0, 4)
         self.filter_korrespondent = QComboBox()
         self.filter_korrespondent.addItem("Alle")
         self.filter_korrespondent.setMinimumWidth(150)
+        self.filter_korrespondent.setToolTip("Nur Dokumente dieses Korrespondenten anzeigen")
         layout.addWidget(self.filter_korrespondent, 0, 5)
 
         # Reset-Button (Zeile 0–1, letzte Spalte)
         reset_btn = QPushButton("Filter zurücksetzen")
+        reset_btn.setToolTip("Alle Filter dieser Leiste auf 'Alle' zurücksetzen")
         reset_btn.clicked.connect(self._reset_filters)
         layout.addWidget(reset_btn, 0, 6, 2, 1)
 
         # Zeile 1: Datum, Betrag
         self.filter_datum_von_cb = QCheckBox("Datum von:")
+        self.filter_datum_von_cb.setToolTip("Aktivieren, um nur Dokumente ab diesem Datum anzuzeigen")
         layout.addWidget(self.filter_datum_von_cb, 1, 0)
         self.filter_datum_von = QDateEdit()
         self.filter_datum_von.setCalendarPopup(True)
@@ -3095,6 +3116,7 @@ class MainWindow(QMainWindow):
         layout.addWidget(self.filter_datum_von, 1, 1)
 
         self.filter_datum_bis_cb = QCheckBox("Datum bis:")
+        self.filter_datum_bis_cb.setToolTip("Aktivieren, um nur Dokumente bis zu diesem Datum anzuzeigen")
         layout.addWidget(self.filter_datum_bis_cb, 1, 2)
         self.filter_datum_bis = QDateEdit()
         self.filter_datum_bis.setCalendarPopup(True)
@@ -3114,6 +3136,7 @@ class MainWindow(QMainWindow):
         self.filter_betrag_von.setSpecialValueText("ab –")
         self.filter_betrag_von.setValue(0.0)
         self.filter_betrag_von.setMinimumWidth(80)
+        self.filter_betrag_von.setToolTip("Nur Dokumente mit mindestens diesem Betrag anzeigen")
         betrag_layout.addWidget(self.filter_betrag_von)
         self.filter_betrag_bis = QDoubleSpinBox()
         self.filter_betrag_bis.setRange(0, 999999.99)
@@ -3121,6 +3144,7 @@ class MainWindow(QMainWindow):
         self.filter_betrag_bis.setSpecialValueText("bis –")
         self.filter_betrag_bis.setValue(0.0)
         self.filter_betrag_bis.setMinimumWidth(80)
+        self.filter_betrag_bis.setToolTip("Nur Dokumente bis zu diesem Betrag anzeigen")
         betrag_layout.addWidget(self.filter_betrag_bis)
         layout.addWidget(betrag_widget, 1, 5)
 
@@ -3482,6 +3506,34 @@ class MainWindow(QMainWindow):
     def check_backup_status(self):
         """Zeigt den Backup-Hinweis (Menue). Macrium-Log-Parsing: Issue #14."""
         self.show_backup_hint(force=True)
+
+    def show_first_steps_hint(self, force: bool = False):
+        """
+        Erklaert den 3-Spalten-Workflow beim ersten Start (Issue #51).
+        Erscheint vor dem Backup-Hinweis, bis der Nutzer "nicht mehr
+        anzeigen" abhakt; ueber das Hilfe-Menue jederzeit erneut.
+        """
+        if not force and self.config.get("first_steps_hint_dismissed", False):
+            return
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Information)
+        box.setWindowTitle("Erste Schritte")
+        box.setText("So sortieren Sie eine PDF in drei Schritten:")
+        box.setInformativeText(
+            "1. Links: Ein PDF anklicken, um es auszuwaehlen.\n"
+            "2. Mitte: Vorgeschlagenen Namen und Metadaten pruefen und bei "
+            "Bedarf anpassen.\n"
+            "3. Rechts: Auf einen Zielordner klicken - das PDF wird dorthin "
+            "verschoben, umbenannt und die Metadaten werden gespeichert.\n\n"
+            "Doppelklick auf einen Ordner im Baum (rechts) oeffnet ihn nur "
+            "zur Ansicht links, ohne etwas zu verschieben."
+        )
+        dismiss = QCheckBox("Diesen Hinweis nicht mehr anzeigen")
+        dismiss.setChecked(self.config.get("first_steps_hint_dismissed", False))
+        box.setCheckBox(dismiss)
+        box.setStandardButtons(QMessageBox.StandardButton.Ok)
+        box.exec()
+        self.config.set("first_steps_hint_dismissed", dismiss.isChecked())
 
     def show_backup_hint(self, force: bool = False):
         """

--- a/src/gui/pdf_thumbnail.py
+++ b/src/gui/pdf_thumbnail.py
@@ -79,6 +79,11 @@ class PDFThumbnailWidget(QFrame):
         # Hover-Effekt
         self.setMouseTracking(True)
         self._update_style()
+        self.setToolTip(
+            "Anklicken wählt diese PDF aus (Strg/Umschalt für Mehrfachauswahl).\n"
+            "Ziehen verschiebt sie per Drag & Drop in einen Zielordner.\n"
+            "Doppelklick öffnet die PDF im Standardprogramm."
+        )
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 8, 8, 8)

--- a/src/main.py
+++ b/src/main.py
@@ -211,8 +211,15 @@ def main():
                 pass
         window.raise_()
         window.activateWindow()
-        # Backup-Hinweis (Issue #7) erst zeigen, wenn der Splash weg ist
-        QTimer.singleShot(300, window.show_backup_hint)
+
+        def show_startup_hints():
+            # Erste-Schritte-Hinweis (Issue #51) vor dem Backup-Hinweis zeigen,
+            # weil der Workflow wichtiger ist als die Backup-Erinnerung.
+            window.show_first_steps_hint()
+            window.show_backup_hint()
+
+        # Hinweise erst zeigen, wenn der Splash weg ist
+        QTimer.singleShot(300, show_startup_hints)
 
     window.thumbnails_loaded.connect(close_splash)
     QTimer.singleShot(15000, close_splash)

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -79,6 +79,8 @@ class Config:
         },
         # Backup-Hinweis beim Start (Issue #7) abgehakt?
         "backup_hint_dismissed": False,
+        # Erste-Schritte-Hinweis beim Start (Issue #51) abgehakt?
+        "first_steps_hint_dismissed": False,
     }
 
     def __init__(self, config_path: str = None):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,3 +32,8 @@ def test_set_llm_api_key_ollama_not_stored_per_provider(tmp_path):
 def test_backup_hint_default_not_dismissed():
     from src.utils.config import Config
     assert Config.DEFAULTS["backup_hint_dismissed"] is False
+
+
+def test_first_steps_hint_default_not_dismissed():
+    from src.utils.config import Config
+    assert Config.DEFAULTS["first_steps_hint_dismissed"] is False

--- a/tests/test_main_window_gui.py
+++ b/tests/test_main_window_gui.py
@@ -316,3 +316,47 @@ def test_model_wait_cancelled_when_selection_changes(main_window, fresh_singleto
     main_window.selected_pdf = None  # Nutzer hat abgewaehlt
     qtbot.waitUntil(lambda: not main_window._model_wait_active, timeout=2000)
     assert QApplication.overrideCursor() is None
+
+
+# --------------------------------------------------------------------- #
+# 5) Erste-Schritte-Hinweis (Issue #51)
+# --------------------------------------------------------------------- #
+
+
+def test_first_steps_hint_skipped_when_dismissed(main_window, monkeypatch):
+    """Bei gesetztem Config-Flag und ohne force wird kein Dialog gezeigt."""
+    from PyQt6.QtWidgets import QMessageBox
+
+    main_window.config.set("first_steps_hint_dismissed", True)
+    calls = []
+    monkeypatch.setattr(QMessageBox, "exec", lambda self: calls.append(True))
+
+    main_window.show_first_steps_hint()
+
+    assert calls == []
+
+
+def test_first_steps_hint_shown_when_not_dismissed(main_window, monkeypatch):
+    """Ohne gesetztes Flag erscheint der Dialog beim Start."""
+    from PyQt6.QtWidgets import QMessageBox
+
+    main_window.config.set("first_steps_hint_dismissed", False)
+    calls = []
+    monkeypatch.setattr(QMessageBox, "exec", lambda self: calls.append(True))
+
+    main_window.show_first_steps_hint()
+
+    assert calls == [True]
+
+
+def test_first_steps_hint_force_ignores_dismissed_flag(main_window, monkeypatch):
+    """Ueber das Hilfe-Menue (force=True) erscheint der Dialog immer."""
+    from PyQt6.QtWidgets import QMessageBox
+
+    main_window.config.set("first_steps_hint_dismissed", True)
+    calls = []
+    monkeypatch.setattr(QMessageBox, "exec", lambda self: calls.append(True))
+
+    main_window.show_first_steps_hint(force=True)
+
+    assert calls == [True]


### PR DESCRIPTION
## Zusammenfassung
Beta-Feedback von WiddyNCE (#51): "wenn ich die anwendung sehe, habe ich null plan, was ich machen kann oder muss".

### Teil 1: Systematische Tooltips
Alle interaktiven Elemente des Hauptfensters erklären jetzt per Tooltip, was ein Klick bewirkt:
- **Zielordner-Baum + Vorschlags-Kacheln**: der für neue Nutzer unsichtbare Kern-Workflow (Einfachklick = PDF hierher verschieben, Doppelklick = Ordner öffnen) steht jetzt am Baum selbst und an jedem Ordner-Item
- **PDF-Thumbnails**: Klick/Strg-Klick/Drag&Drop/Doppelklick erklärt
- **Detail-Panel**: Namensfeld, Vorschlagsliste, KI-Button und alle 9 Metadaten-Felder (je mit kurzer Erklärung, z.B. "Rechnungsbetrag ohne MwSt.")
- **Filterleiste**: alle Combos, Datums-Checkboxen, Betrags-Spinner, Reset-Button
- **Tabs**: Vorschau/Chat und Zielordner/Korrespondenten

Keine Verhaltensänderungen — nur `setToolTip`/`setTabToolTip`.

### Teil 2: "Erste Schritte"-Hinweis
Der Infotext beim Start reichte laut Tester nicht:
- Einmaliger Dialog nach dem Splash (vor dem Backup-Hinweis), der den 3-Spalten-Workflow in 3 Schritten erklärt, mit "Nicht mehr anzeigen"-Checkbox (Muster von `backup_hint_dismissed`, neues Config-Flag `first_steps_hint_dismissed`)
- Jederzeit wieder aufrufbar über **Hilfe → Erste Schritte**

## Tests
- 4 neue Tests (Config-Default + Skip/Show/Force-Verhalten des Dialogs, `QMessageBox.exec` gepatcht — kein echter Dialog im Testlauf)
- Gesamte Suite: 432 passed

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)