### PR TITLE
feat(#48, #49): Update/Uninstall dokumentiert + stabiler Latest-Download-Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,18 @@ Datenbank-Silo, kein Docker, kein Server.
 
 ## ⚡ Installation
 
-1. **Herunterladen:** 👉 [`PDF_Sortier_Meister_Setup_X.Y.Z.exe`](https://github.com/Josi-create/PDF_Sortier_Meister/releases/latest)
+1. **Herunterladen:** 👉 [`PDF_Sortier_Meister_Setup.exe`](https://github.com/Josi-create/PDF_Sortier_Meister/releases/latest/download/PDF_Sortier_Meister_Setup.exe) — dieser Link zeigt immer auf die **neueste Version**
 2. **Doppelklick** auf die Setup-Datei → Weiter → Fertig
 3. Beim ersten Start führt der Einrichtungs-Assistent durch Scan-Ordner, Zielordner und (optional) KI-Anbieter.
 
 Texterkennung (OCR, Tesseract) ist **enthalten** — Scans ohne Textebene funktionieren ohne weitere Installation.
-Deinstallation wie gewohnt über *Apps & Features*; eine neue Version wird einfach drüberinstalliert.
+
+**Update:** Neue Version einfach über die alte drüberinstallieren (gleicher Link oben) — Einstellungen und
+Lerndaten bleiben dabei erhalten, Reste der Vorversion werden automatisch aufgeräumt.
+
+**Deinstallation:** Wie gewohnt über *Windows-Einstellungen → Apps* (bzw. *Apps & Features*). Einstellungen und
+Lerndaten bleiben dabei absichtlich erhalten (praktisch bei Neuinstallation); wer alles restlos entfernen
+möchte, löscht danach noch den Ordner `%APPDATA%\PDF_Sortier_Meister`.
 
 > 🛡️ **Windows SmartScreen warnt?** *„Weitere Informationen“ → „Trotzdem ausführen“.* Das passiert bei
 > unsignierten Programmen — der Quellcode ist hier öffentlich einsehbar.

--- a/installer.iss
+++ b/installer.iss
@@ -28,7 +28,10 @@ DefaultDirName={autopf}\PDF Sortier Meister
 DefaultGroupName=PDF Sortier Meister
 DisableProgramGroupPage=yes
 OutputDir=dist\installer
-OutputBaseFilename=PDF_Sortier_Meister_Setup_{#MyAppVersion}
+; Fester Dateiname (ohne Version), damit der GitHub-Link
+; releases/latest/download/PDF_Sortier_Meister_Setup.exe immer auf die
+; neueste Version zeigt (Issue #49). Die Version steckt in AppVersion.
+OutputBaseFilename=PDF_Sortier_Meister_Setup
 Compression=lzma2/max
 SolidCompression=yes
 WizardStyle=modern
@@ -38,6 +41,12 @@ ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 UninstallDisplayIcon={app}\{#MyAppExeName}
 SetupIconFile=icon.ico
+
+[InstallDelete]
+; Beim Drueber-Installieren die PyInstaller-Dateien der Vorversion
+; entfernen, damit keine veralteten DLLs/Module zurueckbleiben (Issue #48).
+; Nutzerdaten liegen in %APPDATA%\PDF_Sortier_Meister und bleiben unberuehrt.
+Type: filesandordirs; Name: "{app}\_internal"
 
 [Languages]
 Name: "german"; MessagesFile: "compiler:Languages\German.isl"

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -3,7 +3,9 @@ Baut den Windows-Installer (Inno Setup) aus dist/PDF_Sortier_Meister/.
 
 Liest die Version aus src/main.py (__version__), sucht ISCC.exe und ruft
     ISCC.exe /DMyAppVersion=<version> installer.iss
-auf. Ergebnis: dist/installer/PDF_Sortier_Meister_Setup_<version>.exe
+auf. Ergebnis: dist/installer/PDF_Sortier_Meister_Setup.exe
+(fester Name ohne Version, damit der GitHub-releases/latest-Direktlink
+stabil bleibt, Issue #49; die Version steckt in den Datei-Eigenschaften)
 
 Aufruf (nach build.bat bzw. PyInstaller):
     venv\\Scripts\\python.exe scripts\\build_installer.py
@@ -54,7 +56,7 @@ def main() -> None:
     )
     if result.returncode != 0:
         sys.exit(result.returncode)
-    print(f"\nInstaller: dist\\installer\\PDF_Sortier_Meister_Setup_{version}.exe")
+    print("\nInstaller: dist\\installer\\PDF_Sortier_Meister_Setup.exe")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Zusammenfassung

### #48 — Update / Uninstall
Die gute Nachricht vorweg: Beides funktionierte durch die feste Inno-Setup-`AppId` schon weitgehend — es fehlte Aufräumen und Doku:
- **Neu:** `[InstallDelete]` entfernt beim Drüberinstallieren die `_internal`-Dateien der Vorversion, damit keine veralteten PyInstaller-DLLs/Module liegen bleiben
- **README:** eigener Update-/Deinstallations-Abschnitt: v0.17 einfach über v0.16 installieren (Einstellungen + Lerndaten bleiben erhalten), Deinstallation über *Windows-Einstellungen → Apps*, restloses Entfernen via `%APPDATA%\PDF_Sortier_Meister` löschen

### #49 — Latest-Version-Link
- Installer heißt jetzt fest **`PDF_Sortier_Meister_Setup.exe`** (Version steht in den Datei-Eigenschaften und im Release-Tag)
- Damit funktioniert der permanente Direktlink für Beta-Tester: `https://github.com/Josi-create/PDF_Sortier_Meister/releases/latest/download/PDF_Sortier_Meister_Setup.exe` — im README prominent verlinkt, zeigt immer auf die neueste Version

Closes #48
Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)