### PR TITLE
macOS-Support: Verifikation auf echtem Mac + Fixes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,9 @@
   "permissions": {
     "allow": [
       "Bash(git push origin main)",
-      "Bash(git push origin main:*)"
+      "Bash(git push origin main:*)",
+      "PowerShell(.\\\\venv\\\\Scripts\\\\python.exe -m pytest tests/test_platform_paths.py tests/test_tesseract_locator.py -q 2>&1)",
+      "PowerShell(.\\\\venv\\\\Scripts\\\\python.exe -m pytest -q 2>&1)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,9 @@
       "Bash(git push origin main)",
       "Bash(git push origin main:*)",
       "PowerShell(.\\\\venv\\\\Scripts\\\\python.exe -m pytest tests/test_platform_paths.py tests/test_tesseract_locator.py -q 2>&1)",
-      "PowerShell(.\\\\venv\\\\Scripts\\\\python.exe -m pytest -q 2>&1)"
+      "PowerShell(.\\\\venv\\\\Scripts\\\\python.exe -m pytest -q 2>&1)",
+      "PowerShell(.\\\\venv\\\\Scripts\\\\python.exe -c \"compile\\(open\\('pdf_sortier_meister.spec', encoding='utf-8'\\).read\\(\\), 'spec', 'exec'\\); print\\('Spec-Syntax OK'\\)\")",
+      "PowerShell(.\\\\venv\\\\Scripts\\\\python.exe -c \"compile\\(open\\('scripts/prepare_tesseract_mac.py', encoding='utf-8'\\).read\\(\\), 's', 'exec'\\); print\\('prepare_tesseract_mac OK'\\)\")"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,8 @@
       "PowerShell(.\\\\venv\\\\Scripts\\\\python.exe -m pytest tests/test_platform_paths.py tests/test_tesseract_locator.py -q 2>&1)",
       "PowerShell(.\\\\venv\\\\Scripts\\\\python.exe -m pytest -q 2>&1)",
       "PowerShell(.\\\\venv\\\\Scripts\\\\python.exe -c \"compile\\(open\\('pdf_sortier_meister.spec', encoding='utf-8'\\).read\\(\\), 'spec', 'exec'\\); print\\('Spec-Syntax OK'\\)\")",
-      "PowerShell(.\\\\venv\\\\Scripts\\\\python.exe -c \"compile\\(open\\('scripts/prepare_tesseract_mac.py', encoding='utf-8'\\).read\\(\\), 's', 'exec'\\); print\\('prepare_tesseract_mac OK'\\)\")"
+      "PowerShell(.\\\\venv\\\\Scripts\\\\python.exe -c \"compile\\(open\\('scripts/prepare_tesseract_mac.py', encoding='utf-8'\\).read\\(\\), 's', 'exec'\\); print\\('prepare_tesseract_mac OK'\\)\")",
+      "PowerShell(git push -u origin feat/macos-support)"
     ]
   }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 # Claude-Code-Konfiguration: erzwingt LF, damit Agent-Loader nicht an CRLF scheitert.
 .claude/**/*.md text eol=lf
 .claude/**/*.json text eol=lf
+
+# Shell-Skripte brauchen LF, sonst scheitert bash auf macOS/Linux an CRLF.
+*.sh text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pyinstaller pefile
+          pip install openai anthropic
 
       - name: Tesseract-Laufzeit buendeln
         run: python scripts\prepare_tesseract.py
@@ -97,6 +98,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pyinstaller
+          pip install openai anthropic
 
       - name: Signatur-Zertifikat importieren
         if: env.MACOS_CERTIFICATE_P12 != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,148 @@
+name: Release-Builds
+
+# Baut bei einem Versions-Tag (v*) die Release-Assets fuer Windows und
+# macOS (arm64 + x86_64) und haengt sie an ein Draft-Release. Der
+# bisherige manuelle Release-Flow (release/vX.Y.Z-Branch -> Tag) bleibt -
+# nur der Asset-Bau ist automatisiert.
+#
+# workflow_dispatch baut nur die Artefakte (zum Testen), ohne Release.
+#
+# Benoetigte Secrets fuer signierte macOS-Builds (ohne sie entsteht ein
+# unsignierter Build):
+#   MACOS_CERTIFICATE_P12        base64-kodiertes "Developer ID Application"-.p12
+#   MACOS_CERTIFICATE_PASSWORD   Passwort des .p12
+#   MACOS_CODESIGN_IDENTITY      z.B. "Developer ID Application: Name (TEAMID)"
+#   APPLE_ID / APPLE_TEAM_ID / APPLE_APP_SPECIFIC_PASSWORD   Notarisierung
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Tesseract + Inno Setup installieren
+        run: |
+          choco install tesseract --no-progress -y
+          choco install innosetup --no-progress -y
+
+      - name: Deutsche Tesseract-Sprachdaten nachladen
+        # Chocolatey liefert nur eng/osd; deu aus tessdata_fast (Tag gepinnt).
+        run: |
+          curl -L -o "C:\Program Files\Tesseract-OCR\tessdata\deu.traineddata" `
+            https://github.com/tesseract-ocr/tessdata_fast/raw/4.1.0/deu.traineddata
+
+      - name: Dependencies installieren
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller pefile
+
+      - name: Tesseract-Laufzeit buendeln
+        run: python scripts\prepare_tesseract.py
+
+      - name: PyInstaller-Build
+        run: pyinstaller pdf_sortier_meister.spec --clean --noconfirm
+
+      - name: Installer bauen (Inno Setup)
+        run: python scripts\build_installer.py
+
+      - name: Portables Zip erstellen
+        run: |
+          $version = (Select-String -Path src/main.py -Pattern '^__version__\s*=\s*"([^"]+)"').Matches[0].Groups[1].Value
+          Compress-Archive -Path dist\PDF_Sortier_Meister -DestinationPath "dist\installer\PDF_Sortier_Meister-v$version-win64.zip"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-assets
+          path: |
+            dist/installer/PDF_Sortier_Meister_Setup.exe
+            dist/installer/PDF_Sortier_Meister-v*-win64.zip
+          if-no-files-found: error
+
+  build-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest      # arm64 (Apple Silicon)
+            arch: arm64
+          - os: macos-15-intel    # x86_64 (letztes Intel-Image, bis 08/2027)
+            arch: x86_64
+    runs-on: ${{ matrix.os }}
+    env:
+      MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Tesseract installieren
+        run: brew install tesseract tesseract-lang
+
+      - name: Dependencies installieren
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Signatur-Zertifikat importieren
+        if: env.MACOS_CERTIFICATE_P12 != ''
+        env:
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "$MACOS_CERTIFICATE_P12" | base64 --decode > cert.p12
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -lut 3600 build.keychain
+          security import cert.p12 -k build.keychain \
+            -P "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S "apple-tool:,apple:" \
+            -s -k "$KEYCHAIN_PASSWORD" build.keychain
+          rm cert.p12
+
+      - name: Build (App + DMG, optional signiert/notarisiert)
+        env:
+          MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: ./build.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-${{ matrix.arch }}
+          path: dist/installer/PDF_Sortier_Meister-macos-${{ matrix.arch }}.dmg
+          if-no-files-found: error
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build-windows, build-macos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: assets
+          merge-multiple: true
+
+      - name: Draft-Release mit Assets erstellen
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: assets/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Dependencies installieren
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-qt
+
+      - name: Tests ausfuehren
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,9 @@ data/
 # Local helper scripts
 ollama_vlad.bat
 
-# Gebuendelte Drittanbieter-Binaries (scripts/prepare_tesseract.py)
+# Gebuendelte Drittanbieter-Binaries (scripts/prepare_tesseract*.py)
 vendor/
+
+# macOS-Build-Artefakte (scripts/macos/make_icns.sh)
+icon.icns
+icon.iconset/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Hinzugefuegt
+- **macOS-Unterstuetzung** bei gemeinsamer Codebasis: Der Build erzeugt neben der
+  Windows-Version jetzt auch eine macOS-App (`.app` + DMG, Apple Silicon und Intel).
+  Tesseract-OCR ist wie unter Windows gebuendelt (`scripts/prepare_tesseract_mac.py`),
+  die DMGs werden mit Developer ID signiert und notarisiert. Lokaler Build: `./build.sh`.
+- **GitHub-Actions-CI**: Tests laufen bei jedem PR auf Windows und macOS; ein
+  Versions-Tag baut automatisch alle Release-Assets (Setup.exe, win64-Zip, zwei DMGs)
+  als Draft-Release.
+- Neues Modul `src/utils/platform_paths.py` buendelt alle plattformabhaengigen
+  Basisfunktionen (Datenverzeichnis, Dateien/Ordner oeffnen, Dateimanager-Name).
+  Unter macOS liegen Einstellungen/Lerndaten in `~/Library/Application Support/
+  PDF_Sortier_Meister`; unter Windows unveraendert `%APPDATA%\PDF_Sortier_Meister`.
+- Ollama-Empfehlung kennt Apple Silicon: Unified Memory zaehlt als Grafikspeicher
+  (Metal), RAM-Erkennung via `sysctl`.
+
+### Behoben
+- Doppelklick auf eine PDF haette die App unter macOS zum Absturz gebracht
+  (ungeschuetztes `os.startfile`); oeffnet jetzt plattformuebergreifend den
+  Standard-Viewer.
+
 ## [0.17.0] - 2026-08-27
 
 ### Hinzugefuegt

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # PDF Sortier Meister
 
-**Gescannte PDFs sortieren, umbenennen und wiederfinden — auf dem eigenen Windows-PC, ohne Server, mit lokaler KI.**
+**Gescannte PDFs sortieren, umbenennen und wiederfinden — auf dem eigenen PC (Windows & macOS), ohne Server, mit lokaler KI.**
 
 [![Release](https://img.shields.io/github/v/release/Josi-create/PDF_Sortier_Meister?label=Download&color=brightgreen)](https://github.com/Josi-create/PDF_Sortier_Meister/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/Josi-create/PDF_Sortier_Meister/total)](https://github.com/Josi-create/PDF_Sortier_Meister/releases)
 ![Windows](https://img.shields.io/badge/Windows-10%20%2F%2011-0078D6?logo=windows)
+![macOS](https://img.shields.io/badge/macOS-Apple%20Silicon%20%2B%20Intel-black?logo=apple)
 ![Python](https://img.shields.io/badge/Python-3.10+-blue.svg)
 ![PyQt6](https://img.shields.io/badge/GUI-PyQt6-green.svg)
 [![License](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
@@ -25,6 +26,8 @@ Datenbank-Silo, kein Docker, kein Server.
 
 ## ⚡ Installation
 
+### Windows
+
 1. **Herunterladen:** 👉 [`PDF_Sortier_Meister_Setup.exe`](https://github.com/Josi-create/PDF_Sortier_Meister/releases/latest/download/PDF_Sortier_Meister_Setup.exe) — dieser Link zeigt immer auf die **neueste Version**
 2. **Doppelklick** auf die Setup-Datei → Weiter → Fertig
 3. Beim ersten Start führt der Einrichtungs-Assistent durch Scan-Ordner, Zielordner und (optional) KI-Anbieter.
@@ -43,6 +46,17 @@ möchte, löscht danach noch den Ordner `%APPDATA%\PDF_Sortier_Meister`.
 >
 > 📦 **Lieber ohne Installation?** Auf der [Release-Seite](https://github.com/Josi-create/PDF_Sortier_Meister/releases/latest)
 > liegt auch ein portables ZIP: entpacken, `PDF_Sortier_Meister.exe` starten.
+
+### macOS
+
+1. **Herunterladen** (je nach Chip, siehe * → Über diesen Mac*):
+   - Apple Silicon (M1–M4): 👉 [`PDF_Sortier_Meister-macos-arm64.dmg`](https://github.com/Josi-create/PDF_Sortier_Meister/releases/latest/download/PDF_Sortier_Meister-macos-arm64.dmg)
+   - Intel: 👉 [`PDF_Sortier_Meister-macos-x86_64.dmg`](https://github.com/Josi-create/PDF_Sortier_Meister/releases/latest/download/PDF_Sortier_Meister-macos-x86_64.dmg)
+2. DMG öffnen, **„PDF Sortier Meister" auf „Applications" ziehen**, fertig.
+3. Beim ersten Start führt der Einrichtungs-Assistent durch Scan-Ordner, Zielordner und (optional) KI-Anbieter.
+
+Texterkennung (OCR, Tesseract) ist auch hier **enthalten**. Einstellungen und Lerndaten liegen unter
+`~/Library/Application Support/PDF_Sortier_Meister`.
 
 ---
 
@@ -137,12 +151,19 @@ pip install -r requirements.txt
 python run.py
 ```
 
-- Python 3.10+, Windows 10/11
-- OCR im Quellcode-Betrieb: Tesseract installieren (`winget install UB-Mannheim.TesseractOCR`) — die App
-  findet es in den Standardordnern; in den Builds ist es gebündelt
-- Tests: `python -m pytest tests -q` (428 Tests, pytest-qt)
+- Python 3.10+, Windows 10/11 oder macOS (unter macOS: `source venv/bin/activate` statt `venv\Scripts\activate`)
+- OCR im Quellcode-Betrieb: Tesseract installieren — Windows: `winget install UB-Mannheim.TesseractOCR`,
+  macOS: `brew install tesseract tesseract-lang` — die App findet es in den Standardordnern;
+  in den Builds ist es gebündelt
+- Tests: `python -m pytest tests -q` (450+ Tests, pytest-qt); laufen per GitHub Actions auf Windows und macOS
 - Windows-Build: `build.bat` — PyInstaller (`pdf_sortier_meister.spec`), kopiert Tesseract nach `vendor/`
   und baut mit Inno Setup 6 den Installer (`scripts/build_installer.py`)
+- macOS-Build: `./build.sh` — gleicher PyInstaller-Spec, bündelt Tesseract (`scripts/prepare_tesseract_mac.py`,
+  benötigt Homebrew-Tesseract + Xcode Command Line Tools) und erzeugt `.app` + DMG. Mit gesetzten
+  Umgebungsvariablen `MACOS_CODESIGN_IDENTITY` bzw. `APPLE_ID`/`APPLE_TEAM_ID`/`APPLE_APP_SPECIFIC_PASSWORD`
+  wird signiert und notarisiert (in CI kommen diese aus den Repo-Secrets, siehe `.github/workflows/release.yml`)
+- Release-Builds: ein Tag-Push (`vX.Y.Z`) baut per GitHub Actions alle Assets (Setup.exe, win64-Zip,
+  zwei DMGs) und legt ein Draft-Release an
 
 Architektur und Entscheidungen: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) ·
 Versionshistorie: [CHANGELOG.md](CHANGELOG.md) ·

--- a/build.bat
+++ b/build.bat
@@ -17,6 +17,14 @@ if errorlevel 1 (
     pip install pyinstaller
 )
 
+REM Die LLM-Pakete sind in requirements.txt optional, muessen im Release aber
+REM enthalten sein - sonst fehlt die Cloud-KI (OpenRouter/OpenAI/Claude) im Build.
+python -c "import openai, anthropic" 2>NUL
+if errorlevel 1 (
+    echo LLM-Pakete nicht gefunden. Installiere openai + anthropic...
+    pip install openai anthropic
+)
+
 REM Alte Build-Artefakte loeschen
 echo Loesche alte Build-Dateien...
 if exist "build" rmdir /s /q "build"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# ============================================
+# PDF Sortier Meister - macOS-Build (Pendant zu build.bat)
+#
+# Erstellt dist/"PDF Sortier Meister.app" und ein DMG unter
+# dist/installer/PDF_Sortier_Meister-macos-<arch>.dmg (fester Name,
+# damit der GitHub-releases/latest-Direktlink stabil bleibt, wie #49).
+#
+# Voraussetzungen:
+#   brew install tesseract tesseract-lang
+#   Xcode Command Line Tools (otool, install_name_tool, codesign, sips)
+#
+# Optionale Signierung/Notarisierung ueber Umgebungsvariablen:
+#   MACOS_CODESIGN_IDENTITY  -> App + DMG werden Developer-ID-signiert
+#   APPLE_ID, APPLE_TEAM_ID, APPLE_APP_SPECIFIC_PASSWORD
+#                            -> zusaetzlich notarisiert + gestapelt
+# Ohne diese Variablen entsteht ein unsignierter Build (Testen per
+# Rechtsklick -> Oeffnen).
+# ============================================
+set -euo pipefail
+cd "$(dirname "$0")"
+
+PYTHON="${PYTHON:-python3}"
+APP="dist/PDF Sortier Meister.app"
+ARCH="$(uname -m)"
+DMG="dist/installer/PDF_Sortier_Meister-macos-${ARCH}.dmg"
+
+echo "========================================"
+echo "PDF Sortier Meister - Build (macOS ${ARCH})"
+echo "========================================"
+
+if ! "$PYTHON" -c "import PyInstaller" 2>/dev/null; then
+    echo "PyInstaller nicht gefunden. Installiere..."
+    "$PYTHON" -m pip install pyinstaller
+fi
+
+echo "Loesche alte Build-Dateien..."
+rm -rf build dist
+
+if [ ! -x vendor/tesseract/tesseract ]; then
+    echo "Bereite Tesseract-Laufzeit vor (vendor/tesseract)..."
+    "$PYTHON" scripts/prepare_tesseract_mac.py
+fi
+
+if [ ! -f icon.icns ]; then
+    echo "Erzeuge icon.icns aus icon.png..."
+    scripts/macos/make_icns.sh
+fi
+
+echo
+echo "Starte Build (onedir, .app-Bundle)..."
+"$PYTHON" -m PyInstaller pdf_sortier_meister.spec --clean --noconfirm
+
+if [ ! -d "$APP" ]; then
+    echo "BUILD FEHLGESCHLAGEN - $APP fehlt." >&2
+    exit 1
+fi
+
+if [ -n "${MACOS_CODESIGN_IDENTITY:-}" ]; then
+    scripts/macos/sign_app.sh "$APP" "$MACOS_CODESIGN_IDENTITY"
+    if [ -n "${APPLE_ID:-}" ]; then
+        scripts/macos/notarize.sh "$APP"
+    fi
+else
+    echo "HINWEIS: MACOS_CODESIGN_IDENTITY nicht gesetzt - Build bleibt unsigniert."
+fi
+
+echo
+echo "Erstelle DMG..."
+mkdir -p dist/installer
+STAGING="$(mktemp -d)"
+cp -R "$APP" "$STAGING/"
+ln -s /Applications "$STAGING/Applications"
+hdiutil create -volname "PDF Sortier Meister" -srcfolder "$STAGING" \
+    -format UDZO -ov "$DMG"
+rm -rf "$STAGING"
+
+if [ -n "${MACOS_CODESIGN_IDENTITY:-}" ]; then
+    codesign --force --timestamp -s "$MACOS_CODESIGN_IDENTITY" "$DMG"
+    if [ -n "${APPLE_ID:-}" ]; then
+        scripts/macos/notarize.sh "$DMG"
+    fi
+fi
+
+echo
+echo "========================================"
+echo "BUILD ERFOLGREICH!"
+echo "========================================"
+echo "App: $APP"
+echo "DMG: $DMG"

--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,13 @@ if ! "$PYTHON" -c "import PyInstaller" 2>/dev/null; then
     "$PYTHON" -m pip install pyinstaller
 fi
 
+# Die LLM-Pakete sind in requirements.txt optional, muessen im Release aber
+# enthalten sein - sonst fehlt die Cloud-KI (OpenRouter/OpenAI/Claude) im Build.
+if ! "$PYTHON" -c "import openai, anthropic" 2>/dev/null; then
+    echo "LLM-Pakete nicht gefunden. Installiere openai + anthropic..."
+    "$PYTHON" -m pip install openai anthropic
+fi
+
 echo "Loesche alte Build-Dateien..."
 rm -rf build dist
 

--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Hardened-Runtime-Entitlements fuer die notarisierte App.
+  PyInstaller + PyQt6 brauchen JIT-/unsigned-memory-Ausnahmen und
+  duerfen keine Library-Validation erzwingen (Python laedt .so/.dylib
+  aus dem Bundle nach).
+-->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/pdf_sortier_meister.spec
+++ b/pdf_sortier_meister.spec
@@ -1,25 +1,39 @@
 # -*- mode: python ; coding: utf-8 -*-
 """
-PyInstaller Spec-File fuer PDF Sortier Meister
+PyInstaller Spec-File fuer PDF Sortier Meister (Windows + macOS)
 
-Erstellt eine Windows-Distribution mit:
+Erstellt eine Distribution mit:
 - Alle Dependencies gebuendelt (onedir = schneller Start)
-- Nativer PyInstaller-Splash (erscheint aus dem Bootloader,
+- Windows: nativer PyInstaller-Splash (erscheint aus dem Bootloader,
   bevor Python/PyQt6 geladen werden -> maximal schneller Splash)
-- Icon fuer die Anwendung (falls vorhanden)
+- macOS: .app-Bundle via BUNDLE (Splash() wird von PyInstaller auf
+  macOS nicht unterstuetzt; der Qt-Fallback-Splash aus main.py greift)
+- Icon fuer die Anwendung (falls vorhanden; .ico bzw. .icns)
 
 Ausfuehren mit: pyinstaller pdf_sortier_meister.spec --clean
 """
 
+import re
+import sys
 from pathlib import Path
 
 block_cipher = None
+IS_MAC = sys.platform == "darwin"
 
 # Pfade
 ROOT_DIR = Path(SPECPATH)
 SRC_DIR = ROOT_DIR / "src"
 SPLASH_IMG = ROOT_DIR / "SplashScreen3.png"
-ICON_PATH = ROOT_DIR / "icon.ico"
+# icon.icns wird von scripts/macos/make_icns.sh aus icon.png erzeugt (gitignored)
+ICON_PATH = ROOT_DIR / ("icon.icns" if IS_MAC else "icon.ico")
+
+# Version aus src/main.py lesen (gleiche Technik wie scripts/build_installer.py)
+_version_match = re.search(
+    r'^__version__\s*=\s*"([^"]+)"',
+    (SRC_DIR / "main.py").read_text(encoding="utf-8"),
+    re.MULTILINE,
+)
+APP_VERSION = _version_match.group(1) if _version_match else "0.0.0"
 
 # Daten-Dateien die eingebettet werden sollen
 datas = []
@@ -30,14 +44,16 @@ if SPLASH_IMG.exists():
 if (ROOT_DIR / "icon.png").exists():
     # Fenster-/Taskleisten-Icon zur Laufzeit (app.setWindowIcon)
     datas.append((str(ROOT_DIR / "icon.png"), "."))
-# Gebuendelte Tesseract-Laufzeit (vorher scripts/prepare_tesseract.py ausfuehren).
+# Gebuendelte Tesseract-Laufzeit (vorher scripts/prepare_tesseract.py bzw.
+# scripts/prepare_tesseract_mac.py ausfuehren).
 # Landet in _internal/tesseract/ und wird von find_tesseract() zuerst gefunden.
 TESSERACT_DIR = ROOT_DIR / "vendor" / "tesseract"
-if (TESSERACT_DIR / "tesseract.exe").exists():
+TESS_BIN = TESSERACT_DIR / ("tesseract" if IS_MAC else "tesseract.exe")
+if TESS_BIN.exists():
     datas.append((str(TESSERACT_DIR), "tesseract"))
 else:
     print("HINWEIS: vendor/tesseract fehlt - Build ohne gebuendelte OCR "
-          "(scripts/prepare_tesseract.py ausfuehren).")
+          "(scripts/prepare_tesseract.py bzw. prepare_tesseract_mac.py ausfuehren).")
 
 # Hidden imports fuer PyQt6 und sklearn
 hiddenimports = [
@@ -91,9 +107,11 @@ pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 # So erscheint das Bild innerhalb von Millisekunden nach dem Doppelklick.
 # Die App schliesst den Splash per pyi_splash.close() sobald das Hauptfenster
 # vollstaendig geladen ist.
+# Auf macOS unterstuetzt PyInstaller Splash() nicht - dort greift der
+# Qt-Fallback-Splash in main.py.
 # ---------------------------------------------------------------------------
 splash = None
-if SPLASH_IMG.exists():
+if SPLASH_IMG.exists() and not IS_MAC:
     splash = Splash(
         str(SPLASH_IMG),
         binaries=a.binaries,
@@ -105,12 +123,13 @@ if SPLASH_IMG.exists():
     )
 
 # Icon optional
+# UPX nur unter Windows - auf macOS zerstoert es Mach-O-Codesignaturen.
 exe_kwargs = dict(
     name="PDF_Sortier_Meister",
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
-    upx=True,
+    upx=not IS_MAC,
     upx_exclude=[],
     console=False,              # GUI-Anwendung, keine Konsole
     disable_windowed_traceback=False,
@@ -158,7 +177,24 @@ else:
         a.zipfiles,
         a.datas,
         strip=False,
-        upx=True,
+        upx=not IS_MAC,
         upx_exclude=[],
         name="PDF_Sortier_Meister",
+    )
+
+# macOS: .app-Bundle um den onedir-Ordner. Signierung/Notarisierung passiert
+# post-build (scripts/macos/sign_app.sh), nicht ueber codesign_identity.
+if IS_MAC:
+    app = BUNDLE(
+        coll,
+        name="PDF Sortier Meister.app",
+        icon=str(ICON_PATH) if ICON_PATH.exists() else None,
+        bundle_identifier="de.josi-create.pdf-sortier-meister",
+        version=APP_VERSION,
+        info_plist={
+            "CFBundleName": "PDF Sortier Meister",
+            "CFBundleShortVersionString": APP_VERSION,
+            "NSHighResolutionCapable": True,
+            "LSApplicationCategoryType": "public.app-category.productivity",
+        },
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Intended Audience :: End Users/Desktop",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -49,6 +50,8 @@ dev = [
     "pyinstaller>=6.0.0",
     "black>=23.0.0",
     "ruff>=0.1.0",
+    # Build-Zeit-Abhaengigkeit von scripts/prepare_tesseract.py (DLL-Analyse)
+    "pefile>=2023.2.7; sys_platform == 'win32'",
 ]
 all = [
     "pdf-sortier-meister[llm,dev]",

--- a/scripts/macos/make_icns.sh
+++ b/scripts/macos/make_icns.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Erzeugt icon.icns aus icon.png (fuer das .app-Bundle).
+# Aufruf aus dem Repo-Root: scripts/macos/make_icns.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+if [ ! -f icon.png ]; then
+    echo "icon.png fehlt im Repo-Root" >&2
+    exit 1
+fi
+
+rm -rf icon.iconset
+mkdir icon.iconset
+
+for size in 16 32 128 256 512; do
+    sips -z "$size" "$size" icon.png --out "icon.iconset/icon_${size}x${size}.png" >/dev/null
+    double=$((size * 2))
+    sips -z "$double" "$double" icon.png --out "icon.iconset/icon_${size}x${size}@2x.png" >/dev/null
+done
+
+iconutil -c icns icon.iconset -o icon.icns
+rm -rf icon.iconset
+echo "icon.icns erstellt."

--- a/scripts/macos/notarize.sh
+++ b/scripts/macos/notarize.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Notarisiert eine .app oder .dmg bei Apple und heftet das Ticket an.
+# Benoetigte Umgebungsvariablen:
+#   APPLE_ID, APPLE_TEAM_ID, APPLE_APP_SPECIFIC_PASSWORD
+#
+# Aufruf: scripts/macos/notarize.sh "<pfad/zur/.app-oder-.dmg>"
+set -euo pipefail
+
+TARGET="${1:?Pfad zur .app oder .dmg fehlt}"
+: "${APPLE_ID:?APPLE_ID fehlt}"
+: "${APPLE_TEAM_ID:?APPLE_TEAM_ID fehlt}"
+: "${APPLE_APP_SPECIFIC_PASSWORD:?APPLE_APP_SPECIFIC_PASSWORD fehlt}"
+
+SUBMIT_PATH="$TARGET"
+CLEANUP=""
+if [[ "$TARGET" == *.app ]]; then
+    # .app muss als Zip eingereicht werden; das Ticket wird an die .app geheftet.
+    SUBMIT_PATH="$(mktemp -d)/$(basename "$TARGET").zip"
+    ditto -c -k --keepParent "$TARGET" "$SUBMIT_PATH"
+    CLEANUP="$SUBMIT_PATH"
+fi
+
+echo "Reiche $SUBMIT_PATH zur Notarisierung ein ..."
+xcrun notarytool submit "$SUBMIT_PATH" \
+    --apple-id "$APPLE_ID" \
+    --team-id "$APPLE_TEAM_ID" \
+    --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+    --wait
+
+echo "Staple Ticket an $TARGET ..."
+xcrun stapler staple "$TARGET"
+
+[ -n "$CLEANUP" ] && rm -f "$CLEANUP"
+echo "Notarisierung OK."

--- a/scripts/macos/sign_app.sh
+++ b/scripts/macos/sign_app.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Signiert die .app mit einer Developer-ID-Identitaet (Hardened Runtime).
+# Inside-out: erst alle eingebetteten Mach-O-Dateien, zuletzt das Bundle
+# selbst (signiert dabei die Haupt-Executable mit; kein deprecated --deep).
+#
+# Aufruf: scripts/macos/sign_app.sh "<pfad/zur/.app>" "<identity>"
+# Die Identity ist z.B. "Developer ID Application: Max Mustermann (TEAMID)".
+set -euo pipefail
+
+APP="${1:?Pfad zur .app fehlt}"
+IDENTITY="${2:?Codesign-Identity fehlt}"
+ENTITLEMENTS="$(cd "$(dirname "$0")/../.." && pwd)/packaging/macos/entitlements.plist"
+
+echo "Signiere eingebettete Mach-O-Dateien in $APP ..."
+find "$APP/Contents" -type f ! -path "*/Contents/MacOS/PDF_Sortier_Meister" -print0 |
+    while IFS= read -r -d '' f; do
+        if file -b "$f" | grep -q "Mach-O"; then
+            codesign --force --timestamp --options runtime \
+                --entitlements "$ENTITLEMENTS" -s "$IDENTITY" "$f"
+        fi
+    done
+
+echo "Signiere Bundle (inkl. Haupt-Executable) ..."
+codesign --force --timestamp --options runtime \
+    --entitlements "$ENTITLEMENTS" -s "$IDENTITY" "$APP"
+
+echo "Verifiziere ..."
+codesign --verify --deep --strict --verbose=2 "$APP"
+echo "Signatur OK."

--- a/scripts/prepare_tesseract_mac.py
+++ b/scripts/prepare_tesseract_mac.py
@@ -1,0 +1,180 @@
+"""
+Kopiert eine minimale Tesseract-Laufzeit nach vendor/tesseract/, damit
+PyInstaller sie mit der macOS-App buendelt (siehe pdf_sortier_meister.spec).
+Pendant zu scripts/prepare_tesseract.py (Windows).
+
+Quelle: eine Homebrew-Installation. Voraussetzungen:
+    brew install tesseract tesseract-lang   # deu.traineddata kommt aus tesseract-lang
+    Xcode Command Line Tools                # otool, install_name_tool, codesign
+
+Vorgehen:
+1. tesseract-Binary via Homebrew finden (Symlinks aufloesen).
+2. Alle Nicht-System-dylibs rekursiv ermitteln (otool -L, analog zur
+   pefile-Analyse im Windows-Skript) und flach nach vendor/tesseract/
+   kopieren.
+3. Loadpfade auf @loader_path/<name> umschreiben (install_name_tool),
+   damit das Bundle ohne Homebrew auf dem Zielrechner laeuft.
+4. Jede veraenderte Datei ad-hoc signieren (auf arm64 zwingend; die
+   Developer-ID-Signatur von sign_app.sh ueberschreibt das spaeter).
+5. Sprachdaten deu + eng nach vendor/tesseract/tessdata/.
+6. Selbsttest: das relozierte Binary mit --version ausfuehren.
+
+Aufruf:
+    python3 scripts/prepare_tesseract_mac.py [Pfad-zur-tesseract-Binary]
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TARGET = ROOT / "vendor" / "tesseract"
+LANGUAGES = ("deu", "eng")
+
+# Systempfade, deren Bibliotheken auf jedem Mac vorhanden sind.
+_SYSTEM_PREFIXES = ("/usr/lib/", "/System/")
+
+
+def _run(*cmd: str) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.exit(f"Befehl fehlgeschlagen: {' '.join(cmd)}\n{result.stderr}")
+    return result.stdout
+
+
+def find_source() -> Path:
+    if len(sys.argv) > 1:
+        return Path(sys.argv[1]).resolve()
+    found = shutil.which("tesseract")
+    if found:
+        return Path(found).resolve()
+    for prefix in ("/opt/homebrew", "/usr/local"):
+        candidate = Path(prefix) / "bin" / "tesseract"
+        if candidate.is_file():
+            return candidate.resolve()
+    sys.exit(
+        "Keine Tesseract-Installation gefunden. "
+        "Bitte 'brew install tesseract tesseract-lang' ausfuehren "
+        "oder den Binary-Pfad als Argument angeben."
+    )
+
+
+def linked_libs(binary: Path) -> list[str]:
+    """Nicht-System-Abhaengigkeiten einer Mach-O-Datei laut otool -L."""
+    libs = []
+    for line in _run("otool", "-L", str(binary)).splitlines()[1:]:
+        dep = line.strip().split(" (compatibility")[0].strip()
+        if not dep or dep.startswith(_SYSTEM_PREFIXES):
+            continue
+        libs.append(dep)
+    return libs
+
+
+def resolve_dep(dep: str, referrer: Path) -> Path:
+    """Loest eine otool-Referenz (auch @rpath/@loader_path) in einen echten Pfad auf."""
+    if dep.startswith("@loader_path/"):
+        return (referrer.parent / dep[len("@loader_path/"):]).resolve()
+    if dep.startswith("@rpath/"):
+        name = dep[len("@rpath/"):]
+        # Homebrew-Kegs legen rpath-Referenzen neben den anderen dylibs ab.
+        for base in (referrer.parent, *_homebrew_lib_dirs()):
+            candidate = (base / name).resolve()
+            if candidate.is_file():
+                return candidate
+        sys.exit(f"@rpath-Referenz nicht aufloesbar: {dep} (aus {referrer})")
+    return Path(dep).resolve()
+
+
+def _homebrew_lib_dirs() -> list[Path]:
+    return [p for p in (Path("/opt/homebrew/lib"), Path("/usr/local/lib")) if p.is_dir()]
+
+
+def collect_files(exe: Path) -> dict[str, Path]:
+    """Alle zu buendelnden Dateien: Binary + transitiv alle Nicht-System-dylibs."""
+    needed: dict[str, Path] = {exe.name: exe}
+    todo = [exe]
+    while todo:
+        current = todo.pop()
+        for dep in linked_libs(current):
+            real = resolve_dep(dep, current)
+            if real.name in needed:
+                continue
+            if not real.is_file():
+                sys.exit(f"Abhaengigkeit nicht gefunden: {dep} -> {real}")
+            needed[real.name] = real
+            todo.append(real)
+    return needed
+
+
+def rewrite_load_paths(target_file: Path, bundled_names: set[str]) -> None:
+    """Setzt id und alle gebuendelten Referenzen auf @loader_path/<name>."""
+    if target_file.suffix == ".dylib" or ".dylib" in target_file.name:
+        _run("install_name_tool", "-id", f"@loader_path/{target_file.name}", str(target_file))
+    for dep in linked_libs(target_file):
+        name = Path(dep).name
+        if name in bundled_names and not dep.startswith("@loader_path/"):
+            _run("install_name_tool", "-change", dep, f"@loader_path/{name}", str(target_file))
+
+
+def copy_tessdata(source_exe: Path) -> None:
+    """Kopiert deu/eng-Sprachdaten aus dem Homebrew-Keg."""
+    tessdata_target = TARGET / "tessdata"
+    tessdata_target.mkdir(parents=True, exist_ok=True)
+    # <keg>/bin/tesseract -> <keg>/share/tessdata
+    candidates = [source_exe.parent.parent / "share" / "tessdata"]
+    for prefix in ("/opt/homebrew", "/usr/local"):
+        candidates.append(Path(prefix) / "share" / "tessdata")
+    tessdata_source = next((c for c in candidates if c.is_dir()), None)
+    if tessdata_source is None:
+        sys.exit("Kein tessdata-Verzeichnis gefunden (brew install tesseract).")
+    for lang in LANGUAGES:
+        src = tessdata_source / f"{lang}.traineddata"
+        if not src.is_file():
+            sys.exit(
+                f"{src} fehlt. Fuer deutsche Sprachdaten bitte "
+                "'brew install tesseract-lang' ausfuehren."
+            )
+        shutil.copy2(src, tessdata_target / src.name)
+
+
+def main() -> None:
+    if sys.platform != "darwin":
+        sys.exit("Dieses Skript ist nur fuer macOS gedacht "
+                 "(Windows: scripts/prepare_tesseract.py).")
+
+    source_exe = find_source()
+    print(f"Quelle: {source_exe}")
+
+    if TARGET.exists():
+        shutil.rmtree(TARGET)
+    TARGET.mkdir(parents=True)
+
+    files = collect_files(source_exe)
+    bundled_names = set(files)
+    for name, src in sorted(files.items()):
+        dest = TARGET / name
+        shutil.copy2(src, dest)
+        os.chmod(dest, 0o755)
+        rewrite_load_paths(dest, bundled_names)
+        # Umschreiben invalidiert die Signatur - ad-hoc neu signieren.
+        _run("codesign", "--force", "-s", "-", str(dest))
+        print(f"  {name}")
+
+    copy_tessdata(source_exe)
+
+    # Selbsttest: beweist, dass die Relokation vollstaendig ist.
+    bundled_exe = TARGET / source_exe.name
+    version = subprocess.run(
+        [str(bundled_exe), "--version"], capture_output=True, text=True
+    )
+    if version.returncode != 0:
+        sys.exit(f"Selbsttest fehlgeschlagen:\n{version.stderr}")
+    first_line = (version.stdout or version.stderr).splitlines()[0]
+    print(f"OK: {len(files)} Dateien + tessdata ({', '.join(LANGUAGES)}) "
+          f"nach {TARGET} kopiert ({first_line}).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_tesseract_mac.py
+++ b/scripts/prepare_tesseract_mac.py
@@ -91,31 +91,38 @@ def _homebrew_lib_dirs() -> list[Path]:
     return [p for p in (Path("/opt/homebrew/lib"), Path("/usr/local/lib")) if p.is_dir()]
 
 
-def collect_files(exe: Path) -> dict[str, Path]:
-    """Alle zu buendelnden Dateien: Binary + transitiv alle Nicht-System-dylibs."""
+def collect_files(exe: Path) -> tuple[dict[str, Path], dict[str, str]]:
+    """Alle zu buendelnden Dateien: Binary + transitiv alle Nicht-System-dylibs.
+
+    Liefert zusaetzlich ein Mapping Referenzname -> Bundle-Dateiname, weil
+    Homebrew-Referenzen oft auf Symlinks zeigen (z.B. libgif.dylib), waehrend
+    gebuendelt der aufgeloeste reale Name liegt (libgif.7.2.0.dylib).
+    """
     needed: dict[str, Path] = {exe.name: exe}
+    alias: dict[str, str] = {}
     todo = [exe]
     while todo:
         current = todo.pop()
         for dep in linked_libs(current):
             real = resolve_dep(dep, current)
+            alias[Path(dep).name] = real.name
             if real.name in needed:
                 continue
             if not real.is_file():
                 sys.exit(f"Abhaengigkeit nicht gefunden: {dep} -> {real}")
             needed[real.name] = real
             todo.append(real)
-    return needed
+    return needed, alias
 
 
-def rewrite_load_paths(target_file: Path, bundled_names: set[str]) -> None:
+def rewrite_load_paths(target_file: Path, alias: dict[str, str]) -> None:
     """Setzt id und alle gebuendelten Referenzen auf @loader_path/<name>."""
     if target_file.suffix == ".dylib" or ".dylib" in target_file.name:
         _run("install_name_tool", "-id", f"@loader_path/{target_file.name}", str(target_file))
     for dep in linked_libs(target_file):
-        name = Path(dep).name
-        if name in bundled_names and not dep.startswith("@loader_path/"):
-            _run("install_name_tool", "-change", dep, f"@loader_path/{name}", str(target_file))
+        bundled = alias.get(Path(dep).name)
+        if bundled and not dep.startswith("@loader_path/"):
+            _run("install_name_tool", "-change", dep, f"@loader_path/{bundled}", str(target_file))
 
 
 def copy_tessdata(source_exe: Path) -> None:
@@ -126,14 +133,22 @@ def copy_tessdata(source_exe: Path) -> None:
     candidates = [source_exe.parent.parent / "share" / "tessdata"]
     for prefix in ("/opt/homebrew", "/usr/local"):
         candidates.append(Path(prefix) / "share" / "tessdata")
-    tessdata_source = next((c for c in candidates if c.is_dir()), None)
-    if tessdata_source is None:
+    tessdata_dirs = [c for c in candidates if c.is_dir()]
+    if not tessdata_dirs:
         sys.exit("Kein tessdata-Verzeichnis gefunden (brew install tesseract).")
+    # deu.traineddata liegt im tesseract-lang-Keg, nicht im tesseract-Keg -
+    # daher pro Sprache alle Kandidaten durchsuchen.
     for lang in LANGUAGES:
-        src = tessdata_source / f"{lang}.traineddata"
-        if not src.is_file():
+        src = next(
+            (d / f"{lang}.traineddata" for d in tessdata_dirs
+             if (d / f"{lang}.traineddata").is_file()),
+            None,
+        )
+        if src is None:
             sys.exit(
-                f"{src} fehlt. Fuer deutsche Sprachdaten bitte "
+                f"{lang}.traineddata in keinem tessdata-Verzeichnis gefunden "
+                f"({', '.join(str(d) for d in tessdata_dirs)}). "
+                "Fuer deutsche Sprachdaten bitte "
                 "'brew install tesseract-lang' ausfuehren."
             )
         shutil.copy2(src, tessdata_target / src.name)
@@ -151,16 +166,26 @@ def main() -> None:
         shutil.rmtree(TARGET)
     TARGET.mkdir(parents=True)
 
-    files = collect_files(source_exe)
-    bundled_names = set(files)
+    files, alias = collect_files(source_exe)
     for name, src in sorted(files.items()):
         dest = TARGET / name
         shutil.copy2(src, dest)
         os.chmod(dest, 0o755)
-        rewrite_load_paths(dest, bundled_names)
+        rewrite_load_paths(dest, alias)
         # Umschreiben invalidiert die Signatur - ad-hoc neu signieren.
         _run("codesign", "--force", "-s", "-", str(dest))
         print(f"  {name}")
+
+    # Relokation verifizieren: --version allein reicht nicht, weil auf dem
+    # Build-Rechner die Homebrew-Pfade noch existieren und Fehler kaschieren.
+    leftovers = [
+        f"  {name}: {dep}"
+        for name in sorted(files)
+        for dep in linked_libs(TARGET / name)
+        if not dep.startswith(("@loader_path/",) + _SYSTEM_PREFIXES)
+    ]
+    if leftovers:
+        sys.exit("Nicht relozierte Referenzen:\n" + "\n".join(leftovers))
 
     copy_tessdata(source_exe)
 

--- a/src/core/pdf_analyzer.py
+++ b/src/core/pdf_analyzer.py
@@ -156,7 +156,7 @@ class PDFAnalyzer:
 
             tesseract_cmd = find_tesseract()
             if tesseract_cmd is None:
-                print("Warnung: tesseract.exe nicht gefunden. OCR nicht verfügbar.")
+                print("Warnung: Tesseract nicht gefunden. OCR nicht verfügbar.")
                 return ""
             pytesseract.pytesseract.tesseract_cmd = tesseract_cmd
             # Sprachdaten neben der .exe (gebuendelt oder Standardinstallation)
@@ -193,28 +193,41 @@ class PDFAnalyzer:
             return ""
 
 
-def find_tesseract() -> Optional[str]:
-    """
-    Sucht tesseract.exe in dieser Reihenfolge:
-    1. Mit der App gebuendelt (PyInstaller: <_internal>/tesseract/)
-    2. Standard-Installationsordner (Programme, LocalAppData)
-    3. PATH
-
-    Returns:
-        Voller Pfad zu tesseract.exe oder None
-    """
+def _tesseract_candidates() -> list[Path]:
+    """Moegliche Tesseract-Installationsorte in Prioritaetsreihenfolge."""
+    exe_name = "tesseract.exe" if sys.platform == "win32" else "tesseract"
     candidates = []
     bundle_root = getattr(sys, "_MEIPASS", None)
     if bundle_root:
-        candidates.append(Path(bundle_root) / "tesseract" / "tesseract.exe")
-    for env_var in ("ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"):
-        base = os.environ.get(env_var)
-        if not base:
-            continue
-        candidates.append(Path(base) / "Tesseract-OCR" / "tesseract.exe")
-        if env_var == "LOCALAPPDATA":
-            candidates.append(Path(base) / "Programs" / "Tesseract-OCR" / "tesseract.exe")
-    for candidate in candidates:
+        candidates.append(Path(bundle_root) / "tesseract" / exe_name)
+    if sys.platform == "win32":
+        for env_var in ("ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"):
+            base = os.environ.get(env_var)
+            if not base:
+                continue
+            candidates.append(Path(base) / "Tesseract-OCR" / "tesseract.exe")
+            if env_var == "LOCALAPPDATA":
+                candidates.append(Path(base) / "Programs" / "Tesseract-OCR" / "tesseract.exe")
+    elif sys.platform == "darwin":
+        # Aus dem Finder gestartete Apps haben Homebrew nicht im PATH,
+        # darum die Standardpfade explizit pruefen.
+        candidates.append(Path("/opt/homebrew/bin/tesseract"))
+        candidates.append(Path("/usr/local/bin/tesseract"))
+    return candidates
+
+
+def find_tesseract() -> Optional[str]:
+    """
+    Sucht die Tesseract-Binary in dieser Reihenfolge:
+    1. Mit der App gebuendelt (PyInstaller: <_internal>/tesseract/)
+    2. Standard-Installationsorte (Windows: Programme/LocalAppData,
+       macOS: Homebrew)
+    3. PATH
+
+    Returns:
+        Voller Pfad zur Tesseract-Binary oder None
+    """
+    for candidate in _tesseract_candidates():
         if candidate.is_file():
             return str(candidate)
     return shutil.which("tesseract")

--- a/src/core/pdf_analyzer.py
+++ b/src/core/pdf_analyzer.py
@@ -192,46 +192,6 @@ class PDFAnalyzer:
             print(f"OCR-Fehler: {e}")
             return ""
 
-
-def _tesseract_candidates() -> list[Path]:
-    """Moegliche Tesseract-Installationsorte in Prioritaetsreihenfolge."""
-    exe_name = "tesseract.exe" if sys.platform == "win32" else "tesseract"
-    candidates = []
-    bundle_root = getattr(sys, "_MEIPASS", None)
-    if bundle_root:
-        candidates.append(Path(bundle_root) / "tesseract" / exe_name)
-    if sys.platform == "win32":
-        for env_var in ("ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"):
-            base = os.environ.get(env_var)
-            if not base:
-                continue
-            candidates.append(Path(base) / "Tesseract-OCR" / "tesseract.exe")
-            if env_var == "LOCALAPPDATA":
-                candidates.append(Path(base) / "Programs" / "Tesseract-OCR" / "tesseract.exe")
-    elif sys.platform == "darwin":
-        # Aus dem Finder gestartete Apps haben Homebrew nicht im PATH,
-        # darum die Standardpfade explizit pruefen.
-        candidates.append(Path("/opt/homebrew/bin/tesseract"))
-        candidates.append(Path("/usr/local/bin/tesseract"))
-    return candidates
-
-
-def find_tesseract() -> Optional[str]:
-    """
-    Sucht die Tesseract-Binary in dieser Reihenfolge:
-    1. Mit der App gebuendelt (PyInstaller: <_internal>/tesseract/)
-    2. Standard-Installationsorte (Windows: Programme/LocalAppData,
-       macOS: Homebrew)
-    3. PATH
-
-    Returns:
-        Voller Pfad zur Tesseract-Binary oder None
-    """
-    for candidate in _tesseract_candidates():
-        if candidate.is_file():
-            return str(candidate)
-    return shutil.which("tesseract")
-
     def get_metadata(self) -> dict:
         """
         Extrahiert Metadaten aus dem PDF.
@@ -420,6 +380,47 @@ def find_tesseract() -> Optional[str]:
                     return company
 
         return None
+
+
+
+def _tesseract_candidates() -> list[Path]:
+    """Moegliche Tesseract-Installationsorte in Prioritaetsreihenfolge."""
+    exe_name = "tesseract.exe" if sys.platform == "win32" else "tesseract"
+    candidates = []
+    bundle_root = getattr(sys, "_MEIPASS", None)
+    if bundle_root:
+        candidates.append(Path(bundle_root) / "tesseract" / exe_name)
+    if sys.platform == "win32":
+        for env_var in ("ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"):
+            base = os.environ.get(env_var)
+            if not base:
+                continue
+            candidates.append(Path(base) / "Tesseract-OCR" / "tesseract.exe")
+            if env_var == "LOCALAPPDATA":
+                candidates.append(Path(base) / "Programs" / "Tesseract-OCR" / "tesseract.exe")
+    elif sys.platform == "darwin":
+        # Aus dem Finder gestartete Apps haben Homebrew nicht im PATH,
+        # darum die Standardpfade explizit pruefen.
+        candidates.append(Path("/opt/homebrew/bin/tesseract"))
+        candidates.append(Path("/usr/local/bin/tesseract"))
+    return candidates
+
+
+def find_tesseract() -> Optional[str]:
+    """
+    Sucht die Tesseract-Binary in dieser Reihenfolge:
+    1. Mit der App gebuendelt (PyInstaller: <_internal>/tesseract/)
+    2. Standard-Installationsorte (Windows: Programme/LocalAppData,
+       macOS: Homebrew)
+    3. PATH
+
+    Returns:
+        Voller Pfad zur Tesseract-Binary oder None
+    """
+    for candidate in _tesseract_candidates():
+        if candidate.is_file():
+            return str(candidate)
+    return shutil.which("tesseract")
 
 
 class PDFThumbnailCache:

--- a/src/core/pdf_cache.py
+++ b/src/core/pdf_cache.py
@@ -132,7 +132,8 @@ class PDFAnalysisWorker(QThread):
                         self._current_pdf = None
 
             except Exception:
-                pass  # Worker soll nicht abstürzen
+                # Worker soll nicht abstürzen, aber Fehler nicht verschlucken
+                logger.exception("PDFAnalysisWorker: unerwarteter Fehler")
 
 
 class LLMSuggestionWorker(QThread):
@@ -234,7 +235,8 @@ class LLMSuggestionWorker(QThread):
                         self._current_pdf = None
 
             except Exception:
-                pass  # Worker soll nicht abstürzen
+                # Worker soll nicht abstürzen, aber Fehler nicht verschlucken
+                logger.exception("LLMSuggestionWorker: unerwarteter Fehler")
 
 
 class PDFCache(QObject):
@@ -689,6 +691,7 @@ class PDFCache(QObject):
 
     def _on_analysis_error(self, pdf_path: Path, error: str):
         """Wird aufgerufen wenn eine Analyse fehlschlägt."""
+        logger.warning(f"PDF-Analyse fehlgeschlagen für {pdf_path.name}: {error}")
         with self._lock:
             # Callbacks mit leerem Ergebnis aufrufen
             callbacks = self._pending_callbacks.pop(pdf_path, [])

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -501,10 +501,10 @@ class DetailPanel(QWidget):
         file_path = item.data(Qt.ItemDataRole.UserRole)
         if file_path:
             try:
-                import os
+                from src.utils.platform_paths import open_with_default_app
                 path = Path(file_path)
                 if path.exists():
-                    os.startfile(str(path))
+                    open_with_default_app(path)
                 else:
                     from PyQt6.QtWidgets import QMessageBox
                     QMessageBox.warning(

--- a/src/gui/folder_tree_widget.py
+++ b/src/gui/folder_tree_widget.py
@@ -438,8 +438,9 @@ class FolderTreeWidget(QWidget):
         goto_action = menu.addAction("📁 Ordner links öffnen")
         goto_action.triggered.connect(lambda: self.folder_double_clicked.emit(folder_path))
 
-        # Im Explorer öffnen
-        open_action = menu.addAction("📂 Im Windows-Explorer öffnen")
+        # Im Dateimanager öffnen
+        from src.utils.platform_paths import file_manager_name
+        open_action = menu.addAction(f"📂 Im {file_manager_name()} öffnen")
         open_action.triggered.connect(lambda: self._open_in_explorer(folder_path))
 
         menu.addSeparator()
@@ -458,17 +459,10 @@ class FolderTreeWidget(QWidget):
         menu.exec(self.tree.mapToGlobal(position))
 
     def _open_in_explorer(self, folder_path: Path):
-        """Öffnet den Ordner im Explorer."""
-        import os
-        import subprocess
-        import sys
+        """Öffnet den Ordner im Dateimanager des Systems."""
+        from src.utils.platform_paths import open_with_default_app
 
-        if sys.platform == 'win32':
-            os.startfile(str(folder_path))
-        elif sys.platform == 'darwin':
-            subprocess.run(['open', str(folder_path)])
-        else:
-            subprocess.run(['xdg-open', str(folder_path)])
+        open_with_default_app(folder_path)
 
     def _create_subfolder(self, parent_folder: Path):
         """Erstellt einen neuen Unterordner."""

--- a/src/gui/folder_widget.py
+++ b/src/gui/folder_widget.py
@@ -152,8 +152,9 @@ class FolderWidget(QFrame):
         """Zeigt das Kontextmenü an."""
         menu = QMenu(self)
 
-        # Im Explorer öffnen
-        open_action = menu.addAction("Im Explorer öffnen")
+        # Im Dateimanager öffnen
+        from src.utils.platform_paths import file_manager_name
+        open_action = menu.addAction(f"Im {file_manager_name()} öffnen")
         open_action.triggered.connect(lambda: self._open_in_explorer())
 
         menu.addSeparator()
@@ -165,17 +166,10 @@ class FolderWidget(QFrame):
         menu.exec(event.globalPos())
 
     def _open_in_explorer(self):
-        """Öffnet den Ordner im Explorer."""
-        import os
-        import subprocess
-        import sys
+        """Öffnet den Ordner im Dateimanager des Systems."""
+        from src.utils.platform_paths import open_with_default_app
 
-        if sys.platform == 'win32':
-            os.startfile(str(self.folder_path))
-        elif sys.platform == 'darwin':
-            subprocess.run(['open', str(self.folder_path)])
-        else:
-            subprocess.run(['xdg-open', str(self.folder_path)])
+        open_with_default_app(self.folder_path)
 
     # Drag & Drop Unterstützung
     def dragEnterEvent(self, event: QDragEnterEvent):

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -666,13 +666,13 @@ class MainWindow(QMainWindow):
             return
         parts = []
         if analyzed < total:
-            parts.append(f"Analyse: {analyzed}/{total}")
+            parts.append(f"Durchsuche PDFs… {analyzed}/{total}")
         llm_active = (
             self.hybrid_classifier.is_llm_available()
             and self.config.get("llm_precache_enabled", True)
         )
         if llm_active and llm_done < total:
-            parts.append(f"KI-Vorschläge: {llm_done}/{total}")
+            parts.append(f"KI verschlagwortet Ihre PDFs… {llm_done}/{total} abgeschlossen")
         if self._last_llm_error:
             parts.append("⚠ Fehler")
         self.cache_status_label.setText(" | ".join(parts))

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1060,7 +1060,7 @@ class MainWindow(QMainWindow):
 
         up_action = QAction("Übergeordneter Ordner", self)
         up_action.setShortcut("Alt+Up")
-        up_action.setToolTip("Ein Verzeichnis nach oben (wie im Windows-Explorer)")
+        up_action.setToolTip("Ein Verzeichnis nach oben (wie im Dateimanager)")
         up_action.triggered.connect(self.on_navigate_up)
         view_menu.addAction(up_action)
 
@@ -1952,8 +1952,7 @@ class MainWindow(QMainWindow):
     def on_pdf_double_clicked(self, pdf_path: Path):
         """Wird aufgerufen wenn eine PDF doppelgeklickt wird."""
         # PDF mit Standardprogramm öffnen
-        import os
-        os.startfile(str(pdf_path))
+        self._open_pdf_external(str(pdf_path))
 
     def _write_pdf_metadata(
         self,

--- a/src/gui/pdf_thumbnail.py
+++ b/src/gui/pdf_thumbnail.py
@@ -259,16 +259,9 @@ class PDFThumbnailWidget(QFrame):
 
     def _open_pdf(self):
         """Öffnet die PDF mit dem Standardprogramm."""
-        import os
-        import subprocess
-        import sys
+        from src.utils.platform_paths import open_with_default_app
 
-        if sys.platform == 'win32':
-            os.startfile(str(self.pdf_path))
-        elif sys.platform == 'darwin':
-            subprocess.run(['open', str(self.pdf_path)])
-        else:
-            subprocess.run(['xdg-open', str(self.pdf_path)])
+        open_with_default_app(self.pdf_path)
 
     def cleanup(self):
         """Bereinigt Ressourcen."""

--- a/src/ml/ollama_launcher.py
+++ b/src/ml/ollama_launcher.py
@@ -34,9 +34,17 @@ _WINDOWS_RELATIVE_PATHS = [
     "Programs/Ollama/ollama.exe",
 ]
 
+# Standard-Installationsorte unter macOS (Ollama.app bzw. Homebrew).
+# Aus dem Finder gestartete Apps haben Homebrew nicht im PATH.
+_MACOS_PATHS = [
+    "/Applications/Ollama.app/Contents/Resources/ollama",
+    "/opt/homebrew/bin/ollama",
+    "/usr/local/bin/ollama",
+]
+
 
 def find_ollama_executable() -> Optional[str]:
-    """Liefert den Pfad zur ollama.exe oder None, wenn nicht gefunden."""
+    """Liefert den Pfad zur Ollama-Binary oder None, wenn nicht gefunden."""
     if sys.platform == "win32":
         local_appdata = os.environ.get("LOCALAPPDATA", "")
         if local_appdata:
@@ -44,6 +52,10 @@ def find_ollama_executable() -> Optional[str]:
                 p = Path(local_appdata) / rel
                 if p.exists():
                     return str(p)
+    elif sys.platform == "darwin":
+        for candidate in _MACOS_PATHS:
+            if Path(candidate).exists():
+                return candidate
 
     # Fallback: ollama im PATH
     found = shutil.which("ollama")
@@ -162,7 +174,7 @@ def _start_server_process(exe_path: str) -> bool:
             )
         return True
     except OSError as e:
-        logger.warning(f"Konnte ollama.exe nicht starten: {e}")
+        logger.warning(f"Konnte Ollama nicht starten: {e}")
         return False
 
 
@@ -185,12 +197,12 @@ def ensure_running(base_url: str, max_wait: float = 10.0) -> tuple[bool, str]:
     exe = find_ollama_executable()
     if not exe:
         return False, (
-            "ollama.exe wurde nicht gefunden. Bitte Ollama installieren "
+            "Ollama wurde nicht gefunden. Bitte Ollama installieren "
             "(https://ollama.com) oder das Programm in den PATH legen."
         )
 
     if not _start_server_process(exe):
-        return False, f"ollama.exe ({exe}) konnte nicht gestartet werden."
+        return False, f"Ollama ({exe}) konnte nicht gestartet werden."
 
     logger.info(f"Ollama-Server gestartet: {exe}")
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -5,10 +5,11 @@ Konfigurationsverwaltung für PDF Sortier Meister
 import copy
 import json
 import logging
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from src.utils.platform_paths import get_app_data_dir
 
 logger = logging.getLogger("pdf_sortier_meister.config")
 
@@ -97,9 +98,7 @@ class Config:
                         Standard: AppData/PDF_Sortier_Meister/config.json
         """
         if config_path is None:
-            app_data = os.environ.get("APPDATA", os.path.expanduser("~"))
-            config_dir = Path(app_data) / "PDF_Sortier_Meister"
-            config_dir.mkdir(parents=True, exist_ok=True)
+            config_dir = get_app_data_dir()
             self.config_path = config_dir / "config.json"
         else:
             self.config_path = Path(config_path)

--- a/src/utils/explorer_integration.py
+++ b/src/utils/explorer_integration.py
@@ -18,9 +18,10 @@ Stellt zwei Mechanismen bereit:
 from __future__ import annotations
 
 import logging
-import os
 import sys
 from pathlib import Path
+
+from src.utils.platform_paths import get_app_data_dir
 
 logger = logging.getLogger("pdf_sortier_meister.explorer_integration")
 
@@ -32,10 +33,7 @@ CONTEXT_MENU_LABEL = "PDF Sortier Meister von hier oeffnen"
 
 def _app_data_dir() -> Path:
     """Liefert das Datenverzeichnis (gleich wie Config.data_dir)."""
-    app_data = os.environ.get("APPDATA", os.path.expanduser("~"))
-    path = Path(app_data) / "PDF_Sortier_Meister"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    return get_app_data_dir()
 
 
 def _launcher_cmd_path() -> Path:
@@ -73,15 +71,17 @@ def _current_launch_command() -> str:
     return f'"{python_exe}" "{run_script}"'
 
 
-def update_launcher_script() -> Path:
+def update_launcher_script() -> Path | None:
     """
     Schreibt/aktualisiert das Trampolin-Skript launcher.cmd mit dem
     AKTUELLEN Startbefehl. Wird bei jedem Programmstart aufgerufen, damit
     der Registry-Eintrag immer korrekt auflaeuft.
 
     Returns:
-        Den Pfad der geschriebenen cmd-Datei.
+        Den Pfad der geschriebenen cmd-Datei, None auf Nicht-Windows.
     """
+    if sys.platform != "win32":
+        return None
     cmd_path = _launcher_cmd_path()
     launch_cmd = _current_launch_command()
 

--- a/src/utils/hardware.py
+++ b/src/utils/hardware.py
@@ -14,6 +14,10 @@ Quellen (Windows):
 Integrierte GPUs (Intel UHD/Iris, AMD Radeon Graphics in APUs) melden zwar
 einen Speicherwert, teilen sich aber den Arbeitsspeicher - fuer Ollama zaehlt
 das nicht als Grafikspeicher.
+
+macOS: ``sysctl hw.memsize`` liefert den Arbeitsspeicher; auf Apple Silicon
+zaehlt der gemeinsame Speicher (Unified Memory) als Grafikspeicher, weil
+Ollama ihn ueber Metal direkt nutzt.
 """
 
 from __future__ import annotations
@@ -197,8 +201,24 @@ def detect_gpus() -> list[GpuInfo]:
     return gpus
 
 
+def is_apple_silicon() -> bool:
+    """True auf Macs mit Apple-Silicon-Chip (M1 und neuer)."""
+    import platform
+
+    return sys.platform == "darwin" and platform.machine() == "arm64"
+
+
 def total_ram_mb() -> int:
     """Physischer Arbeitsspeicher in MB (0, wenn nicht ermittelbar)."""
+    if sys.platform == "darwin":
+        try:
+            result = subprocess.run(
+                ["sysctl", "-n", "hw.memsize"],
+                capture_output=True, text=True, timeout=5,
+            )
+            return int(result.stdout.strip()) // (1024 * 1024)
+        except (OSError, subprocess.SubprocessError, ValueError):
+            return 0
     if sys.platform != "win32":
         return 0
 
@@ -238,8 +258,29 @@ def recommend(gpus: list[GpuInfo], ram_mb: int = 0) -> OllamaRecommendation:
       lokal nicht empfohlen -> Ollama Cloud
     - dedizierte Karte mit weniger als 4 GB: ebenfalls Cloud
     - Intel Arc: von Ollama unter Windows nicht unterstuetzt -> Cloud
+    - Apple Silicon: Unified Memory zaehlt als Grafikspeicher (Metal);
+      Ollama kann davon etwa zwei Drittel nutzen
     - sonst: groesstes Gemma-3-Modell, das in den Grafikspeicher passt
     """
+    if is_apple_silicon():
+        # Kein dediziertes VRAM, aber die GPU nutzt den gemeinsamen
+        # Speicher direkt - Ollama laeuft lokal ueber Metal.
+        usable_mb = (ram_mb * 2) // 3
+        gpu = GpuInfo("Apple Silicon (Unified Memory)", usable_mb, True, "apple")
+        for min_mb, model, size_gb in MODEL_TIERS:
+            if usable_mb >= min_mb:
+                reason = (
+                    f"Apple Silicon mit {_gb(ram_mb)} gemeinsamem Speicher erkannt - "
+                    f"empfohlenes Modell: {model} (Download ca. {size_gb:.0f} GB)."
+                )
+                return OllamaRecommendation(True, model, size_gb, reason, gpu)
+        return OllamaRecommendation(
+            False, None, 0.0,
+            f"Apple Silicon erkannt, aber mit {_gb(ram_mb)} Arbeitsspeicher zu wenig "
+            f"fuer ein brauchbares lokales Modell.",
+            gpu,
+        )
+
     dedicated = [g for g in gpus if g.dedicated]
     best = max(dedicated, key=lambda g: g.vram_mb) if dedicated else None
 

--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -6,11 +6,12 @@ Logs werden sowohl in die Konsole als auch in eine Datei geschrieben.
 """
 
 import logging
-import os
 import sys
 from datetime import datetime
 from pathlib import Path
 from logging.handlers import RotatingFileHandler
+
+from src.utils.platform_paths import get_app_data_dir
 
 
 # Globale Logger-Instanz
@@ -19,8 +20,7 @@ _logger: logging.Logger | None = None
 
 def get_log_directory() -> Path:
     """Gibt das Log-Verzeichnis zurück (im AppData-Ordner)."""
-    app_data = os.environ.get("APPDATA", os.path.expanduser("~"))
-    log_dir = Path(app_data) / "PDF_Sortier_Meister" / "logs"
+    log_dir = get_app_data_dir() / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     return log_dir
 

--- a/src/utils/platform_paths.py
+++ b/src/utils/platform_paths.py
@@ -1,0 +1,60 @@
+"""
+Zentrale Plattform-Abstraktion fuer Pfade und Shell-Integration.
+
+Alle plattformabhaengigen Basisfunktionen (Datenverzeichnis, Datei/Ordner
+mit der Standard-Anwendung oeffnen, Name des Dateimanagers) liegen hier,
+damit der Rest der Codebasis ohne verstreute sys.platform-Abfragen
+auskommt. sys.platform wird bewusst erst zur Aufrufzeit gelesen, damit
+Tests die Plattform per monkeypatch simulieren koennen.
+
+Windows-Verhalten ist byte-identisch zum bisherigen Code: Das
+Datenverzeichnis bleibt %APPDATA%\\PDF_Sortier_Meister (Fallback: ~).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+APP_DIR_NAME = "PDF_Sortier_Meister"
+
+
+def get_app_data_dir(create: bool = True) -> Path:
+    """
+    Liefert das Datenverzeichnis der Anwendung (Config, Datenbanken, Logs).
+
+    - Windows: %APPDATA%\\PDF_Sortier_Meister (Fallback: ~\\PDF_Sortier_Meister)
+    - macOS:   ~/Library/Application Support/PDF_Sortier_Meister
+    - sonst:   $XDG_DATA_HOME/PDF_Sortier_Meister (Fallback: ~/.local/share/...)
+    """
+    if sys.platform == "win32":
+        base = Path(os.environ.get("APPDATA", os.path.expanduser("~")))
+    elif sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support"
+    else:
+        base = Path(os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share")))
+    path = base / APP_DIR_NAME
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def open_with_default_app(path: Path | str) -> None:
+    """Oeffnet eine Datei oder einen Ordner mit der Standard-Anwendung des Systems."""
+    if sys.platform == "win32":
+        os.startfile(str(path))  # noqa: S606 - gewollter Shell-Aufruf
+    elif sys.platform == "darwin":
+        subprocess.run(["open", str(path)])
+    else:
+        subprocess.run(["xdg-open", str(path)])
+
+
+def file_manager_name() -> str:
+    """Name des System-Dateimanagers fuer UI-Texte."""
+    if sys.platform == "win32":
+        return "Explorer"
+    if sys.platform == "darwin":
+        return "Finder"
+    return "Dateimanager"

--- a/tests/test_pdf_analyzer_methods.py
+++ b/tests/test_pdf_analyzer_methods.py
@@ -1,0 +1,34 @@
+"""Issue #59: Analyse-Methoden waren versehentlich in find_tesseract()
+verschachtelt statt Methoden von PDFAnalyzer - jede Hintergrund-Analyse
+schlug mit AttributeError fehl."""
+import fitz
+
+from src.core.pdf_analyzer import PDFAnalyzer
+
+
+def _pdf(path, text):
+    d = fitz.open(); p = d.new_page(); p.insert_text((72, 72), text); d.save(str(path)); d.close()
+
+
+def test_analyse_methoden_sind_klassenmethoden():
+    for name in ("get_metadata", "extract_dates", "extract_keywords",
+                 "suggest_filename", "_extract_company_name"):
+        assert callable(getattr(PDFAnalyzer, name, None)), (
+            f"PDFAnalyzer.{name} fehlt (Issue #59: in find_tesseract() verschachtelt?)"
+        )
+
+
+def test_analyse_pipeline_liefert_ergebnisse(tmp_path):
+    pdf = tmp_path / "rechnung.pdf"
+    _pdf(pdf, "Rechnung Nr. 42 vom 15.03.2026 ueber 100 Euro, zahlbar sofort.")
+
+    with PDFAnalyzer(pdf) as analyzer:
+        text = analyzer.extract_text(use_ocr=False)
+        keywords = analyzer.extract_keywords()
+        dates = analyzer.extract_dates()
+        metadata = analyzer.get_metadata()
+
+    assert "Rechnung" in text
+    assert "rechnung" in keywords
+    assert dates, "15.03.2026 sollte als Datum erkannt werden"
+    assert metadata["page_count"] == 1

--- a/tests/test_platform_paths.py
+++ b/tests/test_platform_paths.py
@@ -1,0 +1,61 @@
+"""Tests fuer die Plattform-Abstraktion (Datenverzeichnis, Dateimanager-Name).
+
+Wichtigster Test: Der Windows-Pfad ist byte-identisch zum bisherigen
+Inline-Ausdruck ``%APPDATA%\\PDF_Sortier_Meister`` - Bestandsnutzer duerfen
+ihr Datenverzeichnis nicht verlieren.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.utils.platform_paths import file_manager_name, get_app_data_dir
+
+
+def test_windows_path_matches_legacy_expression(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("APPDATA", str(tmp_path / "AppData" / "Roaming"))
+
+    legacy = Path(os.environ.get("APPDATA", os.path.expanduser("~"))) / "PDF_Sortier_Meister"
+    assert get_app_data_dir(create=False) == legacy
+
+
+def test_windows_fallback_home_without_appdata(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delenv("APPDATA", raising=False)
+
+    expected = Path(os.path.expanduser("~")) / "PDF_Sortier_Meister"
+    assert get_app_data_dir(create=False) == expected
+
+
+def test_darwin_path_is_application_support(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    expected = Path.home() / "Library" / "Application Support" / "PDF_Sortier_Meister"
+    assert get_app_data_dir(create=False) == expected
+
+
+def test_linux_respects_xdg_data_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+
+    assert get_app_data_dir(create=False) == tmp_path / "xdg" / "PDF_Sortier_Meister"
+
+
+def test_create_flag_creates_directory(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    path = get_app_data_dir()
+    assert path.is_dir()
+
+
+@pytest.mark.parametrize(
+    "platform, expected",
+    [("win32", "Explorer"), ("darwin", "Finder"), ("linux", "Dateimanager")],
+)
+def test_file_manager_name(monkeypatch, platform, expected):
+    monkeypatch.setattr(sys, "platform", platform)
+    assert file_manager_name() == expected

--- a/tests/test_tesseract_locator.py
+++ b/tests/test_tesseract_locator.py
@@ -4,12 +4,14 @@ import sys
 
 import pytest
 
-from src.core.pdf_analyzer import find_tesseract
+from src.core.pdf_analyzer import _tesseract_candidates, find_tesseract
 
 
 @pytest.fixture
 def isolated_env(tmp_path, monkeypatch):
-    """Keine echte Tesseract-Installation darf durchschlagen."""
+    """Keine echte Tesseract-Installation darf durchschlagen (win32-Sicht)."""
+    # Plattform pinnen, damit die Tests auch auf macOS/Linux-Runnern laufen.
+    monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.delattr(sys, "_MEIPASS", raising=False)
     for var in ("ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"):
         monkeypatch.setenv(var, str(tmp_path / var.replace("(", "").replace(")", "")))
@@ -52,3 +54,35 @@ def test_path_fallback(isolated_env, monkeypatch):
         "src.core.pdf_analyzer.shutil.which", lambda _name: r"D:\tools\tesseract.exe"
     )
     assert find_tesseract() == r"D:\tools\tesseract.exe"
+
+
+# --- macOS-Suchpfade ---
+
+
+@pytest.fixture
+def darwin_env(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+    monkeypatch.setattr("src.core.pdf_analyzer.shutil.which", lambda _name: None)
+
+
+def test_darwin_candidates_contain_homebrew_paths(darwin_env):
+    candidates = [str(p) for p in _tesseract_candidates()]
+    assert "/opt/homebrew/bin/tesseract" in [c.replace("\\", "/") for c in candidates]
+    assert "/usr/local/bin/tesseract" in [c.replace("\\", "/") for c in candidates]
+
+
+def test_darwin_bundled_binary_first(darwin_env, tmp_path, monkeypatch):
+    bundle = tmp_path / "_internal"
+    monkeypatch.setattr(sys, "_MEIPASS", str(bundle), raising=False)
+    candidates = _tesseract_candidates()
+    assert candidates[0] == bundle / "tesseract" / "tesseract"
+
+
+def test_darwin_bundled_binary_found(darwin_env, tmp_path, monkeypatch):
+    bundle = tmp_path / "_internal"
+    bundled = bundle / "tesseract" / "tesseract"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_bytes(b"")
+    monkeypatch.setattr(sys, "_MEIPASS", str(bundle), raising=False)
+    assert find_tesseract() == str(bundled)


### PR DESCRIPTION
Verifikation des macOS-Ports auf einem Intel-Mac (x86_64, macOS 26.3). Alle 461 Tests gruen, .app + DMG gebaut, Smoke-Test (Start aus Finder, Einrichtungs-Assistent, Config unter ~/Library/Application Support, OCR mit gebuendeltem Tesseract, OpenRouter-Cloud-KI, Vorschau, Finder-Kontextmenue, DMG-Installation) erfolgreich.

Dabei gefundene und gefixte Fehler:
- Tesseract-Buendelung: tessdata-Suche fand deu.traineddata nicht (tesseract-lang-Keg); Symlink-Referenzen wurden nicht auf @loader_path umgeschrieben
- Analyse-Worker verschluckten Fehler stumm (kein Logging)
- LLM-Pakete (openai, anthropic) fehlten in allen Release-Builds -> Cloud-KI in ausgelieferten Builds funktionslos (betraf auch Windows)
- Issue #59: Analyse-Methoden waren in find_tesseract() verschachtelt -> Hintergrund-Analyse hing plattformuebergreifend bei 0/N (Fixes #59)
- Verstaendlicher Fortschrittstext in der Statusleiste

Offen: arm64 ungetestet, Signierung/Notarisierung noch ohne Zertifikat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)