### PR TITLE
feat: Update-Pruefung beim Start gegen GitHub-Releases (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Hinzugefuegt
+- **Update-Pruefung** (Issue #73): Kurz nach dem Start fragt die App im Hintergrund
+  die Versionsnummer des neuesten GitHub-Releases ab (`src/utils/update_check.py`,
+  nur `releases/latest`, keine Nutzerdaten). Gibt es eine neuere Version, erscheint
+  ein Hinweis in der Statusleiste und ein Dialog mit "Download-Seite oeffnen",
+  "Diese Version ueberspringen" und "Spaeter". Manuell ueber Hilfe > Nach Updates
+  suchen; abschaltbar unter Einstellungen > Allgemein > Updates.
+
 ## [0.18.0] - 2026-08-28
 
 ### Hinzugefuegt

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -2,6 +2,7 @@
 Hauptfenster der PDF Sortier Meister Anwendung
 """
 
+import logging
 import time
 from pathlib import Path
 from typing import Optional
@@ -43,6 +44,7 @@ from src.gui.folder_widget import FolderWidget
 from src.gui.folder_tree_widget import FolderTreeWidget
 from src.gui.rename_dialog import RenameDialog, RenameSuggestion, generate_rename_suggestions
 from src.gui.detail_panel import DetailPanel
+from src.utils.update_check import UpdateCheckError, UpdateInfo, check_for_update
 from src.gui.settings_dialog import SettingsDialog
 from src.gui.setup_wizard import SetupWizard
 from src.gui.korrespondent_sidebar import KorrespondentSidebar
@@ -62,6 +64,28 @@ class _ClickableLabel(QLabel):
     def mouseDoubleClickEvent(self, event):
         self.doubleClicked.emit()
         super().mouseDoubleClickEvent(event)
+
+
+class _UpdateCheckThread(QThread):
+    """Fragt im Hintergrund das neueste GitHub-Release ab (Issue #73)."""
+
+    # (UpdateInfo | None, Fehlertext) - leerer Fehlertext = Pruefung ok
+    result_ready = pyqtSignal(object, str)
+
+    def __init__(self, current_version: str, parent=None):
+        super().__init__(parent)
+        self._current_version = current_version
+
+    def run(self):
+        try:
+            info = check_for_update(self._current_version)
+        except UpdateCheckError as e:
+            self.result_ready.emit(None, str(e))
+            return
+        except Exception as e:  # noqa: BLE001 - Hintergrund-Thread darf nie crashen
+            self.result_ready.emit(None, f"Unerwarteter Fehler: {e}")
+            return
+        self.result_ready.emit(info, "")
 
 
 class MainWindow(QMainWindow):
@@ -1111,6 +1135,11 @@ class MainWindow(QMainWindow):
         first_steps_action.triggered.connect(lambda: self.show_first_steps_hint(force=True))
         help_menu.addAction(first_steps_action)
 
+        update_action = QAction("Nach Updates suchen...", self)
+        update_action.setToolTip("Prüft, ob auf GitHub eine neuere Version veröffentlicht wurde")
+        update_action.triggered.connect(lambda: self.check_for_updates(manual=True))
+        help_menu.addAction(update_action)
+
         about_action = QAction("Über PDF Sortier Meister", self)
         about_action.triggered.connect(self.show_about)
         help_menu.addAction(about_action)
@@ -1212,6 +1241,16 @@ class MainWindow(QMainWindow):
 
         self.backup_status_label = QLabel("Backup: Nicht geprüft")
         self.statusbar.addPermanentWidget(self.backup_status_label)
+
+        # Update-Hinweis (Issue #73): erst sichtbar, wenn ein Update gefunden wurde
+        self.update_status_label = _ClickableLabel("")
+        self.update_status_label.setStyleSheet("color: #d17a00; font-weight: bold;")
+        self.update_status_label.setToolTip("Doppelklick zeigt Details zum Update.")
+        self.update_status_label.doubleClicked.connect(self._show_available_update)
+        self.update_status_label.setVisible(False)
+        self.statusbar.addPermanentWidget(self.update_status_label)
+        self._update_thread: Optional[_UpdateCheckThread] = None
+        self._available_update: Optional[UpdateInfo] = None
 
         self.statusbar.showMessage("Bereit")
 
@@ -3656,6 +3695,132 @@ class MainWindow(QMainWindow):
         box.setStandardButtons(QMessageBox.StandardButton.Ok)
         box.exec()
         self.config.set("backup_hint_dismissed", dismiss.isChecked())
+
+    # ------------------------------------------------------------------ #
+    # Update-Pruefung (Issue #73)
+    # ------------------------------------------------------------------ #
+
+    def schedule_update_check(self, delay_ms: int = 3000) -> bool:
+        """Plant die automatische Update-Pruefung kurz nach dem Start.
+
+        Returns:
+            True, wenn eine Pruefung geplant wurde (Einstellung aktiv).
+        """
+        if not self.config.get("update_check_enabled", True):
+            return False
+        QTimer.singleShot(delay_ms, lambda: self.check_for_updates(manual=False))
+        return True
+
+    def check_for_updates(self, manual: bool = False) -> None:
+        """Startet die Update-Pruefung im Hintergrund.
+
+        Args:
+            manual: True bei Aufruf ueber das Hilfe-Menue - dann wird auch
+                    "keine neue Version" bzw. ein Fehler als Dialog gemeldet.
+        """
+        if self._update_thread is not None and self._update_thread.isRunning():
+            if manual:
+                self.statusbar.showMessage("Update-Prüfung läuft bereits...", 3000)
+            return
+        from src.main import __version__
+
+        thread = _UpdateCheckThread(__version__, self)
+        thread.result_ready.connect(
+            lambda info, error, m=manual: self._on_update_check_finished(info, error, m)
+        )
+        self._update_thread = thread
+        if manual:
+            self.statusbar.showMessage("Suche nach Updates...", 5000)
+        thread.start()
+
+    def _on_update_check_finished(self, info: Optional[UpdateInfo], error: str,
+                                  manual: bool = False) -> None:
+        """Verarbeitet das Ergebnis der Update-Pruefung im GUI-Thread."""
+        from src.main import __version__
+
+        if error:
+            logging.getLogger(__name__).info("Update-Pruefung fehlgeschlagen: %s", error)
+            if manual:
+                QMessageBox.warning(
+                    self,
+                    "Update-Prüfung fehlgeschlagen",
+                    "Die Update-Prüfung konnte nicht durchgeführt werden:\n"
+                    f"{error}\n\n"
+                    "Bitte prüfen Sie Ihre Internetverbindung oder versuchen Sie es später erneut.",
+                )
+            return
+
+        if info is None:
+            if manual:
+                QMessageBox.information(
+                    self,
+                    "Kein Update verfügbar",
+                    f"Sie verwenden bereits die aktuelle Version {__version__}.",
+                )
+            return
+
+        skipped = self.config.get("update_skipped_version", "")
+        if not manual and info.version == skipped:
+            # Nutzer hat diese Version bewusst ausgeblendet - nicht nerven.
+            logging.getLogger(__name__).info(
+                "Update %s verfuegbar, vom Nutzer uebersprungen", info.version
+            )
+            return
+
+        self._available_update = info
+        self.update_status_label.setText(f"Update: v{info.version} verfügbar")
+        self.update_status_label.setVisible(True)
+        self._show_update_dialog(info)
+
+    def _show_available_update(self) -> None:
+        """Doppelklick auf den Statusleisten-Hinweis: Dialog erneut zeigen."""
+        if self._available_update is not None:
+            self._show_update_dialog(self._available_update)
+
+    def _show_update_dialog(self, info: UpdateInfo) -> None:
+        """Zeigt den Update-Dialog (Download-Seite / Überspringen / Später)."""
+        from src.main import __version__
+
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Information)
+        box.setWindowTitle("Update verfügbar")
+        box.setText(
+            f"<b>Version {info.version}</b> von PDF Sortier Meister ist verfügbar.<br>"
+            f"Installiert ist Version {__version__}."
+        )
+        hint = (
+            "Auf der Download-Seite finden Sie den Installer und die Liste der "
+            "Änderungen. Installieren Sie die neue Version einfach über die "
+            "bestehende - Ihre Einstellungen und Lerndaten bleiben erhalten."
+        )
+        if info.asset_name:
+            hint += f"\n\nDatei für Ihr System: {info.asset_name}"
+        box.setInformativeText(hint)
+        if info.notes:
+            box.setDetailedText(info.notes)
+
+        download_btn = box.addButton("Download-Seite öffnen", QMessageBox.ButtonRole.AcceptRole)
+        skip_btn = box.addButton("Diese Version überspringen", QMessageBox.ButtonRole.ActionRole)
+        box.addButton("Später", QMessageBox.ButtonRole.RejectRole)
+        box.setDefaultButton(download_btn)
+        box.exec()
+
+        clicked = box.clickedButton()
+        if clicked is download_btn:
+            QDesktopServices.openUrl(QUrl(info.page_url))
+        elif clicked is skip_btn:
+            self._skip_update(info)
+
+    def _skip_update(self, info: UpdateInfo) -> None:
+        """Blendet diese Version bis zum naechsten Release aus."""
+        self.config.set("update_skipped_version", info.version)
+        self._available_update = None
+        self.update_status_label.setVisible(False)
+        self.statusbar.showMessage(
+            f"Version {info.version} wird übersprungen "
+            "(Hilfe > Nach Updates suchen zeigt sie erneut).",
+            5000,
+        )
 
     def open_setup_wizard(self):
         """Oeffnet den Einrichtungs-Assistenten (auch nachtraeglich nutzbar)."""

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -501,6 +501,28 @@ class SettingsDialog(QDialog):
 
             layout.addWidget(explorer_group)
 
+        # Update-Pruefung (Issue #73)
+        update_group = QGroupBox("Updates")
+        update_layout = QVBoxLayout(update_group)
+
+        self.update_check_checkbox = QCheckBox("Beim Programmstart auf neue Versionen prüfen")
+        self.update_check_checkbox.setToolTip(
+            "Fragt kurz nach dem Start die Versionsnummer des neuesten Releases\n"
+            "auf GitHub ab. Es werden keine Daten über Sie oder Ihre Dokumente\n"
+            "gesendet. Manuell jederzeit über Hilfe > Nach Updates suchen."
+        )
+        update_layout.addWidget(self.update_check_checkbox)
+
+        update_info = QLabel(
+            "Es wird nur die Versionsnummer des neuesten Releases abgerufen; "
+            "heruntergeladen und installiert wird nichts automatisch."
+        )
+        update_info.setStyleSheet("color: gray;")
+        update_info.setWordWrap(True)
+        update_layout.addWidget(update_info)
+
+        layout.addWidget(update_group)
+
         # Debug-Bereich
         debug_group = QGroupBox("Debug / Zurücksetzen")
         debug_layout = QVBoxLayout(debug_group)
@@ -1056,6 +1078,9 @@ class SettingsDialog(QDialog):
         self.llm_precache_checkbox.setChecked(self.config.get("llm_precache_enabled", True))
         self._update_cache_stats()
 
+        # Update-Pruefung (Issue #73)
+        self.update_check_checkbox.setChecked(self.config.get("update_check_enabled", True))
+
         # Explorer-Integration: aktuellen Stand aus der Registry lesen.
         if sys.platform == "win32":
             try:
@@ -1123,6 +1148,9 @@ class SettingsDialog(QDialog):
 
         llm_precache = self.llm_precache_checkbox.isChecked()
         self.config.set("llm_precache_enabled", llm_precache)
+
+        # Update-Pruefung (Issue #73)
+        self.config.set("update_check_enabled", self.update_check_checkbox.isChecked())
 
         # Cache-Modul über Änderung informieren
         try:

--- a/src/main.py
+++ b/src/main.py
@@ -235,6 +235,11 @@ def main():
         if config.get_scan_folder():
             window.initial_load()
 
+    # Update-Pruefung im Hintergrund, kurz nach dem Start (Issue #73).
+    # Bewusst hier und nicht im MainWindow-Konstruktor, damit Tests und
+    # Dialoge, die ein MainWindow erzeugen, keine Netzwerkzugriffe ausloesen.
+    window.schedule_update_check()
+
     # Falls als Argument eine PDF-Datei uebergeben wurde, diese nach dem
     # initialen Laden auswaehlen und den Rename-Dialog oeffnen. Kurze
     # Verzoegerung, damit load_pdfs() die Widgets erstellt hat.

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -87,6 +87,11 @@ class Config:
         "backup_hint_dismissed": False,
         # Erste-Schritte-Hinweis beim Start (Issue #51) abgehakt?
         "first_steps_hint_dismissed": False,
+        # Update-Pruefung beim Start (Issue #73): fragt nur die Versionsnummer
+        # des neuesten GitHub-Releases ab, sendet keine Nutzerdaten.
+        "update_check_enabled": True,
+        # Vom Nutzer per "Diese Version ueberspringen" ausgeblendete Version
+        "update_skipped_version": "",
     }
 
     def __init__(self, config_path: str = None):

--- a/src/utils/update_check.py
+++ b/src/utils/update_check.py
@@ -1,0 +1,149 @@
+"""
+Update-Pruefung gegen die GitHub-Releases (Issue #73).
+
+Reine Logik ohne Qt, damit sie ohne GUI testbar ist. Es wird ausschliesslich
+die oeffentliche Release-Info abgerufen (``releases/latest``); dabei werden
+keine Daten ueber den Nutzer oder seine Dokumente uebertragen.
+
+Draft- und Pre-Releases liefert der ``latest``-Endpunkt von GitHub nicht,
+d.h. ein Release wird erst nach dem Veroeffentlichen als Update erkannt.
+"""
+from __future__ import annotations
+
+import json
+import platform
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+
+GITHUB_REPO = "Josi-create/PDF_Sortier_Meister"
+LATEST_RELEASE_API = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+RELEASES_PAGE_URL = f"https://github.com/{GITHUB_REPO}/releases/latest"
+
+# Feste Asset-Namen aus dem Release-Workflow (installer.iss / build.sh)
+WINDOWS_ASSET = "PDF_Sortier_Meister_Setup.exe"
+MACOS_ASSET_TEMPLATE = "PDF_Sortier_Meister-macos-{arch}.dmg"
+
+DEFAULT_TIMEOUT = 3.0
+
+_VERSION_RE = re.compile(r"^\s*v?(\d+(?:\.\d+)*)")
+
+
+class UpdateCheckError(Exception):
+    """Netzwerk- oder Antwortfehler bei der Update-Pruefung."""
+
+
+@dataclass
+class UpdateInfo:
+    """Beschreibt ein verfuegbares Update."""
+
+    version: str       # normalisiert, z.B. "0.19.0"
+    tag: str           # Git-Tag, z.B. "v0.19.0"
+    page_url: str      # Release-Seite auf GitHub
+    download_url: str  # Direktlink zum passenden Installer (oder Release-Seite)
+    asset_name: str = ""  # Dateiname des Installers, falls gefunden
+    notes: str = ""    # Release-Notes (Markdown)
+
+
+def parse_version(text: str) -> tuple[int, ...]:
+    """Zerlegt "v0.19.0" / "0.19" in ein Tupel; leer bei unbrauchbarem Text."""
+    if not text:
+        return ()
+    m = _VERSION_RE.match(str(text))
+    if not m:
+        return ()
+    return tuple(int(part) for part in m.group(1).split("."))
+
+
+def is_newer(candidate: str, current: str) -> bool:
+    """True, wenn ``candidate`` eine hoehere Version als ``current`` ist."""
+    a, b = parse_version(candidate), parse_version(current)
+    if not a or not b:
+        return False
+    length = max(len(a), len(b))
+    a += (0,) * (length - len(a))
+    b += (0,) * (length - len(b))
+    return a > b
+
+
+def expected_asset_name(platform_name: str | None = None,
+                        arch: str | None = None) -> str | None:
+    """Name des Installer-Assets fuer diese Plattform (None = unbekannt)."""
+    platform_name = platform_name or sys.platform
+    if platform_name == "win32":
+        return WINDOWS_ASSET
+    if platform_name == "darwin":
+        arch = (arch or platform.machine() or "").lower()
+        arch = "arm64" if arch in ("arm64", "aarch64") else "x86_64"
+        return MACOS_ASSET_TEMPLATE.format(arch=arch)
+    return None
+
+
+def pick_download(release: dict, platform_name: str | None = None,
+                  arch: str | None = None) -> tuple[str, str]:
+    """Liefert (download_url, asset_name) fuer diese Plattform.
+
+    Faellt auf die Release-Seite zurueck, wenn kein passendes Asset existiert.
+    """
+    page_url = release.get("html_url") or RELEASES_PAGE_URL
+    name = expected_asset_name(platform_name, arch)
+    if name:
+        for asset in release.get("assets") or []:
+            if asset.get("name") == name and asset.get("browser_download_url"):
+                return asset["browser_download_url"], name
+    return page_url, ""
+
+
+def fetch_latest_release(timeout: float = DEFAULT_TIMEOUT,
+                         user_agent: str = "PDF-Sortier-Meister") -> dict:
+    """Holt die JSON-Beschreibung des neuesten veroeffentlichten Releases."""
+    req = urllib.request.Request(
+        LATEST_RELEASE_API,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": user_agent,
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def check_for_update(current_version: str,
+                     fetch: Callable[[], dict] = fetch_latest_release,
+                     platform_name: str | None = None,
+                     arch: str | None = None) -> UpdateInfo | None:
+    """Prueft, ob ein neueres Release als ``current_version`` existiert.
+
+    Returns:
+        UpdateInfo bei neuerer Version, sonst None.
+
+    Raises:
+        UpdateCheckError: bei Netzwerkfehlern oder unbrauchbarer Antwort.
+    """
+    try:
+        release = fetch()
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        raise UpdateCheckError(str(getattr(e, "reason", None) or e)) from e
+
+    if not isinstance(release, dict):
+        raise UpdateCheckError("Unerwartete Antwort von GitHub")
+
+    tag = release.get("tag_name") or ""
+    parsed = parse_version(tag)
+    if not parsed:
+        raise UpdateCheckError(f"Unbrauchbare Versionsangabe: {tag!r}")
+    if not is_newer(tag, current_version):
+        return None
+
+    download_url, asset_name = pick_download(release, platform_name, arch)
+    return UpdateInfo(
+        version=".".join(str(p) for p in parsed),
+        tag=tag,
+        page_url=release.get("html_url") or RELEASES_PAGE_URL,
+        download_url=download_url,
+        asset_name=asset_name,
+        notes=release.get("body") or "",
+    )

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,198 @@
+"""Tests fuer die Update-Pruefung gegen GitHub Releases (Issue #73).
+
+Reine Logik-Tests ohne Qt und ohne Netzwerk: ``fetch`` wird injiziert bzw.
+``urllib.request.urlopen`` gepatcht.
+"""
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+
+import pytest
+
+from src.utils import update_check as uc
+
+# --------------------------------------------------------------------- #
+# Versionsvergleich
+# --------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("v0.19.0", (0, 19, 0)),
+        ("0.19.0", (0, 19, 0)),
+        ("  v1.2 ", (1, 2)),
+        ("v0.19.0-beta", (0, 19, 0)),
+        ("", ()),
+        ("release", ()),
+        (None, ()),
+    ],
+)
+def test_parse_version(text, expected):
+    assert uc.parse_version(text) == expected
+
+
+@pytest.mark.parametrize(
+    "candidate, current, newer",
+    [
+        ("v0.19.0", "0.18.0", True),
+        ("v0.18.1", "0.18.0", True),
+        ("v1.0.0", "0.18.0", True),
+        ("v0.18.0", "0.18.0", False),
+        ("v0.17.0", "0.18.0", False),
+        ("v0.18", "0.18.0", False),     # aufgefuellt: 0.18.0 == 0.18.0
+        ("v0.18.0.1", "0.18.0", True),
+        ("kaputt", "0.18.0", False),
+        ("v0.19.0", "", False),
+    ],
+)
+def test_is_newer(candidate, current, newer):
+    assert uc.is_newer(candidate, current) is newer
+
+
+# --------------------------------------------------------------------- #
+# Plattform-Asset
+# --------------------------------------------------------------------- #
+
+
+def test_expected_asset_name_windows():
+    assert uc.expected_asset_name("win32") == "PDF_Sortier_Meister_Setup.exe"
+
+
+@pytest.mark.parametrize("arch, expected", [
+    ("arm64", "PDF_Sortier_Meister-macos-arm64.dmg"),
+    ("aarch64", "PDF_Sortier_Meister-macos-arm64.dmg"),
+    ("x86_64", "PDF_Sortier_Meister-macos-x86_64.dmg"),
+    ("AMD64", "PDF_Sortier_Meister-macos-x86_64.dmg"),
+])
+def test_expected_asset_name_macos(arch, expected):
+    assert uc.expected_asset_name("darwin", arch) == expected
+
+
+def test_expected_asset_name_unknown_platform():
+    assert uc.expected_asset_name("linux") is None
+
+
+def _release(tag="v0.19.0", assets=None, **extra):
+    data = {
+        "tag_name": tag,
+        "html_url": f"https://github.com/{uc.GITHUB_REPO}/releases/tag/{tag}",
+        "body": "## Neu\n- Update-Check",
+        "assets": assets if assets is not None else [
+            {"name": "PDF_Sortier_Meister_Setup.exe",
+             "browser_download_url": "https://dl/Setup.exe"},
+            {"name": "PDF_Sortier_Meister-macos-arm64.dmg",
+             "browser_download_url": "https://dl/arm64.dmg"},
+        ],
+    }
+    data.update(extra)
+    return data
+
+
+def test_pick_download_finds_platform_asset():
+    url, name = uc.pick_download(_release(), "win32")
+    assert (url, name) == ("https://dl/Setup.exe", "PDF_Sortier_Meister_Setup.exe")
+    url, name = uc.pick_download(_release(), "darwin", "arm64")
+    assert (url, name) == ("https://dl/arm64.dmg", "PDF_Sortier_Meister-macos-arm64.dmg")
+
+
+def test_pick_download_falls_back_to_release_page():
+    rel = _release()
+    # Intel-DMG fehlt im Release -> Release-Seite
+    assert uc.pick_download(rel, "darwin", "x86_64") == (rel["html_url"], "")
+    # Unbekannte Plattform -> Release-Seite
+    assert uc.pick_download(rel, "linux") == (rel["html_url"], "")
+    # Auch ohne html_url gibt es einen brauchbaren Link
+    assert uc.pick_download({"assets": []}, "win32") == (uc.RELEASES_PAGE_URL, "")
+
+
+# --------------------------------------------------------------------- #
+# check_for_update
+# --------------------------------------------------------------------- #
+
+
+def test_check_for_update_returns_info_for_newer_release():
+    info = uc.check_for_update("0.18.0", fetch=lambda: _release("v0.19.0"),
+                               platform_name="win32")
+    assert info is not None
+    assert info.version == "0.19.0"
+    assert info.tag == "v0.19.0"
+    assert info.page_url.endswith("/releases/tag/v0.19.0")
+    assert info.download_url == "https://dl/Setup.exe"
+    assert info.asset_name == "PDF_Sortier_Meister_Setup.exe"
+    assert "Update-Check" in info.notes
+
+
+@pytest.mark.parametrize("tag", ["v0.18.0", "v0.17.5"])
+def test_check_for_update_returns_none_when_current(tag):
+    assert uc.check_for_update("0.18.0", fetch=lambda: _release(tag)) is None
+
+
+def test_check_for_update_network_error_raises():
+    def boom():
+        raise urllib.error.URLError("Name or service not known")
+
+    with pytest.raises(uc.UpdateCheckError) as exc:
+        uc.check_for_update("0.18.0", fetch=boom)
+    assert "Name or service not known" in str(exc.value)
+
+
+def test_check_for_update_timeout_raises():
+    def boom():
+        raise TimeoutError("timed out")
+
+    with pytest.raises(uc.UpdateCheckError):
+        uc.check_for_update("0.18.0", fetch=boom)
+
+
+@pytest.mark.parametrize("payload", [None, [], {"message": "Not Found"}, {"tag_name": "latest"}])
+def test_check_for_update_bad_payload_raises(payload):
+    with pytest.raises(uc.UpdateCheckError):
+        uc.check_for_update("0.18.0", fetch=lambda: payload)
+
+
+# --------------------------------------------------------------------- #
+# fetch_latest_release: Request-Aufbau (ohne echtes Netz)
+# --------------------------------------------------------------------- #
+
+
+class _FakeResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+        return False
+
+
+def test_fetch_latest_release_builds_request(monkeypatch):
+    seen = {}
+
+    def fake_urlopen(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["headers"] = {k.lower(): v for k, v in req.header_items()}
+        seen["timeout"] = timeout
+        return _FakeResponse(json.dumps(_release()).encode("utf-8"))
+
+    monkeypatch.setattr(uc.urllib.request, "urlopen", fake_urlopen)
+
+    data = uc.fetch_latest_release(timeout=1.5, user_agent="PDF-Sortier-Meister/0.18.0")
+
+    assert data["tag_name"] == "v0.19.0"
+    assert seen["url"] == uc.LATEST_RELEASE_API
+    assert seen["url"].endswith("/releases/latest")
+    assert seen["headers"]["accept"] == "application/vnd.github+json"
+    assert seen["headers"]["user-agent"] == "PDF-Sortier-Meister/0.18.0"
+    assert seen["timeout"] == 1.5
+
+
+def test_fetch_latest_release_http_error_surfaces_as_update_check_error(monkeypatch):
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, 403, "rate limited", {}, None)
+
+    monkeypatch.setattr(uc.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(uc.UpdateCheckError):
+        uc.check_for_update("0.18.0")

--- a/tests/test_update_check_gui.py
+++ b/tests/test_update_check_gui.py
@@ -1,0 +1,217 @@
+"""GUI-Tests fuer die Update-Pruefung im Hauptfenster (Issue #73).
+
+Kein Netzwerk: Der Hintergrund-Thread wird nicht gestartet, stattdessen wird
+der Ergebnis-Slot ``_on_update_check_finished`` direkt aufgerufen. Der
+Update-Dialog wird durch einen Recorder ersetzt, damit nichts modal blockiert.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.utils.update_check import UpdateInfo
+
+
+@pytest.fixture
+def fresh_singletons(monkeypatch, tmp_path):
+    from src.core import pdf_cache as pc_mod
+    from src.ml import classifier as cl_mod
+    from src.ml import hybrid_classifier as hc_mod
+    from src.utils import config as cfg_mod
+    from src.utils import database as db_mod
+    from tests.conftest import patch_singletons
+
+    fresh_config = cfg_mod.Config(config_path=tmp_path / "config.json")
+    fresh_config.set("persist_pdf_cache", False)
+    monkeypatch.setattr(pc_mod.PDFCache, "_instance", None)
+    patch_singletons(monkeypatch, {
+        "get_config": lambda: fresh_config,
+        "get_database": lambda: db_mod.Database(db_path=str(tmp_path / "u.db")),
+        "get_classifier": cl_mod.PDFClassifier,
+        "get_hybrid_classifier": hc_mod.HybridClassifier,
+        "get_pdf_cache": pc_mod.PDFCache,
+    })
+    return fresh_config
+
+
+@pytest.fixture
+def main_window(qtbot, fresh_singletons, monkeypatch):
+    from PyQt6.QtCore import QSettings
+    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+
+    from src.gui import main_window as mw_mod
+    monkeypatch.setattr(mw_mod.QMainWindow, "showMaximized", lambda self: None)
+    monkeypatch.setattr(mw_mod.QMainWindow, "show", lambda self: None)
+
+    win = mw_mod.MainWindow()
+    qtbot.addWidget(win)
+    yield win
+    win.close()
+
+
+@pytest.fixture
+def dialog_recorder(monkeypatch):
+    """Ersetzt den modalen Update-Dialog durch einen Aufruf-Recorder."""
+    from src.gui import main_window as mw_mod
+
+    calls = []
+    monkeypatch.setattr(
+        mw_mod.MainWindow, "_show_update_dialog", lambda self, info: calls.append(info)
+    )
+    return calls
+
+
+def _info(version="0.99.0"):
+    return UpdateInfo(
+        version=version,
+        tag=f"v{version}",
+        page_url="https://github.com/Josi-create/PDF_Sortier_Meister/releases/latest",
+        download_url="https://dl/Setup.exe",
+        asset_name="PDF_Sortier_Meister_Setup.exe",
+        notes="Notes",
+    )
+
+
+# --------------------------------------------------------------------- #
+# Struktur
+# --------------------------------------------------------------------- #
+
+
+def test_window_has_hidden_update_label_and_help_action(main_window):
+    assert main_window.update_status_label.isHidden()
+    help_menu = next(
+        m for m in main_window.menuBar().findChildren(type(main_window.menuBar().actions()[0].menu()))
+        if m.title() == "Hilfe"
+    )
+    titles = [a.text() for a in help_menu.actions()]
+    assert "Nach Updates suchen..." in titles
+
+
+def test_constructor_does_not_start_update_thread(main_window):
+    # Der Netzwerkzugriff wird erst durch main.py via schedule_update_check geplant.
+    assert main_window._update_thread is None
+
+
+# --------------------------------------------------------------------- #
+# Ergebnis-Verarbeitung
+# --------------------------------------------------------------------- #
+
+
+def test_update_available_shows_status_and_dialog(main_window, dialog_recorder):
+    main_window._on_update_check_finished(_info("0.99.0"), "", manual=False)
+
+    assert not main_window.update_status_label.isHidden()
+    assert "0.99.0" in main_window.update_status_label.text()
+    assert main_window._available_update is not None
+    assert len(dialog_recorder) == 1 and dialog_recorder[0].version == "0.99.0"
+
+
+def test_skipped_version_is_silent_on_automatic_check(main_window, dialog_recorder, fresh_singletons):
+    fresh_singletons.set("update_skipped_version", "0.99.0")
+
+    main_window._on_update_check_finished(_info("0.99.0"), "", manual=False)
+
+    assert main_window.update_status_label.isHidden()
+    assert dialog_recorder == []
+
+
+def test_skipped_version_still_shown_on_manual_check(main_window, dialog_recorder, fresh_singletons):
+    fresh_singletons.set("update_skipped_version", "0.99.0")
+
+    main_window._on_update_check_finished(_info("0.99.0"), "", manual=True)
+
+    assert len(dialog_recorder) == 1
+
+
+def test_newer_release_after_skip_is_shown_again(main_window, dialog_recorder, fresh_singletons):
+    fresh_singletons.set("update_skipped_version", "0.99.0")
+
+    main_window._on_update_check_finished(_info("0.99.1"), "", manual=False)
+
+    assert len(dialog_recorder) == 1
+
+
+def test_skip_update_persists_version_and_hides_label(main_window, dialog_recorder, fresh_singletons):
+    info = _info("0.99.0")
+    main_window._on_update_check_finished(info, "", manual=False)
+    assert not main_window.update_status_label.isHidden()
+
+    main_window._skip_update(info)
+
+    assert fresh_singletons.get("update_skipped_version") == "0.99.0"
+    assert main_window.update_status_label.isHidden()
+    assert main_window._available_update is None
+
+
+def test_no_update_is_silent_when_automatic(main_window, dialog_recorder, monkeypatch):
+    from src.gui import main_window as mw_mod
+    boxes = []
+    monkeypatch.setattr(mw_mod.QMessageBox, "information",
+                        staticmethod(lambda *a, **k: boxes.append(a)))
+
+    main_window._on_update_check_finished(None, "", manual=False)
+
+    assert boxes == [] and dialog_recorder == []
+    assert main_window.update_status_label.isHidden()
+
+
+def test_no_update_reports_current_version_when_manual(main_window, monkeypatch):
+    from src.gui import main_window as mw_mod
+    from src.main import __version__
+    boxes = []
+    monkeypatch.setattr(mw_mod.QMessageBox, "information",
+                        staticmethod(lambda *a, **k: boxes.append(a)))
+
+    main_window._on_update_check_finished(None, "", manual=True)
+
+    assert len(boxes) == 1
+    assert __version__ in boxes[0][2]
+
+
+def test_error_is_silent_when_automatic_but_warns_when_manual(main_window, monkeypatch):
+    from src.gui import main_window as mw_mod
+    warnings = []
+    monkeypatch.setattr(mw_mod.QMessageBox, "warning",
+                        staticmethod(lambda *a, **k: warnings.append(a)))
+
+    main_window._on_update_check_finished(None, "Verbindung fehlgeschlagen", manual=False)
+    assert warnings == []
+
+    main_window._on_update_check_finished(None, "Verbindung fehlgeschlagen", manual=True)
+    assert len(warnings) == 1
+    assert "Verbindung fehlgeschlagen" in warnings[0][2]
+
+
+# --------------------------------------------------------------------- #
+# Planung beim Start + Einstellung
+# --------------------------------------------------------------------- #
+
+
+def test_schedule_respects_setting(main_window, fresh_singletons, monkeypatch):
+    from src.gui import main_window as mw_mod
+    scheduled = []
+    monkeypatch.setattr(mw_mod.QTimer, "singleShot",
+                        staticmethod(lambda ms, fn: scheduled.append(ms)))
+
+    assert main_window.schedule_update_check() is True
+    assert scheduled == [3000]
+
+    fresh_singletons.set("update_check_enabled", False)
+    assert main_window.schedule_update_check() is False
+    assert scheduled == [3000]
+
+
+def test_settings_dialog_round_trips_update_setting(qtbot, fresh_singletons):
+    from src.gui.settings_dialog import SettingsDialog
+
+    dialog = SettingsDialog()
+    qtbot.addWidget(dialog)
+    assert dialog.update_check_checkbox.isChecked()
+
+    dialog.update_check_checkbox.setChecked(False)
+    dialog._save_settings()
+
+    assert fresh_singletons.get("update_check_enabled") is False
+
+    dialog2 = SettingsDialog()
+    qtbot.addWidget(dialog2)
+    assert not dialog2.update_check_checkbox.isChecked()


### PR DESCRIPTION
Closes #73

## Was
- Neues Modul `src/utils/update_check.py`: fragt `releases/latest` der GitHub-API ab (3 s Timeout), vergleicht mit `__version__`, waehlt den passenden Installer (Setup.exe / macOS-DMG je Architektur). Nur die Versionsnummer wird abgerufen, keine Nutzerdaten.
- Hauptfenster: Pruefung im QThread, von `main.py` 3 s nach dem Start geplant. Bei neuer Version: Statusleisten-Hinweis (Doppelklick = Details) + Dialog **Download-Seite oeffnen / Diese Version ueberspringen / Spaeter**. Uebersprungene Version wird gemerkt, ein spaeteres Release erscheint wieder.
- Hilfe > **Nach Updates suchen...** prueft manuell (meldet auch "aktuell" und Fehler).
- Einstellungen > Allgemein > **Updates**: abschaltbar (`update_check_enabled`, Default an).

## Entscheidung (Josi, 2026-08-28)
Nur Link + Download-Seite, kein automatischer Download/Install.

## Verifikation
- 512/512 Tests gruen (47 neu: Versionsvergleich, Asset-Auswahl, Request-Aufbau, Fehlerfaelle, Statusleiste/Dialog-Logik, Einstellung).
- Live gegen die echte API geprueft: v0.18.0 wird erkannt, Setup.exe-Link gefunden, mit `0.18.0` als installierter Version -> kein Update.
- Dialog + Statusleiste mit isoliertem APPDATA per Screenshot geprueft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
