### PR TITLE
chore(release): v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-08-28
+
 ### Hinzugefuegt
 - **Integrierte PDF-Vorschau** (Issues #74, #76) auf Basis von QtPdf (Qts eigener,
   PDFium-basierter Viewer - kein Browser, kein QtWebEngine, kein eigener Renderer):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdf-sortier-meister"
-version = "0.18.0"
+version = "0.19.0"
 description = "Ein intelligentes Programm zum Sortieren und Umbenennen von gescannten PDF-Dokumenten"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,7 @@ from src.utils.single_instance import (
 from src.utils.explorer_integration import update_launcher_script
 
 # Versionsnummer zentral definiert
-__version__ = "0.18.0"
+__version__ = "0.19.0"
 
 
 def _apply_wizard_result(window, config):


### PR DESCRIPTION
Versions-Bump auf 0.19.0 (src/main.py, pyproject.toml), CHANGELOG-Abschnitt [0.19.0] - 2026-08-28. Inhalt: Update-Check (#73), integrierte PDF-Vorschau (#74/#76), Auto-Next (#75), Poe entfernt (#66), Wizard-Texte (#60/#67), LLM-Status-Fix (#65), KI-Zusammenfassung (Metadaten-Schluessel). 585 Tests gruen.