### PR TITLE
feat: Ollama-Empfehlung fuer Laptops ohne GPU, zentrale Modell-Tabelle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Hinzugefuegt
+- **Ollama-Empfehlung fuer Laptops ohne dedizierte GPU** (Issue #62): hat das
+  System genug Arbeitsspeicher (ab 16 GB, z.B. schneller Shared-RAM), empfiehlt
+  der Einrichtungs-Assistent jetzt `gemma3:1b` lokal als "moeglich, aber
+  langsamer" statt direkt auf Ollama Cloud zu verweisen; Ollama Cloud bleibt
+  als Alternative im Empfehlungstext genannt. Bei wenig Arbeitsspeicher bleibt
+  es bei der bisherigen Cloud-Empfehlung.
+- `docs/RELEASE_CHECKLISTE.md`: Ablauf fuer Releases mit Pflichtpunkt
+  "LLM-Modell-Empfehlungen pruefen" (Issue #63), in README verlinkt.
+
+### Geaendert
+- `src/utils/hardware.py`: Modell-Empfehlungstabelle (`MODEL_TIERS`,
+  `RAM_ONLY_MODEL`, `CLOUD_MODEL`) zu einer zentralen, kommentierten
+  Datenstruktur mit Pruefdatum (`MODEL_TIERS_CHECKED_ON`) zusammengefasst,
+  damit ein Update der LLM-Empfehlungen an einer Stelle passiert (Issue #63).
+
 ## [0.19.0] - 2026-08-28
 
 ### Hinzugefuegt

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ python run.py
 
 Architektur und Entscheidungen: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) ·
 Versionshistorie: [CHANGELOG.md](CHANGELOG.md) ·
+Release-Ablauf: [docs/RELEASE_CHECKLISTE.md](docs/RELEASE_CHECKLISTE.md) ·
 Offene Vorhaben: [Issues](https://github.com/Josi-create/PDF_Sortier_Meister/issues)
 
 ---

--- a/docs/RELEASE_CHECKLISTE.md
+++ b/docs/RELEASE_CHECKLISTE.md
@@ -1,0 +1,47 @@
+# Release-Checkliste
+
+Ablauf fuer einen neuen Release von PDF Sortier Meister (`vX.Y.Z`).
+
+## 1. Vorbereitung
+
+- [ ] Alle Feature-PRs fuer den Release sind gemergt (main ist gruen: CI auf
+      Windows und macOS laeuft durch).
+- [ ] **LLM-Modell-Empfehlungen pruefen** (`src/utils/hardware.py`, `MODEL_TIERS`
+      / `RAM_ONLY_MODEL` / `CLOUD_MODEL`): sind die empfohlenen Ollama-Modelle
+      noch aktuell (Ollama-Library, Downloadgroessen), gibt es neuere/bessere
+      Gemma-Generationen, ist `gpt-oss:120b` noch das sinnvolle Cloud-Default?
+      `MODEL_TIERS_CHECKED_ON` in `hardware.py` auf das heutige Datum setzen.
+      (Hintergrund: Issue #63 - Empfehlungen veralten schnell.)
+
+## 2. Release-Branch
+
+- [ ] Branch `release/vX.Y.Z` von main abzweigen.
+- [ ] Version bumpen:
+  - `src/main.py` - `__version__ = "X.Y.Z"`
+  - `pyproject.toml` - `version = "X.Y.Z"`
+- [ ] `CHANGELOG.md`: neuen Abschnitt `## [X.Y.Z] - JJJJ-MM-TT` mit den
+      Eintraegen aus `## [Unreleased]` fuellen (bestehende Unreleased-Eintraege
+      dorthin verschieben), `## [Unreleased]` leer stehen lassen.
+- [ ] PR `release/vX.Y.Z` -> `main` erstellen und mergen.
+
+## 3. Tag und Build
+
+- [ ] Annotierten Tag `vX.Y.Z` auf dem main-Merge-Commit setzen und pushen
+      (`git tag -a vX.Y.Z -m "..." && git push origin vX.Y.Z`).
+- [ ] `.github/workflows/release.yml` baut automatisch bei Tag-Push:
+      Windows-Setup.exe, win64-Zip, macOS-DMGs (arm64 + x86_64) - als
+      Draft-Release. Build in GitHub Actions abwarten.
+
+## 4. Release veroeffentlichen
+
+- [ ] Draft-Release pruefen, deutsche Release-Notes schreiben (Abschnitte
+      **Neu**, **Behoben**, **Fuer Beta-Tester**), Download-Links im Format
+      `releases/latest/download/...` verwenden.
+- [ ] Draft veroeffentlichen.
+
+## 5. Smoke-Test
+
+- [ ] Gebaute EXE (bzw. DMG) mit isoliertem APPDATA/HOME starten (frisches
+      Profil, kein bestehendes Config-/Datenbank-Verzeichnis) und den
+      Einrichtungs-Assistenten inkl. Ollama-Erkennung/-Empfehlung, Sortierung
+      und Beenden pruefen.

--- a/src/utils/hardware.py
+++ b/src/utils/hardware.py
@@ -27,7 +27,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Callable, NamedTuple, Optional
 
 
 @dataclass
@@ -47,15 +47,41 @@ class OllamaRecommendation:
     gpu: Optional[GpuInfo]         # die massgebliche Grafikkarte
 
 
-# (min. Grafikspeicher in MB, Modell, Downloadgroesse in GB)
+# ---------------------------------------------------------------------------
+# Modell-Empfehlungen - zuletzt geprueft am 2026-08-28.
+#
+# Ollama-Modelle veralten schnell (neue Gemma-/Llama-Generationen, andere
+# Downloadgroessen). Diese Tabelle ist die EINE Stelle, die bei einem Update
+# angepasst werden muss - siehe docs/RELEASE_CHECKLISTE.md ("LLM-Modell-
+# Empfehlungen pruefen"). ``recommend()`` liest ausschliesslich daraus.
+#
 # Gemma 3 ist mehrsprachig stark (Deutsch) und liefert stabiles JSON.
-MODEL_TIERS = [
-    (20000, "gemma3:27b", 17.0),
-    (10000, "gemma3:12b", 8.1),
-    (4000, "gemma3:4b", 3.3),
-]
-MIN_VRAM_MB = MODEL_TIERS[-1][0]
+# ---------------------------------------------------------------------------
+MODEL_TIERS_CHECKED_ON = "2026-08-28"
 
+
+class ModelTier(NamedTuple):
+    min_vram_mb: int      # ab dieser Grafikspeicher-Groesse (MB) empfohlen
+    model: str             # Ollama-Modellname
+    size_gb: float          # Downloadgroesse in GB
+
+
+# (min. Grafikspeicher in MB, Modell, Downloadgroesse in GB) - absteigend
+MODEL_TIERS = [
+    ModelTier(20000, "gemma3:27b", 17.0),
+    ModelTier(10000, "gemma3:12b", 8.1),
+    ModelTier(4000, "gemma3:4b", 3.3),
+]
+MIN_VRAM_MB = MODEL_TIERS[-1].min_vram_mb
+
+# Laptops/Desktops ohne dedizierte Grafikkarte, aber mit genug Arbeitsspeicher
+# (z.B. schneller DDR5-Shared-RAM): das kleinste Gemma-3-Modell laeuft auch
+# rein auf der CPU. Spuerbar langsamer als mit GPU, aber fuer gelegentliche
+# Nutzung brauchbar - daher "moeglich", nicht die Standardempfehlung.
+RAM_ONLY_MIN_RAM_MB = 16000
+RAM_ONLY_MODEL = ModelTier(RAM_ONLY_MIN_RAM_MB, "gemma3:1b", 0.8)
+
+# Modell fuer Ollama Cloud (kein lokaler Download, benoetigt API-Key).
 CLOUD_MODEL = "gpt-oss:120b"
 
 _INTEGRATED_PATTERNS = (
@@ -255,7 +281,9 @@ def recommend(gpus: list[GpuInfo], ram_mb: int = 0) -> OllamaRecommendation:
 
     Regeln:
     - keine dedizierte Grafikkarte (nur integrierte Grafik oder gar keine):
-      lokal nicht empfohlen -> Ollama Cloud
+      lokal nicht empfohlen -> Ollama Cloud, ausser es ist genug Arbeitsspeicher
+      vorhanden (RAM_ONLY_MIN_RAM_MB) - dann ist das kleinste Gemma-3-Modell
+      auf der CPU "moeglich, aber langsamer", mit Ollama Cloud als Alternative
     - dedizierte Karte mit weniger als 4 GB: ebenfalls Cloud
     - Intel Arc: von Ollama unter Windows nicht unterstuetzt -> Cloud
     - Apple Silicon: Unified Memory zaehlt als Grafikspeicher (Metal);
@@ -286,17 +314,35 @@ def recommend(gpus: list[GpuInfo], ram_mb: int = 0) -> OllamaRecommendation:
 
     if best is None:
         integrated = next((g for g in gpus if not g.dedicated), None)
-        if integrated:
+        gpu_desc = (
+            f"Nur integrierte Grafik erkannt ({integrated.name})" if integrated
+            else "Keine Grafikkarte erkannt"
+        )
+        if ram_mb >= RAM_ONLY_MIN_RAM_MB:
+            # Kein dediziertes VRAM, aber genug Arbeitsspeicher fuer das
+            # kleinste Gemma-3-Modell auf der CPU (z.B. Laptop mit schnellem
+            # Shared-RAM) - moeglich, aber deutlich langsamer als mit GPU.
             reason = (
-                f"Nur integrierte Grafik erkannt ({integrated.name}), die sich den "
-                f"Arbeitsspeicher teilt. Ein lokales Modell wuerde auf dem Prozessor "
-                f"laufen - pro Dokument dauert das oft eine Minute oder laenger."
+                f"{gpu_desc}, aber {_gb(ram_mb)} Arbeitsspeicher vorhanden. "
+                f"{RAM_ONLY_MODEL.model} laeuft auch ohne Grafikkarte auf dem "
+                f"Prozessor - moeglich, aber je nach Dokument spuerbar langsamer "
+                f"als mit GPU. Alternative: Ollama Cloud (keine Wartezeit, aber "
+                f"Dokumentinhalte werden dabei an ollama.com uebertragen)."
             )
-        else:
-            reason = (
-                "Keine Grafikkarte erkannt. Ein lokales Modell wuerde auf dem "
-                "Prozessor laufen - pro Dokument dauert das oft eine Minute oder laenger."
+            return OllamaRecommendation(
+                True, RAM_ONLY_MODEL.model, RAM_ONLY_MODEL.size_gb, reason, integrated
             )
+        reason = (
+            f"{gpu_desc}"
+            + (
+                ", die sich den Arbeitsspeicher teilt. Ein lokales Modell wuerde "
+                "auf dem Prozessor laufen - pro Dokument dauert das oft eine "
+                "Minute oder laenger."
+                if integrated else
+                ". Ein lokales Modell wuerde auf dem Prozessor laufen - pro "
+                "Dokument dauert das oft eine Minute oder laenger."
+            )
+        )
         return OllamaRecommendation(False, None, 0.0, reason, integrated)
 
     if best.vendor == "intel":

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -44,18 +44,44 @@ def test_parse_nvidia_smi():
     assert all(g.dedicated and g.vendor == "nvidia" for g in gpus)
 
 
-def test_no_gpu_recommends_cloud():
-    rec = recommend([], ram_mb=32000)
+def test_no_gpu_low_ram_recommends_cloud():
+    rec = recommend([], ram_mb=8000)
     assert rec.local_ok is False
     assert rec.model is None
     assert "Keine Grafikkarte" in rec.reason
 
 
-def test_integrated_only_recommends_cloud_even_with_much_ram():
-    rec = recommend([_gpu("Intel(R) UHD Graphics 770", 0, dedicated=False, vendor="intel")], ram_mb=65536)
+def test_no_gpu_high_ram_recommends_small_local_model():
+    """Laptop/Desktop ohne GPU, aber genug Shared-RAM (Issue #62): kleines
+    lokales Modell als moeglich, aber langsamer - mit Cloud als Alternative."""
+    rec = recommend([], ram_mb=32000)
+    assert rec.local_ok is True
+    assert rec.model == "gemma3:1b"
+    assert rec.model_size_gb > 0
+    assert "langsamer" in rec.reason
+    assert "Cloud" in rec.reason
+
+
+def test_integrated_only_low_ram_recommends_cloud():
+    rec = recommend([_gpu("Intel(R) UHD Graphics 770", 0, dedicated=False, vendor="intel")], ram_mb=8000)
     assert rec.local_ok is False
     assert "integrierte Grafik" in rec.reason
     assert rec.gpu.name.startswith("Intel")
+
+
+def test_integrated_only_high_ram_recommends_small_local_model():
+    rec = recommend([_gpu("Intel(R) UHD Graphics 770", 0, dedicated=False, vendor="intel")], ram_mb=32000)
+    assert rec.local_ok is True
+    assert rec.model == "gemma3:1b"
+    assert "Cloud" in rec.reason
+    assert rec.gpu.name.startswith("Intel")
+
+
+def test_no_ram_info_defaults_to_cloud():
+    """ram_mb=0 (nicht ermittelbar) darf nicht versehentlich die RAM-Stufe treffen."""
+    rec = recommend([])
+    assert rec.local_ok is False
+    assert rec.model is None
 
 
 def test_small_vram_recommends_cloud():


### PR DESCRIPTION
## Zusammenfassung
- Neue Empfehlungsstufe in `src/utils/hardware.py`: ohne dedizierte GPU, aber ab 16 GB RAM wird `gemma3:1b` lokal als "moeglich, aber langsamer" empfohlen, mit Ollama Cloud als genannter Alternative im Empfehlungstext; bei wenig RAM bleibt es bei Cloud (Issue #62). Wird ueber die bestehende `OllamaRecommendation`/Wizard-Anzeige (`setup_wizard.py`) automatisch sichtbar.
- Modell-Empfehlungstabelle (`MODEL_TIERS`, `RAM_ONLY_MODEL`, `CLOUD_MODEL`) zu einer zentralen, kommentierten Datenstruktur mit Pruefdatum (`MODEL_TIERS_CHECKED_ON`) zusammengefasst (Issue #63).
- Neu: `docs/RELEASE_CHECKLISTE.md` mit dem Release-Ablauf und Pflichtpunkt "LLM-Modell-Empfehlungen pruefen", in README verlinkt.
- CHANGELOG unter `[Unreleased]` ergaenzt.

## Test plan
- [x] `venv/Scripts/python.exe -m pytest tests -q -p no:cacheprovider` -> 588 passed
- [x] Neue/angepasste Tests in `tests/test_hardware.py` fuer die RAM-Stufe (mit/ohne integrierte GPU, niedriges/hohes RAM)

Closes #62
Closes #63