### PR TITLE
fix(ci): Test-Workflow auf Windows und macOS gruen

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,6 @@ jobs:
       - name: Tests ausfuehren
         env:
           QT_QPA_PLATFORM: offscreen
+          PYTHONMALLOC: debug
+          PYTHONFAULTHANDLER: "1"
         run: pytest tests/test_main_window_gui.py -v -s --log-cli-level=DEBUG

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Tests ausfuehren
         env:
           QT_QPA_PLATFORM: offscreen
-        run: pytest
+        run: pytest tests/test_main_window_gui.py -v -s --log-cli-level=DEBUG

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,4 @@ jobs:
       - name: Tests ausfuehren
         env:
           QT_QPA_PLATFORM: offscreen
-          PYTHONMALLOC: debug
-          PYTHONFAULTHANDLER: "1"
-        run: pytest tests/test_main_window_gui.py -v -s --log-cli-level=DEBUG
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ ignore = ["E501"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short"

--- a/src/core/pdf_cache.py
+++ b/src/core/pdf_cache.py
@@ -274,6 +274,11 @@ class PDFCache(QObject):
         self._lock = Lock()
         self._worker: Optional[PDFAnalysisWorker] = None
         self._llm_worker: Optional[LLMSuggestionWorker] = None
+        # Worker, die nach stop_worker() noch laufen (z.B. mitten in einer
+        # Analyse). Die Referenz muss erhalten bleiben: gibt der GC das
+        # Python-Objekt eines laufenden QThread frei, loescht Qt den Thread im
+        # Betrieb -> Absturz (Access Violation).
+        self._stopping_workers: list[QThread] = []
         self._llm_queued: set[Path] = set()  # PDFs, die in der LLM-Queue stehen
         self._pending_callbacks: dict[Path, list[Callable]] = {}
         self._persist_cache = True  # Standardmäßig persistenten Cache nutzen
@@ -504,15 +509,24 @@ class PDFCache(QObject):
         """Stoppt den Hintergrund-Worker."""
         if self._worker and self._worker.isRunning():
             self._worker.stop()
-            self._worker.wait(2000)
+            if not self._worker.wait(2000):
+                self._keep_until_finished(self._worker)
             self._worker = None
 
     def stop_llm_worker(self):
         """Stoppt den LLM-Hintergrund-Worker."""
         if self._llm_worker and self._llm_worker.isRunning():
             self._llm_worker.stop()
-            self._llm_worker.wait(2000)
+            if not self._llm_worker.wait(2000):
+                self._keep_until_finished(self._llm_worker)
             self._llm_worker = None
+
+    def _keep_until_finished(self, worker: QThread):
+        """Haelt einen nach dem Stop noch laufenden Thread referenziert (siehe __init__)."""
+        logger.warning(
+            f"{type(worker).__name__} laeuft nach Stop noch - wird im Hintergrund beendet"
+        )
+        self._stopping_workers.append(worker)
 
     def get(self, pdf_path: Path) -> Optional[PDFAnalysisResult]:
         """

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -6,7 +6,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from PyQt6.QtCore import Qt, QDate, QTimer, QUrl, pyqtSignal
+from PyQt6.QtCore import Qt, QDate, QThread, QTimer, QUrl, pyqtSignal
 from PyQt6.QtGui import QAction, QDesktopServices
 from PyQt6.QtWidgets import (
     QMainWindow,
@@ -1244,9 +1244,23 @@ class MainWindow(QMainWindow):
         """Wird beim Schließen des Fensters aufgerufen."""
         self.save_settings()
 
+        # Fenstergebundene Timer anhalten: Nach dem Schliessen darf kein
+        # verzoegerter Callback (Pre-Caching, Modell-Warten, Raster-Relayout)
+        # mehr auf ein halb zerstoertes Fenster treffen.
+        for name in ("_precache_timer", "_model_wait_timer", "_grid_relayout_timer"):
+            timer = getattr(self, name, None)
+            if timer is not None:
+                timer.stop()
+
         # Thumbnail-Threads beenden
         for widget in self.pdf_widgets:
             widget.cleanup()
+
+        # Kind-Threads (Ordner-Scan, Metadaten-Leser) zu Ende laufen lassen.
+        # Wird ein noch laufender QThread mitsamt seinem Eltern-Widget
+        # zerstoert, bricht Qt den Prozess hart ab.
+        for thread in self.findChildren(QThread):
+            thread.wait(5000)
 
         # Ausstehendes Hintergrund-Training des Klassifikators abschliessen
         try:

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -6,6 +6,16 @@ from src.utils import hardware
 from src.utils.hardware import GpuInfo, classify_gpu_name, parse_nvidia_smi, recommend
 
 
+@pytest.fixture(autouse=True)
+def _no_apple_silicon(monkeypatch):
+    """Die Tests beschreiben den Windows-Pfad (dedizierte GPU vs. integriert).
+
+    ``recommend()`` prueft zuerst ``is_apple_silicon()`` - auf den macOS-CI-Runnern
+    (Apple Silicon) wuerde sonst jeder Test in den Unified-Memory-Zweig laufen.
+    """
+    monkeypatch.setattr(hardware, "is_apple_silicon", lambda: False)
+
+
 def _gpu(name, vram_mb, dedicated=True, vendor="nvidia"):
     return GpuInfo(name=name, vram_mb=vram_mb, dedicated=dedicated, vendor=vendor)
 

--- a/tests/test_main_window_gui.py
+++ b/tests/test_main_window_gui.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from PyQt6 import sip
 from PyQt6.QtWidgets import QTabWidget, QStatusBar, QWidget
 
 
@@ -75,8 +76,15 @@ def main_window(qtbot, fresh_singletons, monkeypatch):
     monkeypatch.setattr(mw_mod.QMainWindow, "show", lambda self: None)
 
     win = mw_mod.MainWindow()
-    qtbot.addWidget(win)
-    return win
+    yield win
+
+    # Bewusst nicht qtbot.addWidget(): das raeumt nur per deleteLater() auf,
+    # und MainWindow haengt in einem Referenzzyklus - das alte Fenster lebte
+    # so bis zum naechsten GC-Lauf weiter, mitsamt scharfer Timer, die dann
+    # waehrend eines spaeteren Tests auf ein halb zerstoertes Fenster feuerten
+    # (Access Violation auf langsamen CI-Runnern). Deshalb sofort zerstoeren.
+    win.close()
+    sip.delete(win)
 
 
 # --------------------------------------------------------------------- #
@@ -316,6 +324,45 @@ def test_model_wait_cancelled_when_selection_changes(main_window, fresh_singleto
     main_window.selected_pdf = None  # Nutzer hat abgewaehlt
     qtbot.waitUntil(lambda: not main_window._model_wait_active, timeout=2000)
     assert QApplication.overrideCursor() is None
+
+
+def test_close_stops_window_timers(main_window, fresh_singletons):
+    """Nach close() darf kein fenstergebundener Timer mehr feuern.
+
+    Sonst trifft z.B. der 500-ms-Pre-Caching-Timer auf ein bereits (teil-)
+    zerstoertes Fenster - auf langsamen CI-Runnern ein harter Absturz.
+    """
+    main_window._schedule_pre_caching([fresh_singletons["tmp_path"] / "a.pdf"])
+    main_window._grid_relayout_timer.start()
+    assert main_window._precache_timer.isActive()
+
+    main_window.close()
+
+    assert not main_window._precache_timer.isActive()
+    assert not main_window._grid_relayout_timer.isActive()
+
+
+def test_close_waits_for_child_threads(main_window):
+    """close() laesst QThreads mit Widget-Parent zu Ende laufen.
+
+    Ordner-Scan und Metadaten-Leser haengen als Kinder am Fenster. Wird das
+    Fenster zerstoert, waehrend so ein Thread laeuft, bricht Qt den Prozess
+    hart ab - auf langsamen CI-Runnern regelmaessig beim Aufraeumen.
+    """
+    import time
+    from PyQt6.QtCore import QThread
+
+    class _Slow(QThread):
+        def run(self):
+            time.sleep(0.3)
+
+    thread = _Slow(main_window.detail_panel)
+    thread.start()
+    assert thread.isRunning()
+
+    main_window.close()
+
+    assert thread.isFinished()
 
 
 # --------------------------------------------------------------------- #

--- a/tests/test_pdf_cache_worker_stop.py
+++ b/tests/test_pdf_cache_worker_stop.py
@@ -1,0 +1,66 @@
+"""stop_worker() darf einen noch laufenden QThread nicht dem GC ueberlassen.
+
+Gibt Python das Objekt eines laufenden QThread frei, loescht Qt den Thread im
+Betrieb - das endet in einem harten Absturz (Access Violation), nicht in einer
+Exception. Auf langsamen Rechnern (CI) steckte der Analyse-Worker beim Schliessen
+noch im Import/der Analyse, ueberlebte das 2-s-Timeout und stuerzte beim
+naechsten GC-Lauf ab.
+"""
+import gc
+import threading
+
+import pytest
+from PyQt6.QtCore import QThread
+
+
+class _SlowWorker(QThread):
+    """Blockiert in run(), bis das Event gesetzt wird."""
+
+    def __init__(self):
+        super().__init__()
+        self.release = threading.Event()
+
+    def stop(self):
+        pass  # laesst sich nicht sofort stoppen - wie eine laufende Analyse
+
+    def run(self):
+        self.release.wait()
+
+
+@pytest.fixture
+def cache(tmp_path, monkeypatch):
+    from src.core import pdf_cache as pc
+    from src.utils import config as cfg_mod
+
+    fresh = cfg_mod.Config(config_path=tmp_path / "config.json")
+    fresh.set("persist_pdf_cache", False)
+    monkeypatch.setattr(cfg_mod, "get_config", lambda: fresh)
+    monkeypatch.setattr(pc.PDFCache, "_instance", None)
+    return pc.PDFCache()
+
+
+@pytest.mark.parametrize("attr,stop", [
+    ("_worker", "stop_worker"),
+    ("_llm_worker", "stop_llm_worker"),
+])
+def test_stop_keeps_running_thread_referenced(cache, monkeypatch, attr, stop):
+    # wait() soll wie ein abgelaufenes Timeout wirken, ohne 2 s zu warten
+    monkeypatch.setattr(_SlowWorker, "wait", lambda self, *_: False)
+
+    worker = _SlowWorker()
+    setattr(cache, attr, worker)
+    worker.start()
+    assert worker.isRunning()
+
+    getattr(cache, stop)()
+    assert getattr(cache, attr) is None
+
+    # Ohne die Referenz in _stopping_workers wuerde der GC den laufenden Thread
+    # loeschen -> Prozessabsturz statt Testfehler.
+    del worker
+    gc.collect()
+    (worker,) = cache._stopping_workers
+    assert worker.isRunning()
+
+    worker.release.set()
+    assert QThread.wait(worker, 5000)


### PR DESCRIPTION
## Summary
Der Test-Workflow aus #69 war auf beiden Plattformen rot (alle bisherigen `main`-Runs). Drei getrennte Ursachen:

1. **`ModuleNotFoundError: No module named 'src'`** (beide Plattformen) – CI ruft `pytest` direkt auf, ohne das Paket zu installieren; das Projektverzeichnis lag nicht auf `sys.path`. Lokal fiel das nicht auf, weil das Paket editierbar installiert ist. → `pythonpath = ["."]` in `[tool.pytest.ini_options]`.
2. **11 Fehler in `tests/test_hardware.py`** (macOS) – `recommend()` prueft zuerst `is_apple_silicon()`; auf den Apple-Silicon-Runnern liefen alle Windows-GPU-Szenarien in den Unified-Memory-Zweig. → Autouse-Fixture patcht `is_apple_silicon()` auf `False`.
3. **Access Violation im GUI-Testlauf** (Windows, deterministisch im Setup des Tests nach den Navigations-Tests, Trace `line ??? in <lambda>`) – echter App-Bug:
   - Ordner-Scan (`_TreeScanThread`) und Metadaten-Leser (`_PdfMetadataReader`) sind `QThread`s mit Widget-Parent. Wird das Fenster zerstoert, waehrend so ein Thread laeuft, bricht Qt den Prozess hart ab. Auf dem langsamen Runner lief der Scan beim Aufraeumen noch.
   - `MainWindow` haengt in einem Referenzzyklus und wird daher nicht beim Fixture-Teardown, sondern erst vom zyklischen GC geloescht – zu einem beliebigen spaeteren Zeitpunkt (daher der "unschuldige" Lambda-Frame im Trace).
   - Pre-Caching- und Modell-Warte-Timer blieben nach `close()` scharf.
   → `closeEvent()` stoppt die Fenster-Timer und wartet auf Kind-Threads. Die `main_window`-Fixture zerstoert das Fenster deterministisch (`close` + `sip.delete`); damit war der Absturz auch lokal reproduzierbar.
   - Nebenbefund, ebenfalls behoben: `stop_worker()` gab die Referenz auf einen ggf. noch laufenden Analyse-`QThread` frei (gleiche Absturzklasse beim Beenden waehrend einer Analyse). Laufende Worker bleiben jetzt bis zum Ende referenziert.

## Test plan
- [x] (1) CI-Zustand lokal simuliert (editable-`.pth` deaktiviert): ohne Fix 34 Collection-Errors, mit Fix 461 Tests gesammelt
- [x] (3) lokal reproduziert: GUI-Datei allein mit deterministischer Fixture → Exit 127 ohne Fix, 23 passed mit Fix, 4/4 Wiederholungen stabil
- [x] Regressionstests: `test_close_stops_window_timers`, `test_close_waits_for_child_threads`, `tests/test_pdf_cache_worker_stop.py` (ohne Fix stirbt der Prozess)
- [x] Volle Suite lokal mit `QT_QPA_PLATFORM=offscreen`: 465 passed
- [x] macOS-CI gruen
- [ ] Windows-CI gruen

🤖 Generated with [Claude Code](https://claude.com/claude-code)