### PR TITLE
feat: Naechste PDF nach dem Verschieben automatisch auswaehlen

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -715,10 +715,16 @@ class MainWindow(QMainWindow):
             self._thumbnails_signal_emitted = True
             self.thumbnails_loaded.emit()
 
-    def remove_pdf_widget(self, pdf_path: Path):
-        """Entfernt ein einzelnes PDF-Widget aus der Ansicht (ohne vollständigen Refresh)."""
-        for widget in self.pdf_widgets:
+    def remove_pdf_widget(self, pdf_path: Path) -> Optional[int]:
+        """Entfernt ein einzelnes PDF-Widget aus der Ansicht (ohne vollständigen Refresh).
+
+        Gibt die Rasterposition zurück, an der das Widget stand (Issue #75:
+        automatische Auswahl der nächsten PDF), oder None falls nicht gefunden.
+        """
+        index = None
+        for i, widget in enumerate(self.pdf_widgets):
             if widget.pdf_path == pdf_path:
+                index = i
                 # Widget aus Layout entfernen
                 self.pdf_layout.removeWidget(widget)
                 widget.cleanup() if hasattr(widget, 'cleanup') else None
@@ -738,6 +744,26 @@ class MainWindow(QMainWindow):
         # Aus Mehrfachauswahl entfernen
         if pdf_path in self.selected_pdfs:
             self.selected_pdfs.remove(pdf_path)
+
+        return index
+
+    def _remove_pdf_widget_and_select_next(self, pdf_path: Path) -> bool:
+        """Entfernt ein PDF-Widget und wählt danach automatisch die nächste PDF
+        an derselben Rasterposition aus, falls die entfernte PDF die aktuell
+        ausgewählte war (Issue #75: nach dem Wegsortieren automatisch weiter).
+
+        Läuft über den normalen Klick-Pfad (on_pdf_clicked), damit Detail-Panel,
+        Vorschläge und Ordner-Highlights wie bei einem echten Klick aktualisiert
+        werden. Gibt True zurück, wenn eine Folge-PDF automatisch ausgewählt wurde.
+        """
+        was_selected = self.selected_pdf == pdf_path
+        index = self.remove_pdf_widget(pdf_path)
+        if was_selected and index is not None and self.pdf_widgets:
+            next_index = min(index, len(self.pdf_widgets) - 1)
+            next_path = self.pdf_widgets[next_index].pdf_path
+            self.on_pdf_clicked(next_path)
+            return True
+        return False
 
     def _update_pdf_widget_path(self, old_path: Path, new_path: Path):
         """Aktualisiert den Pfad eines PDF-Widgets nach Umbenennung."""
@@ -1782,8 +1808,8 @@ class MainWindow(QMainWindow):
 
             # UI aktualisieren
             self.config.add_to_last_used(folder_path)
-            self.remove_pdf_widget(pdf_path)
-            self.detail_panel.clear()
+            if not self._remove_pdf_widget_and_select_next(pdf_path):
+                self.detail_panel.clear()
             timer.step("ui")
             self._refresh_after_move(folder_path, pdf_path.parent)
             timer.step("tree")
@@ -1859,7 +1885,7 @@ class MainWindow(QMainWindow):
                 self.config.add_to_last_used(folder_path)
 
                 # Nur das verschobene PDF-Widget entfernen (NICHT refresh_view!)
-                self.remove_pdf_widget(pdf_path)
+                self._remove_pdf_widget_and_select_next(pdf_path)
 
                 # Ordneransicht aktualisieren (um PDF-Zähler zu aktualisieren)
                 self._refresh_after_move(folder_path, pdf_path.parent)
@@ -1892,6 +1918,7 @@ class MainWindow(QMainWindow):
         moved_pdfs = []
         move_pairs = []  # (source, dest) für Undo
         errors = []
+        original_selected = self.selected_pdf
 
         for pdf_path in pdf_paths:
             try:
@@ -1944,15 +1971,26 @@ class MainWindow(QMainWindow):
                 desc = f"{moved_count} PDFs → {relative_path}"
             self._push_undo({"type": "move", "moves": move_pairs, "description": desc})
 
-        # Verschobene PDF-Widgets entfernen
+        # Verschobene PDF-Widgets entfernen; Position der zuvor ausgewählten
+        # PDF merken, um danach die nächste automatisch auszuwählen (Issue #75)
+        selected_removed_index = None
         for moved_pdf in moved_pdfs:
-            self.remove_pdf_widget(moved_pdf)
+            index = self.remove_pdf_widget(moved_pdf)
+            if moved_pdf == original_selected:
+                selected_removed_index = index
 
         # Auswahl zurücksetzen
-        self.selected_pdf = None
-        self.selected_pdf_text = None
-        self.selected_pdf_keywords = None
         self.selected_pdfs = []
+        auto_selected = False
+        if selected_removed_index is not None and self.pdf_widgets:
+            next_index = min(selected_removed_index, len(self.pdf_widgets) - 1)
+            next_path = self.pdf_widgets[next_index].pdf_path
+            self.on_pdf_clicked(next_path)
+            auto_selected = True
+        else:
+            self.selected_pdf = None
+            self.selected_pdf_text = None
+            self.selected_pdf_keywords = None
 
         # Zuletzt verwendet aktualisieren
         self.config.add_to_last_used(folder_path)
@@ -1960,8 +1998,9 @@ class MainWindow(QMainWindow):
         # Ordneransicht aktualisieren
         self._refresh_after_move(folder_path, *{p.parent for p in pdf_paths})
 
-        # Vorschläge leeren
-        self.clear_suggestions()
+        # Vorschläge leeren (nur wenn keine Folge-PDF automatisch ausgewählt wurde)
+        if not auto_selected:
+            self.clear_suggestions()
 
     def on_pdf_double_clicked(self, pdf_path: Path):
         """Wird aufgerufen wenn eine PDF doppelgeklickt wird."""
@@ -2360,7 +2399,7 @@ class MainWindow(QMainWindow):
                 })
 
                 # Nur das verschobene PDF-Widget entfernen
-                self.remove_pdf_widget(pdf_path)
+                self._remove_pdf_widget_and_select_next(pdf_path)
                 # Ordneransicht aktualisieren
                 self._refresh_after_move(folder_path, pdf_path.parent)
                 # Phase 21: Automation-Regeln (Vorschlag im Statusbar)

--- a/tests/test_auto_next_after_move_gui.py
+++ b/tests/test_auto_next_after_move_gui.py
@@ -1,0 +1,244 @@
+"""GUI-Tests fuer Issue #75: Nach dem Wegsortieren automatisch die naechste
+PDF auswaehlen.
+
+Deckt die drei Verschiebe-Pfade ab, die ``remove_pdf_widget`` aufrufen:
+``move_pdf_to_folder_and_learn`` (Einzelauswahl, Klick auf Vorschlag/Ordner),
+``move_multiple_pdfs_to_folder`` (Mehrfachauswahl) sowie den Fall, dass die
+verschobene PDF gar nicht die ausgewaehlte war (keine Auto-Auswahl).
+
+Fixtures folgen dem Muster aus ``tests/test_main_window_gui.py``: Singletons
+werden auf tmp-Pfade umgebogen, damit nie gegen die echte Nutzer-Config in
+%APPDATA% getestet wird.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PyQt6 import sip
+from PyQt6.QtWidgets import QMessageBox
+
+
+# --------------------------------------------------------------------- #
+# Fixtures: Singletons monkeypatchen (identisch zu test_main_window_gui.py)
+# --------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def fresh_singletons(monkeypatch, tmp_path):
+    """Setzt die Module-Singletons auf tmp-Pfade und leere Defaults."""
+    db_path = tmp_path / "auto_next_smoke.db"
+    from src.utils import config as cfg_mod
+    from src.utils import database as db_mod
+    from src.ml import classifier as cl_mod
+    from src.ml import hybrid_classifier as hc_mod
+    from src.core import pdf_cache as pc_mod
+
+    from tests.conftest import patch_singletons
+    fresh_config = cfg_mod.Config(config_path=tmp_path / "config.json")
+    fresh_config.set("persist_pdf_cache", False)
+    monkeypatch.setattr(pc_mod.PDFCache, "_instance", None)
+    patch_singletons(monkeypatch, {
+        "get_config": lambda: fresh_config,
+        "get_database": lambda: db_mod.Database(db_path=str(db_path)),
+        "get_classifier": cl_mod.PDFClassifier,
+        "get_hybrid_classifier": hc_mod.HybridClassifier,
+        "get_pdf_cache": pc_mod.PDFCache,
+    })
+
+    return {"config": fresh_config, "tmp_path": tmp_path}
+
+
+@pytest.fixture
+def main_window(qtbot, fresh_singletons, monkeypatch):
+    """Eine frische MainWindow-Instanz, headless."""
+    from PyQt6.QtCore import QSettings
+    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+
+    from src.gui import main_window as mw_mod
+    monkeypatch.setattr(mw_mod.QMainWindow, "showMaximized", lambda self: None)
+    monkeypatch.setattr(mw_mod.QMainWindow, "show", lambda self: None)
+
+    # Modale Dialoge duerfen den Test nie blockieren: Verschieben immer
+    # bestaetigen, Fehler-/Warn-Dialoge nur protokollieren.
+    monkeypatch.setattr(
+        mw_mod.QMessageBox, "question",
+        lambda *a, **k: QMessageBox.StandardButton.Yes,
+    )
+    monkeypatch.setattr(mw_mod.QMessageBox, "critical", lambda *a, **k: None)
+    monkeypatch.setattr(mw_mod.QMessageBox, "warning", lambda *a, **k: None)
+
+    win = mw_mod.MainWindow()
+    # Modell als "sofort bereit" behandeln: sonst haengt der Klick-Pfad in
+    # _wait_for_model_then_apply an einem Hintergrund-Timer, der beim
+    # Schliessen des Fensters nicht garantiert den Override-Cursor
+    # zuruecksetzt (siehe closeEvent) und so Folge-Tests verunreinigt.
+    monkeypatch.setattr(win.classifier, "is_model_ready", lambda: True)
+
+    yield win
+
+    win.close()
+    sip.delete(win)
+
+
+def _make_scan_folder(tmp_path: Path, names: list[str]) -> Path:
+    """Legt einen Scan-Ordner mit minimalen PDF-Dateien an."""
+    scan = tmp_path / "Scan"
+    scan.mkdir()
+    for name in names:
+        (scan / name).write_bytes(b"%PDF-1.4\n%%EOF\n")
+    return scan
+
+
+def _prime_cache(main_window, paths: list[Path]) -> None:
+    """Legt fuer jede PDF ein leeres Analyse-Ergebnis synchron in den Cache.
+
+    Ohne das wuerde ``update_suggestions_for_pdf`` bei jedem Klick einen
+    Hintergrund-Analyse-Worker anstossen (``request_analysis``) - fuer diese
+    Tests irrelevant und eine Quelle fuer Nebenlaeufigkeit/Testverunreinigung.
+    """
+    from src.core.pdf_cache import PDFAnalysisResult
+
+    for path in paths:
+        main_window.pdf_cache._cache[path] = PDFAnalysisResult(
+            pdf_path=path,
+            file_modified=path.stat().st_mtime,
+        )
+
+
+# --------------------------------------------------------------------- #
+# Einzelauswahl: move_pdf_to_folder_and_learn
+# --------------------------------------------------------------------- #
+
+
+def test_move_selects_next_pdf_in_same_grid_slot(main_window, fresh_singletons):
+    """Wird die ausgewaehlte PDF aus der Mitte weggeraeumt, ruckt die naechste
+    an dieselbe Rasterposition und wird automatisch ausgewaehlt."""
+    scan = _make_scan_folder(fresh_singletons["tmp_path"], ["a.pdf", "b.pdf", "c.pdf"])
+    ziel = fresh_singletons["tmp_path"] / "Ziel"
+    ziel.mkdir()
+    main_window._navigate_to_folder(scan)
+    assert len(main_window.pdf_widgets) == 3
+    _prime_cache(main_window, [w.pdf_path for w in main_window.pdf_widgets])
+
+    middle_path = main_window.pdf_widgets[1].pdf_path
+    remaining_path = main_window.pdf_widgets[2].pdf_path
+
+    main_window.on_pdf_clicked(middle_path)
+    assert main_window.selected_pdf == middle_path
+
+    main_window.move_pdf_to_folder_and_learn(middle_path, ziel)
+
+    assert len(main_window.pdf_widgets) == 2
+    assert main_window.selected_pdf == remaining_path
+    selected_widgets = [w for w in main_window.pdf_widgets if w.selected]
+    assert [w.pdf_path for w in selected_widgets] == [remaining_path]
+
+
+def test_move_last_pdf_selects_new_last_pdf(main_window, fresh_singletons):
+    """War die zuletzt im Raster stehende PDF ausgewaehlt, wird nach dem
+    Verschieben die neue letzte PDF ausgewaehlt."""
+    scan = _make_scan_folder(fresh_singletons["tmp_path"], ["a.pdf", "b.pdf", "c.pdf"])
+    ziel = fresh_singletons["tmp_path"] / "Ziel"
+    ziel.mkdir()
+    main_window._navigate_to_folder(scan)
+    _prime_cache(main_window, [w.pdf_path for w in main_window.pdf_widgets])
+
+    last_path = main_window.pdf_widgets[-1].pdf_path
+    new_last_path = main_window.pdf_widgets[-2].pdf_path
+
+    main_window.on_pdf_clicked(last_path)
+    main_window.move_pdf_to_folder_and_learn(last_path, ziel)
+
+    assert len(main_window.pdf_widgets) == 2
+    assert main_window.selected_pdf == new_last_path
+
+
+def test_move_last_remaining_pdf_clears_selection(main_window, fresh_singletons):
+    """Wird die einzige verbliebene PDF verschoben, bleibt die Auswahl leer
+    (kein Absturz, keine Phantom-Auswahl)."""
+    scan = _make_scan_folder(fresh_singletons["tmp_path"], ["a.pdf"])
+    ziel = fresh_singletons["tmp_path"] / "Ziel"
+    ziel.mkdir()
+    main_window._navigate_to_folder(scan)
+    _prime_cache(main_window, [w.pdf_path for w in main_window.pdf_widgets])
+
+    only_path = main_window.pdf_widgets[0].pdf_path
+    main_window.on_pdf_clicked(only_path)
+
+    main_window.move_pdf_to_folder_and_learn(only_path, ziel)
+
+    assert main_window.pdf_widgets == []
+    assert main_window.selected_pdf is None
+
+
+def test_move_non_selected_pdf_does_not_change_selection(main_window, fresh_singletons):
+    """Wird eine andere als die ausgewaehlte PDF verschoben (z.B. per
+    Kontextmenue), bleibt die aktuelle Auswahl unangetastet."""
+    scan = _make_scan_folder(fresh_singletons["tmp_path"], ["a.pdf", "b.pdf", "c.pdf"])
+    ziel = fresh_singletons["tmp_path"] / "Ziel"
+    ziel.mkdir()
+    main_window._navigate_to_folder(scan)
+    _prime_cache(main_window, [w.pdf_path for w in main_window.pdf_widgets])
+
+    selected_path = main_window.pdf_widgets[0].pdf_path
+    other_path = main_window.pdf_widgets[2].pdf_path
+
+    main_window.on_pdf_clicked(selected_path)
+    assert main_window.selected_pdf == selected_path
+
+    main_window.move_pdf_to_folder_and_learn(other_path, ziel)
+
+    assert len(main_window.pdf_widgets) == 2
+    assert main_window.selected_pdf == selected_path
+
+
+# --------------------------------------------------------------------- #
+# Mehrfachauswahl: move_multiple_pdfs_to_folder
+# --------------------------------------------------------------------- #
+
+
+def test_move_multiple_selects_next_after_batch(main_window, fresh_singletons):
+    """Bei Mehrfachauswahl reicht es, nach dem letzten entfernten Widget die
+    naechste PDF auszuwaehlen (Issue #75)."""
+    scan = _make_scan_folder(
+        fresh_singletons["tmp_path"], ["a.pdf", "b.pdf", "c.pdf", "d.pdf"]
+    )
+    ziel = fresh_singletons["tmp_path"] / "Ziel"
+    ziel.mkdir()
+    main_window._navigate_to_folder(scan)
+    assert len(main_window.pdf_widgets) == 4
+    _prime_cache(main_window, [w.pdf_path for w in main_window.pdf_widgets])
+
+    paths = [w.pdf_path for w in main_window.pdf_widgets]
+    # a, b als Mehrfachauswahl markieren; b ist die "aktive" (zuletzt
+    # angeklickte) PDF fuer Vorschlaege - siehe _update_selection_status.
+    main_window.on_pdf_clicked(paths[0])
+    main_window.on_pdf_ctrl_clicked(paths[1])
+    assert main_window.selected_pdf == paths[1]
+    assert set(main_window.selected_pdfs) == {paths[0], paths[1]}
+
+    main_window.move_multiple_pdfs_to_folder([paths[0], paths[1]], ziel)
+
+    assert len(main_window.pdf_widgets) == 2
+    assert main_window.selected_pdfs == []
+    # a und b werden entfernt; c und d ruecken nach - c steht jetzt an der
+    # Position, an der zuletzt b (die aktive Auswahl) stand.
+    assert main_window.selected_pdf == paths[2]
+
+
+def test_move_multiple_without_prior_selection_clears_as_before(main_window, fresh_singletons):
+    """War keine Einzelauswahl aktiv, bleibt das bisherige Verhalten (Auswahl
+    leer, Vorschlaege geleert) erhalten."""
+    scan = _make_scan_folder(fresh_singletons["tmp_path"], ["a.pdf", "b.pdf"])
+    ziel = fresh_singletons["tmp_path"] / "Ziel"
+    ziel.mkdir()
+    main_window._navigate_to_folder(scan)
+    paths = [w.pdf_path for w in main_window.pdf_widgets]
+
+    assert main_window.selected_pdf is None
+    main_window.move_multiple_pdfs_to_folder(list(paths), ziel)
+
+    assert main_window.pdf_widgets == []
+    assert main_window.selected_pdf is None
+    assert main_window.selected_pdfs == []


### PR DESCRIPTION
## Zusammenfassung
- Nach dem Wegsortieren einer PDF (Einzel- oder Mehrfachauswahl) wird automatisch die PDF an derselben Rasterposition ausgewaehlt, sofern die entfernte PDF die aktuell ausgewaehlte war.
- Die Auswahl laeuft ueber den normalen Klick-Pfad (`on_pdf_clicked`), damit Detail-Panel, Vorschlaege und Ordner-Highlights genauso aktualisiert werden wie bei einem echten Klick.
- Betrifft alle Verschiebe-Pfade, die `remove_pdf_widget` nutzen: `_move_rename_and_learn`, `move_pdf_to_folder_and_learn`, `on_pdf_move` sowie `move_multiple_pdfs_to_folder` (Mehrfachauswahl: Auswahl nach dem letzten entfernten Widget).
- `_undo_move` ist unveraendert (macht ohnehin einen vollen Refresh via `load_pdfs()`).

## Test plan
- [x] Neuer GUI-Test `tests/test_auto_next_after_move_gui.py` (pytest-qt): Auswahl rueckt bei Einzel- und Mehrfachauswahl korrekt nach, bleibt bei nicht-betroffener Auswahl unangetastet, wird bei letzter verbliebener PDF sauber geleert.
- [x] Volle Suite gruen: `pytest tests -q` -> 471 passed.

Closes #75