### PR TITLE
fix: LLM-Status nach Erststart-Wizard aktualisieren

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -40,6 +40,22 @@ from src.utils.explorer_integration import update_launcher_script
 __version__ = "0.18.0"
 
 
+def _apply_wizard_result(window, config):
+    """Aktualisiert das Hauptfenster nach dem Einrichtungs-Assistenten.
+
+    Laedt die PDFs aus dem neu gesetzten Scan-Ordner und initialisiert den
+    LLM-Provider neu, damit die Statusleiste den tatsaechlichen Zustand zeigt.
+    Ohne diesen Aufruf bleibt der HybridClassifier des Hauptfensters auf dem
+    Provider "none" haengen, mit dem er VOR dem Wizard gebaut wurde, und die
+    Statusleiste zeigt "LLM: Aus" bis zum naechsten Neustart (Issue #65).
+    Spiegelt den Ablauf von MainWindow.open_setup_wizard() fuer den
+    nachtraeglichen Aufruf ueber das Menue.
+    """
+    if config.get_scan_folder():
+        window.initial_load()
+    window._on_settings_changed()
+
+
 def _extract_path_arg(argv: list[str]) -> str:
     """
     Liefert das erste Argument, das auf einen existierenden Ordner ODER
@@ -231,9 +247,9 @@ def main():
         close_splash()
         wizard = SetupWizard(window)
         wizard.exec()
-        # Nach dem Wizard: Hauptfenster mit neuem Scan-Ordner aktualisieren
-        if config.get_scan_folder():
-            window.initial_load()
+        # Nach dem Wizard: Hauptfenster mit neuem Scan-Ordner und LLM-Status
+        # aktualisieren (Closes #65)
+        _apply_wizard_result(window, config)
 
     # Falls als Argument eine PDF-Datei uebergeben wurde, diese nach dem
     # initialen Laden auswaehlen und den Rename-Dialog oeffnen. Kurze

--- a/tests/test_first_start_wizard.py
+++ b/tests/test_first_start_wizard.py
@@ -1,0 +1,58 @@
+"""Tests fuer main._apply_wizard_result (Issue #65).
+
+Nach dem Erststart-Wizard muss der LLM-Provider im Hauptfenster neu
+initialisiert werden, sonst zeigt die Statusleiste "LLM: Aus", obwohl der
+Wizard z.B. Ollama erfolgreich eingerichtet hat. Ursache: der
+HybridClassifier des Hauptfensters wird VOR dem Wizard mit Provider "none"
+gebaut und ohne einen expliziten Re-Init-Aufruf nie aktualisiert.
+
+Nutzt ein Fake-Fenster (MagicMock) statt eines echten MainWindow, damit der
+Test schnell und ohne Qt-Widget-Erzeugung laeuft. Da src.main beim Import
+src.gui.main_window mitzieht, laeuft der Test trotzdem ueber die
+qtbot-Fixture (pytest-qt), damit eine QApplication existiert.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from src.main import _apply_wizard_result
+
+
+def test_apply_wizard_result_reinits_llm_with_scan_folder(qtbot, fresh_config):
+    """Wizard hat einen Scan-Ordner gesetzt: initial_load() UND
+    _on_settings_changed() (re-init LLM-Provider, Status, Pre-Caching)
+    muessen aufgerufen werden."""
+    fresh_config.set_scan_folder("C:/irgendein/ordner")
+    window = MagicMock()
+
+    _apply_wizard_result(window, fresh_config)
+
+    window.initial_load.assert_called_once()
+    window._on_settings_changed.assert_called_once()
+
+
+def test_apply_wizard_result_reinits_llm_without_scan_folder(qtbot, fresh_config):
+    """Wizard wurde ohne Scan-Ordner beendet (z.B. abgebrochen):
+    initial_load() ist sinnlos und wird uebersprungen, aber der
+    LLM-Status muss trotzdem aktualisiert werden."""
+    window = MagicMock()
+
+    _apply_wizard_result(window, fresh_config)
+
+    window.initial_load.assert_not_called()
+    window._on_settings_changed.assert_called_once()
+
+
+def test_apply_wizard_result_calls_settings_changed_after_initial_load(qtbot, fresh_config):
+    """Reihenfolge ist wichtig: initial_load() zuerst (laedt die PDFs),
+    danach _on_settings_changed() (re-init LLM + Pre-Caching), damit das
+    Pre-Caching die bereits geladenen PDFs sieht."""
+    fresh_config.set_scan_folder("C:/irgendein/ordner")
+    calls = []
+    window = MagicMock()
+    window.initial_load.side_effect = lambda: calls.append("initial_load")
+    window._on_settings_changed.side_effect = lambda: calls.append("settings_changed")
+
+    _apply_wizard_result(window, fresh_config)
+
+    assert calls == ["initial_load", "settings_changed"]


### PR DESCRIPTION
## Zusammenfassung

Nach dem Einrichtungs-Assistenten beim allerersten Programmstart zeigte die Statusleiste "LLM: Aus", obwohl z.B. Ollama im Wizard erfolgreich eingerichtet wurde - bis zum naechsten Neustart der App.

**Ursache:** In `src/main.py` wurde der `HybridClassifier` des Hauptfensters bereits VOR dem Wizard mit Provider `"none"` gebaut. Nach `wizard.exec()` rief `main()` nur `window.initial_load()` auf, aber nie eine Re-Initialisierung des LLM-Providers. Der Menue-Weg (`MainWindow.open_setup_wizard()`) machte das schon richtig, indem er zusaetzlich `self._on_settings_changed()` aufruft.

**Fix:** Neue Hilfsfunktion `_apply_wizard_result(window, config)` in `src/main.py`, die nach `initial_load()` (falls ein Scan-Ordner gesetzt wurde) zusaetzlich `window._on_settings_changed()` aufruft - das re-initialisiert den LLM-Provider, aktualisiert die Statusanzeige und stoesst das Pre-Caching fuer bereits geladene PDFs an. Spiegelt exakt den bestehenden Ablauf von `MainWindow.open_setup_wizard()`.

## Aenderungen

- `src/main.py`: neue Funktion `_apply_wizard_result()`, im Erststart-Zweig von `main()` genutzt
- `tests/test_first_start_wizard.py`: neue Tests mit Fake-Window (MagicMock), pruefen Aufruf und Reihenfolge von `initial_load()` / `_on_settings_changed()`

## Test plan

- [x] `pytest tests -q` - 468 passed
- [x] Neue Tests laufen ueber `fresh_config`-Fixture (keine echte Nutzer-Config in %APPDATA%)

Closes #65