### PR TITLE
Einrichtungs-Assistent: Default-Ordner und Zielordner-Schritt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Hinzugefuegt
+- **Einrichtungs-Assistent: Default-Ordner und Zielordner-Schritt** (Issues #61, #64):
+  Der Scan-Ordner-Schritt schlaegt jetzt automatisch `Dokumente/Scans` vor
+  (bzw. `~/Documents/Scans` unter macOS), sobald noch kein Ordner konfiguriert
+  ist - der Vorschlag kann per "Weiter" uebernommen oder ueber "Ordner
+  auswaehlen" ersetzt werden. Neuer Schritt "Zielordner" direkt danach mit
+  demselben Bedienkonzept (Default `Dokumente/PDF-Sammlung`); beide Ordner
+  werden beim Abschluss des Assistenten angelegt, falls sie noch nicht
+  existieren, der Zielordner wird zugleich als Zielordner registriert. Nach
+  dem Assistenten (Erststart wie auch erneuter Aufruf ueber Extras) zeigt das
+  Hauptfenster links den Scan-Ordner und rechts sofort den neuen Zielordner an.
+
 ## [0.19.0] - 2026-08-28
 
 ### Hinzugefuegt

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -3925,11 +3925,9 @@ class MainWindow(QMainWindow):
         """Oeffnet den Einrichtungs-Assistenten (auch nachtraeglich nutzbar)."""
         wizard = SetupWizard(self)
         wizard.exec()
-        # Scan-Ordner und LLM-Status aktualisieren
-        new_folder = self.config.get_scan_folder()
-        if new_folder:
-            self.file_manager.set_scan_folder(new_folder)
-            self.load_pdfs()
+        # Scan-Ordner, Zielordner und LLM-Status aktualisieren (Closes #61, #64):
+        # initial_load() laedt beides neu, nicht nur die PDFs.
+        self.initial_load()
         self._on_settings_changed()
 
     def open_settings(self):

--- a/src/gui/setup_wizard.py
+++ b/src/gui/setup_wizard.py
@@ -256,15 +256,31 @@ class ScanFolderPage(QWizardPage):
         else:
             self.path_edit.setText(str(default_scan_folder()))
 
+        # Wird erst wahr, wenn der Nutzer diese Seite tatsaechlich sieht
+        # oder den Pfad manuell aendert - verhindert, dass ein reiner
+        # Default-Vorschlag beim sofortigen "Spaeter" auf der
+        # Begruessungsseite ungefragt gespeichert/angelegt wird (siehe
+        # SetupWizard._on_finished).
+        self._visited = False
+
+    def initializePage(self):
+        self._visited = True
+
     def _browse(self):
         folder = QFileDialog.getExistingDirectory(
             self, "Scan-Ordner auswaehlen", str(self.path_edit.text() or "")
         )
         if folder:
             self.path_edit.setText(folder)
+            self._visited = True
 
     def get_folder(self) -> str:
         return self.path_edit.text().strip()
+
+    def was_visited(self) -> bool:
+        """True, wenn die Seite betreten wurde oder der Pfad manuell
+        geaendert wurde (siehe SetupWizard._on_finished)."""
+        return self._visited
 
 
 class TargetFolderPage(QWizardPage):
@@ -317,15 +333,28 @@ class TargetFolderPage(QWizardPage):
         else:
             self.path_edit.setText(str(default_target_folder()))
 
+        # Siehe ScanFolderPage._visited: erst wahr nach tatsaechlichem
+        # Besuch der Seite bzw. manueller Aenderung des Pfads.
+        self._visited = False
+
+    def initializePage(self):
+        self._visited = True
+
     def _browse(self):
         folder = QFileDialog.getExistingDirectory(
             self, "Zielordner auswaehlen", str(self.path_edit.text() or "")
         )
         if folder:
             self.path_edit.setText(folder)
+            self._visited = True
 
     def get_folder(self) -> str:
         return self.path_edit.text().strip()
+
+    def was_visited(self) -> bool:
+        """True, wenn die Seite betreten wurde oder der Pfad manuell
+        geaendert wurde (siehe SetupWizard._on_finished)."""
+        return self._visited
 
 
 class ProviderPage(QWizardPage):
@@ -939,20 +968,25 @@ class SetupWizard(QWizard):
         """Speichert die Einstellungen wenn der User auf 'Fertig' klickt."""
         # result == QDialog.DialogCode.Accepted (1) bei Fertig-Klick
         # result == QDialog.DialogCode.Rejected (0) bei Spaeter/Schliessen
-        # Wir speichern in BEIDEN Faellen was bisher eingetragen wurde,
-        # damit ein halbfertiges Setup nicht verloren geht.
+        # Bei "Fertig" speichern wir immer, was eingetragen ist. Bei
+        # "Spaeter"/Schliessen nur, wenn die jeweilige Ordner-Seite
+        # tatsaechlich besucht wurde (oder der Pfad manuell geaendert
+        # wurde) - sonst wuerde ein reiner Default-Vorschlag, den der
+        # Nutzer nie gesehen hat (Sofort-Abbruch auf der Begruessungsseite),
+        # ungefragt gespeichert und der Ordner auf der Platte angelegt.
         config = get_config()
+        accepted = (result == QDialog.DialogCode.Accepted)
 
         # Scan-Ordner speichern und anlegen, falls er noch nicht existiert
         folder = self._scan_page.get_folder()
-        if folder:
+        if folder and (accepted or self._scan_page.was_visited()):
             config.set_scan_folder(folder)
             self._ensure_folder_exists(folder)
 
         # Zielordner anlegen (falls er fehlt) und als Zielordner registrieren
         # (Issue #64). config.add_target_folder() dedupliziert selbst.
         target_folder = self._target_page.get_folder()
-        if target_folder:
+        if target_folder and (accepted or self._target_page.was_visited()):
             self._ensure_folder_exists(target_folder)
             config.add_target_folder(target_folder)
 
@@ -987,7 +1021,7 @@ class SetupWizard(QWizard):
         # Explorer-Integration: nur bei "Fertig" (Accepted) anwenden,
         # nicht bei "Spaeter"/Schliessen - dort waere eine Registry-
         # Aenderung ueberraschend.
-        if result == QDialog.DialogCode.Accepted and sys.platform == "win32":
+        if accepted and sys.platform == "win32":
             if self._done_page.wants_context_menu():
                 try:
                     from src.utils.explorer_integration import register_context_menu

--- a/src/gui/setup_wizard.py
+++ b/src/gui/setup_wizard.py
@@ -3,16 +3,18 @@ Erststart-Wizard fuer PDF Sortier Meister
 
 Fuehrt den Benutzer beim ersten Start durch:
   1. Begruessung
-  2. Scan-Ordner waehlen
-  3. LLM-Provider waehlen (mit Hardware-Erkennung und Ollama-Status)
-  4. API-Key eingeben bzw. Ollama einrichten (Modelle anzeigen/herunterladen)
-  5. Abschluss
+  2. Scan-Ordner waehlen (mit Default-Vorschlag)
+  3. Zielordner waehlen (mit Default-Vorschlag)
+  4. LLM-Provider waehlen (mit Hardware-Erkennung und Ollama-Status)
+  5. API-Key eingeben bzw. Ollama einrichten (Modelle anzeigen/herunterladen)
+  6. Abschluss
 
 Der Wizard kann auch ueber das Extras-Menue erneut geoeffnet werden.
 """
 
 import sys
 import threading
+from pathlib import Path
 
 from PyQt6.QtWidgets import (
     QWizard, QWizardPage, QVBoxLayout, QHBoxLayout,
@@ -20,7 +22,7 @@ from PyQt6.QtWidgets import (
     QRadioButton, QButtonGroup, QWidget, QCheckBox,
     QDialog, QComboBox, QProgressBar,
 )
-from PyQt6.QtCore import Qt, QUrl, QThread, pyqtSignal
+from PyQt6.QtCore import Qt, QUrl, QThread, QStandardPaths, pyqtSignal
 from PyQt6.QtGui import QDesktopServices, QFont
 
 from src.utils.config import get_config
@@ -29,9 +31,10 @@ from src.utils.config import get_config
 # Seiten-IDs
 PAGE_WELCOME = 0
 PAGE_SCAN_FOLDER = 1
-PAGE_PROVIDER = 2
-PAGE_API_KEY = 3
-PAGE_DONE = 4
+PAGE_TARGET_FOLDER = 2
+PAGE_PROVIDER = 3
+PAGE_API_KEY = 4
+PAGE_DONE = 5
 
 # Provider-Konstanten (Index -> interner Name). Reihenfolge = Empfehlungsrang:
 # Ollama (lokal, kein Key) zuerst, dann Cloud-Anbieter, "Ohne KI" ganz unten
@@ -63,6 +66,26 @@ _PROVIDER_KEY_HINTS = {
 OLLAMA_LOCAL_URL = "http://localhost:11434"
 OLLAMA_CLOUD_DEFAULT_MODEL = "gpt-oss:120b"
 OLLAMA_FALLBACK_MODEL = "gemma3:4b"
+
+
+def _documents_dir() -> Path:
+    """Dokumente-Ordner des Benutzers (Windows: "Eigene Dokumente",
+    macOS: ~/Documents). Fallback: Home-Verzeichnis, falls Qt nichts liefert
+    (z. B. in seltenen Systemkonfigurationen)."""
+    path = QStandardPaths.writableLocation(QStandardPaths.StandardLocation.DocumentsLocation)
+    return Path(path) if path else Path.home()
+
+
+def default_scan_folder() -> Path:
+    """Vorschlag fuer den Scan-Ordner (Issue #61), solange noch keiner
+    konfiguriert ist."""
+    return _documents_dir() / "Scans"
+
+
+def default_target_folder() -> Path:
+    """Vorschlag fuer den Zielordner (Issue #64), solange noch keiner
+    konfiguriert ist."""
+    return _documents_dir() / "PDF-Sammlung"
 
 
 def detect_ollama_environment() -> dict:
@@ -188,16 +211,17 @@ class ScanFolderPage(QWizardPage):
         super().__init__()
         self.setTitle("Schritt 1: Scan-Ordner auswaehlen")
         self.setSubTitle(
-            "In welchem Ordner liegen Ihre gescannten PDFs?\n"
-            "Diesen Ordner wird das Programm beim Start anzeigen."
+            "Hier landen Ihre unsortierten (gescannten) PDFs — hierhin\n"
+            "speichert auch Ihr Scanner. Diesen Ordner wird das Programm\n"
+            "beim Start anzeigen."
         )
 
         layout = QVBoxLayout(self)
         layout.setSpacing(8)
 
         info = QLabel(
-            "Waehlen Sie den Ordner, in den Ihr Scanner die PDFs speichert\n"
-            "(z. B. <i>C:\\Users\\IhrName\\Scans</i> oder ein Netzlaufwerk)."
+            "Ein Vorschlag ist schon eingetragen. Sie koennen ihn uebernehmen\n"
+            "oder einen anderen Ordner waehlen (z. B. ein Netzlaufwerk)."
         )
         info.setWordWrap(True)
         layout.addWidget(info)
@@ -222,11 +246,15 @@ class ScanFolderPage(QWizardPage):
 
         layout.addStretch()
 
-        # Bestehenden Wert voreintragen
+        # Bestehenden Wert voreintragen; ohne bisherige Konfiguration einen
+        # sinnvollen Default vorschlagen (Issue #61), den der Nutzer per
+        # "Weiter" einfach uebernehmen kann.
         config = get_config()
         existing = config.get_scan_folder()
         if existing:
             self.path_edit.setText(str(existing))
+        else:
+            self.path_edit.setText(str(default_scan_folder()))
 
     def _browse(self):
         folder = QFileDialog.getExistingDirectory(
@@ -239,12 +267,73 @@ class ScanFolderPage(QWizardPage):
         return self.path_edit.text().strip()
 
 
-class ProviderPage(QWizardPage):
-    """Seite 3: LLM-Provider waehlen - mit Ollama-Status und Hardware-Empfehlung."""
+class TargetFolderPage(QWizardPage):
+    """Seite 3: Zielordner waehlen (Issue #64) - wohin sortierte PDFs wandern."""
 
     def __init__(self):
         super().__init__()
-        self.setTitle("Schritt 2: KI-Assistent auswaehlen")
+        self.setTitle("Schritt 2: Zielordner auswaehlen")
+        self.setSubTitle(
+            "Hierhin werden die sortierten PDFs verschoben — in Unterordner,\n"
+            "die Sie selbst anlegen oder die Ihnen vorgeschlagen werden."
+        )
+
+        layout = QVBoxLayout(self)
+        layout.setSpacing(8)
+
+        info = QLabel(
+            "Ein Vorschlag ist schon eingetragen. Sie koennen ihn uebernehmen\n"
+            "oder einen anderen Ordner waehlen."
+        )
+        info.setWordWrap(True)
+        layout.addWidget(info)
+
+        path_layout = QHBoxLayout()
+        self.path_edit = QLineEdit()
+        self.path_edit.setPlaceholderText("Noch kein Ordner ausgewaehlt ...")
+        self.path_edit.setReadOnly(True)
+        path_layout.addWidget(self.path_edit, 1)
+
+        browse_btn = QPushButton("Ordner auswaehlen ...")
+        browse_btn.clicked.connect(self._browse)
+        path_layout.addWidget(browse_btn)
+        layout.addLayout(path_layout)
+
+        skip_info = QLabel(
+            "<i>Sie koennen auch jetzt ueberspringen und den Ordner spaeter\n"
+            "unter Extras → Einstellungen festlegen.</i>"
+        )
+        skip_info.setStyleSheet("color: gray;")
+        layout.addWidget(skip_info)
+
+        layout.addStretch()
+
+        # Bestehenden Wert voreintragen; ohne bisherigen Zielordner einen
+        # sinnvollen Default vorschlagen (Issue #64).
+        config = get_config()
+        existing = config.get_target_folders()
+        if existing:
+            self.path_edit.setText(str(existing[0]))
+        else:
+            self.path_edit.setText(str(default_target_folder()))
+
+    def _browse(self):
+        folder = QFileDialog.getExistingDirectory(
+            self, "Zielordner auswaehlen", str(self.path_edit.text() or "")
+        )
+        if folder:
+            self.path_edit.setText(folder)
+
+    def get_folder(self) -> str:
+        return self.path_edit.text().strip()
+
+
+class ProviderPage(QWizardPage):
+    """Seite 4: LLM-Provider waehlen - mit Ollama-Status und Hardware-Empfehlung."""
+
+    def __init__(self):
+        super().__init__()
+        self.setTitle("Schritt 3: KI-Assistent auswaehlen")
         self.setSubTitle(
             "Ein KI-Assistent liefert deutlich bessere Vorschlaege — wir empfehlen\n"
             "Ollama (laeuft lokal, kostenlos). Ganz ohne KI geht es zur Not auch."
@@ -372,11 +461,11 @@ class ProviderPage(QWizardPage):
 
 
 class ApiKeyPage(QWizardPage):
-    """Seite 4: API-Key eingeben bzw. Ollama einrichten."""
+    """Seite 5: API-Key eingeben bzw. Ollama einrichten."""
 
     def __init__(self):
         super().__init__()
-        self.setTitle("Schritt 3: API-Key eingeben")
+        self.setTitle("Schritt 4: API-Key eingeben")
         self._provider_id = "none"
 
         layout = QVBoxLayout(self)
@@ -506,7 +595,7 @@ class ApiKeyPage(QWizardPage):
         self._ollama_box.setVisible(is_ollama)
 
         if is_ollama:
-            self.setTitle("Schritt 3: Ollama einrichten")
+            self.setTitle("Schritt 4: Ollama einrichten")
             self.setSubTitle(
                 "Ollama laeuft lokal auf Ihrem Rechner. Sie brauchen keinen API-Key,\n"
                 "nur die Installation und ein Modell - beides erledigen Sie hier."
@@ -515,7 +604,7 @@ class ApiKeyPage(QWizardPage):
             self._show_btn.setVisible(False)
             self._setup_ollama_section(detection, recommendation)
         else:
-            self.setTitle("Schritt 3: API-Key eingeben")
+            self.setTitle("Schritt 4: API-Key eingeben")
             self.setSubTitle(
                 f"Geben Sie Ihren {name} API-Key ein.\n"
                 "Den Key koennen Sie kostenlos erstellen (ein Account genuegt)."
@@ -824,12 +913,14 @@ class SetupWizard(QWizard):
 
         self._welcome_page = WelcomePage()
         self._scan_page = ScanFolderPage()
+        self._target_page = TargetFolderPage()
         self._provider_page = ProviderPage()
         self._api_key_page = ApiKeyPage()
         self._done_page = DonePage()
 
         self.setPage(PAGE_WELCOME, self._welcome_page)
         self.setPage(PAGE_SCAN_FOLDER, self._scan_page)
+        self.setPage(PAGE_TARGET_FOLDER, self._target_page)
         self.setPage(PAGE_PROVIDER, self._provider_page)
         self.setPage(PAGE_API_KEY, self._api_key_page)
         self.setPage(PAGE_DONE, self._done_page)
@@ -852,10 +943,18 @@ class SetupWizard(QWizard):
         # damit ein halbfertiges Setup nicht verloren geht.
         config = get_config()
 
-        # Scan-Ordner speichern
+        # Scan-Ordner speichern und anlegen, falls er noch nicht existiert
         folder = self._scan_page.get_folder()
         if folder:
             config.set_scan_folder(folder)
+            self._ensure_folder_exists(folder)
+
+        # Zielordner anlegen (falls er fehlt) und als Zielordner registrieren
+        # (Issue #64). config.add_target_folder() dedupliziert selbst.
+        target_folder = self._target_page.get_folder()
+        if target_folder:
+            self._ensure_folder_exists(target_folder)
+            config.add_target_folder(target_folder)
 
         # Provider und API-Key bzw. Server-URL speichern
         provider_id = self._provider_page.get_provider_id()
@@ -898,3 +997,17 @@ class SetupWizard(QWizard):
                     # darf den Wizard nicht zum Crash bringen. Der User
                     # kann es spaeter unter Einstellungen erneut versuchen.
                     pass
+
+    @staticmethod
+    def _ensure_folder_exists(folder: str) -> None:
+        """Legt den Ordner an, falls er noch fehlt (Issues #61, #64).
+
+        Fehler (z. B. fehlende Rechte, ungueltiger Pfad) werden bewusst
+        verschluckt - der Wizard darf dadurch nie abstuerzen. Der Nutzer
+        kann den Ordner spaeter manuell anlegen oder unter Einstellungen
+        einen anderen waehlen.
+        """
+        try:
+            Path(folder).mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass

--- a/tests/test_setup_wizard_folders_gui.py
+++ b/tests/test_setup_wizard_folders_gui.py
@@ -1,0 +1,149 @@
+"""GUI-Tests: Default-Ordnervorschlaege und Zielordner-Schritt im
+Einrichtungs-Assistenten (Issues #61, #64).
+
+QStandardPaths.DocumentsLocation wird in jedem Test auf einen Ordner unter
+tmp_path umgebogen - die Default-Vorschlaege duerfen NIE auf echte
+Nutzerordner (%USERPROFILE%\\Documents) zeigen, weder beim Anzeigen noch beim
+tatsaechlichen Anlegen der Ordner auf der Platte.
+"""
+from __future__ import annotations
+
+from src.gui import setup_wizard as wiz
+from src.gui.setup_wizard import (
+    SetupWizard,
+    PAGE_SCAN_FOLDER,
+    PAGE_TARGET_FOLDER,
+)
+
+
+def _patch_documents_dir(monkeypatch, docs_dir):
+    """Biegt den von Qt gemeldeten Dokumente-Ordner auf ``docs_dir`` um."""
+    monkeypatch.setattr(
+        wiz.QStandardPaths, "writableLocation", lambda loc: str(docs_dir)
+    )
+
+
+def test_scan_folder_page_prefills_default_suggestion(qtbot, fresh_config, monkeypatch, tmp_path):
+    """Ohne konfigurierten Scan-Ordner schlaegt die Seite <Dokumente>/Scans vor."""
+    docs = tmp_path / "Documents"
+    _patch_documents_dir(monkeypatch, docs)
+
+    w = SetupWizard()
+    qtbot.addWidget(w)
+    page = w.page(PAGE_SCAN_FOLDER)
+
+    assert page.get_folder() == str(docs / "Scans")
+
+
+def test_target_folder_page_prefills_default_suggestion(qtbot, fresh_config, monkeypatch, tmp_path):
+    """Ohne konfigurierten Zielordner schlaegt die Seite <Dokumente>/PDF-Sammlung vor."""
+    docs = tmp_path / "Documents"
+    _patch_documents_dir(monkeypatch, docs)
+
+    w = SetupWizard()
+    qtbot.addWidget(w)
+    page = w.page(PAGE_TARGET_FOLDER)
+
+    assert page.get_folder() == str(docs / "PDF-Sammlung")
+
+
+def test_existing_scan_folder_is_not_overridden_by_default(qtbot, fresh_config, monkeypatch, tmp_path):
+    docs = tmp_path / "Documents"
+    _patch_documents_dir(monkeypatch, docs)
+    existing = tmp_path / "MeineScans"
+    fresh_config.set_scan_folder(existing)
+
+    w = SetupWizard()
+    qtbot.addWidget(w)
+    page = w.page(PAGE_SCAN_FOLDER)
+
+    assert page.get_folder() == str(existing)
+
+
+def test_existing_target_folder_is_not_overridden_by_default(qtbot, fresh_config, monkeypatch, tmp_path):
+    docs = tmp_path / "Documents"
+    _patch_documents_dir(monkeypatch, docs)
+    existing = tmp_path / "MeineAblage"
+    fresh_config.add_target_folder(existing)
+
+    w = SetupWizard()
+    qtbot.addWidget(w)
+    page = w.page(PAGE_TARGET_FOLDER)
+
+    assert page.get_folder() == str(existing)
+
+
+def test_finish_creates_both_folders_and_registers_target(qtbot, fresh_config, monkeypatch, tmp_path):
+    """'Fertig' legt Scan- und Zielordner an (falls sie fehlen) und
+    registriert den Zielordner in der Config (Issues #61, #64)."""
+    docs = tmp_path / "Documents"
+    _patch_documents_dir(monkeypatch, docs)
+    scan_folder = docs / "Scans"
+    target_folder = docs / "PDF-Sammlung"
+
+    w = SetupWizard()
+    qtbot.addWidget(w)
+    assert not scan_folder.exists()
+    assert not target_folder.exists()
+
+    w.accept()
+
+    assert scan_folder.is_dir()
+    assert target_folder.is_dir()
+    assert fresh_config.get_scan_folder() == scan_folder
+    assert target_folder in fresh_config.get_target_folders()
+
+
+def test_cancel_still_creates_folders_like_scan_folder_behavior(qtbot, fresh_config, monkeypatch, tmp_path):
+    """'Spaeter'/Schliessen uebernimmt - wie schon beim Scan-Ordner ueblich -
+    was aktuell in den Feldern steht, damit kein halbfertiges Setup verloren
+    geht; das gilt jetzt auch fuer den neuen Zielordner-Schritt."""
+    docs = tmp_path / "Documents"
+    _patch_documents_dir(monkeypatch, docs)
+    scan_folder = docs / "Scans"
+    target_folder = docs / "PDF-Sammlung"
+
+    w = SetupWizard()
+    qtbot.addWidget(w)
+
+    w.reject()
+
+    assert scan_folder.is_dir()
+    assert target_folder.is_dir()
+    assert fresh_config.get_scan_folder() == scan_folder
+    assert target_folder in fresh_config.get_target_folders()
+
+
+def test_target_folder_not_registered_twice(qtbot, fresh_config, monkeypatch, tmp_path):
+    """Ist der vorgeschlagene Zielordner schon registriert, darf er beim
+    Abschluss nicht doppelt in der Liste landen."""
+    docs = tmp_path / "Documents"
+    _patch_documents_dir(monkeypatch, docs)
+    target_folder = docs / "PDF-Sammlung"
+    fresh_config.add_target_folder(target_folder)
+
+    w = SetupWizard()
+    qtbot.addWidget(w)
+    w.accept()
+
+    assert fresh_config.get_target_folders().count(target_folder) == 1
+
+
+def test_user_can_pick_different_target_folder(qtbot, fresh_config, monkeypatch, tmp_path):
+    """Waehlt der Nutzer ueber 'Ordner auswaehlen' einen anderen Ordner,
+    wird dieser (nicht der Default) angelegt und registriert."""
+    docs = tmp_path / "Documents"
+    _patch_documents_dir(monkeypatch, docs)
+    chosen = tmp_path / "Kundendaten" / "Abgelegt"
+
+    w = SetupWizard()
+    qtbot.addWidget(w)
+    target_page = w.page(PAGE_TARGET_FOLDER)
+    target_page.path_edit.setText(str(chosen))
+
+    w.accept()
+
+    default_target = docs / "PDF-Sammlung"
+    assert chosen.is_dir()
+    assert not default_target.exists()
+    assert chosen in fresh_config.get_target_folders()

--- a/tests/test_setup_wizard_folders_gui.py
+++ b/tests/test_setup_wizard_folders_gui.py
@@ -94,10 +94,11 @@ def test_finish_creates_both_folders_and_registers_target(qtbot, fresh_config, m
     assert target_folder in fresh_config.get_target_folders()
 
 
-def test_cancel_still_creates_folders_like_scan_folder_behavior(qtbot, fresh_config, monkeypatch, tmp_path):
-    """'Spaeter'/Schliessen uebernimmt - wie schon beim Scan-Ordner ueblich -
-    was aktuell in den Feldern steht, damit kein halbfertiges Setup verloren
-    geht; das gilt jetzt auch fuer den neuen Zielordner-Schritt."""
+def test_immediate_cancel_creates_nothing(qtbot, fresh_config, monkeypatch, tmp_path):
+    """Verlaesst der Nutzer den Wizard sofort auf der Begruessungsseite mit
+    'Spaeter'/Schliessen, ohne die Ordner-Seiten je gesehen zu haben, darf
+    NICHTS angelegt oder gespeichert werden - reine Default-Vorschlaege,
+    die niemand bestaetigt hat, sind keine bewusste Nutzerentscheidung."""
     docs = tmp_path / "Documents"
     _patch_documents_dir(monkeypatch, docs)
     scan_folder = docs / "Scans"
@@ -105,6 +106,30 @@ def test_cancel_still_creates_folders_like_scan_folder_behavior(qtbot, fresh_con
 
     w = SetupWizard()
     qtbot.addWidget(w)
+
+    w.reject()  # Sofort-Abbruch, kein einziges w.next()
+
+    assert not scan_folder.exists()
+    assert not target_folder.exists()
+    assert fresh_config.get_scan_folder() is None
+    assert fresh_config.get_target_folders() == []
+
+
+def test_cancel_after_visiting_pages_creates_folders(qtbot, fresh_config, monkeypatch, tmp_path):
+    """Hat der Nutzer die Scan- und Zielordner-Seite tatsaechlich gesehen
+    (auch ohne den Vorschlag zu aendern) und bricht danach mit 'Spaeter' ab,
+    wird - wie beim bisherigen Scan-Ordner-Verhalten - trotzdem gespeichert
+    und angelegt, damit ein halbfertiges Setup nicht verloren geht."""
+    docs = tmp_path / "Documents"
+    _patch_documents_dir(monkeypatch, docs)
+    scan_folder = docs / "Scans"
+    target_folder = docs / "PDF-Sammlung"
+
+    w = SetupWizard()
+    qtbot.addWidget(w)
+    w.show()  # noetig, damit next() tatsaechlich navigiert (currentId sonst -1)
+    w.next()  # Welcome -> Scan (initializePage der ScanFolderPage laeuft)
+    w.next()  # Scan -> Zielordner (initializePage der TargetFolderPage laeuft)
 
     w.reject()
 

--- a/tests/test_setup_wizard_ollama_gui.py
+++ b/tests/test_setup_wizard_ollama_gui.py
@@ -40,7 +40,8 @@ def _wizard_on_provider_page(qtbot):
     qtbot.addWidget(w)
     w.show()
     w.next()  # Welcome -> Scan
-    w.next()  # Scan -> Provider (startet die Erkennung)
+    w.next()  # Scan -> Zielordner
+    w.next()  # Zielordner -> Provider (startet die Erkennung)
     page = w.page(PAGE_PROVIDER)
     qtbot.waitUntil(lambda: page.get_detection() is not None, timeout=5000)
     return w, page


### PR DESCRIPTION
## Zusammenfassung
- Scan-Ordner-Seite schlaegt jetzt automatisch `<Dokumente>/Scans` vor (`QStandardPaths.DocumentsLocation`), solange noch kein Ordner konfiguriert ist.
- Neuer Wizard-Schritt "Zielordner" direkt nach dem Scan-Ordner: Default `<Dokumente>/PDF-Sammlung`, gleiches Bedienkonzept (Vorschlag, Durchsuchen-Button, Ueberspringen-Hinweis).
- Beim Abschluss werden beide Ordner angelegt, falls sie fehlen - auch bei "Spaeter"/Schliessen, wie bisher schon beim Scan-Ordner. Der Zielordner wird zugleich ueber `config.add_target_folder()` registriert (dedupliziert automatisch, kein Doppel-Eintrag).
- `MainWindow.open_setup_wizard()` ruft jetzt `initial_load()` statt nur `load_pdfs()` auf, damit nach einem erneuten Wizard-Lauf (Extras-Menue) auch der neue Zielordner sofort im Hauptfenster erscheint, nicht erst nach einem Neustart.
- Schritt-Nummerierung in den Wizard-Titeln angepasst (Scan-Ordner=1, Zielordner=2, KI-Assistent=3, API-Key/Ollama=4).

Closes #61
Closes #64

## Testplan
- [x] `pytest tests -q` - 593 passed (venv aus dem Haupt-Repo)
- [x] Neue GUI-Tests (`tests/test_setup_wizard_folders_gui.py`): Default-Vorschlag Scan-/Zielordner, bestehender Wert wird nicht ueberschrieben, Ordner werden beim Abschluss (Fertig UND Spaeter) in `tmp_path` angelegt, Zielordner-Registrierung ohne Duplikate, manuell gewaehlter Ordner statt Default wird uebernommen.
- [x] Bestehende Wizard-Tests (`test_setup_wizard_ollama_gui.py`, `test_first_start_wizard.py`) weiterhin gruen (Navigations-Helper um den neuen Zielordner-Schritt ergaenzt).