### PR TITLE
feat: Aktivitaetsanzeige fuer KI-Aufrufe mit Uhr und Schaetzung (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Hinzugefuegt
+- **Aktivitaetsanzeige fuer KI-Aufrufe** (Issue #68): Solange die KI arbeitet, zeigt
+  die Statusleiste eine vorwaerts laufende Uhr ("KI arbeitet „rechnung.pdf“ seit 0:42")
+  und - sobald Erfahrungswerte fuer dasselbe Provider/Modell-Setting vorliegen - eine
+  Schaetzung ("ca. 30 s", Median der letzten 20 Aufrufe, gespeichert in
+  `llm_timing.json` im Datenverzeichnis). Dasselbe im Chat ("KI denkt… seit 0:05 ·
+  ca. 20 s") und auf dem Button "KI-Metadaten neu generieren".
+- "KI-Metadaten neu generieren" laeuft jetzt im Hintergrund - vorher fror das Fenster
+  fuer die Dauer der Anfrage ein (Kern: `src/core/llm_activity.py`).
+
 ## [0.19.0] - 2026-08-28
 
 ### Hinzugefuegt

--- a/src/core/llm_activity.py
+++ b/src/core/llm_activity.py
@@ -1,0 +1,241 @@
+"""
+Aktivitaetsanzeige fuer KI-Aufrufe (Issue #68).
+
+Beta-Feedback: Auf langsamen Rechnern oder bei haengender Cloud-Verbindung
+muss sichtbar sein, dass der Computer arbeitet - eine Sanduhr reicht nicht.
+Gewuenscht: eine vorwaerts laufende Uhr ("KI denkt seit 0:42") und, wenn
+moeglich, eine Schaetzung aus frueheren Anfragen mit demselben Setting.
+
+Zwei Bausteine:
+
+* ``LLMTimingStore`` merkt sich die Dauer abgeschlossener Aufrufe je
+  Schluessel ``provider|modell|art`` (die letzten 20) in einer JSON-Datei im
+  Datenverzeichnis und liefert daraus den Median als Schaetzung.
+* ``LLMActivity`` ist der prozessweite Zaehler laufender Aufrufe. Worker
+  melden ``begin()``/``end()``; die GUI haengt sich an ``changed`` und tickt
+  waehrenddessen einmal pro Sekunde ihre Anzeige.
+
+Aufrufe kommen aus Worker-Threads - alle Zugriffe sind per Lock geschuetzt,
+das Signal wird von Qt in den GUI-Thread gequeued.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import statistics
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from PyQt6.QtCore import QObject, pyqtSignal
+
+logger = logging.getLogger("pdf_sortier_meister.llm_activity")
+
+MAX_SAMPLES = 20
+MIN_SAMPLES_FOR_ESTIMATE = 2
+TIMING_FILENAME = "llm_timing.json"
+
+# Arten von Aufrufen (Teil des Schluessels, weil ein Chat mit Kontext
+# deutlich laenger dauert als ein Namensvorschlag)
+KIND_SUGGEST = "suggest"
+KIND_CHAT = "chat"
+
+
+def format_elapsed(seconds: float) -> str:
+    """0:07, 0:42, 1:05, 12:30 - Minuten:Sekunden, vorwaerts zaehlend."""
+    total = max(0, int(seconds))
+    minutes, secs = divmod(total, 60)
+    return f"{minutes}:{secs:02d}"
+
+
+def format_estimate(seconds: float | None) -> str:
+    """'ca. 30 s' bzw. 'ca. 1:30 min'; leer, wenn keine Schaetzung vorliegt."""
+    if seconds is None or seconds <= 0:
+        return ""
+    if seconds < 60:
+        return f"ca. {max(1, int(round(seconds)))} s"
+    return f"ca. {format_elapsed(seconds)} min"
+
+
+def timing_key(provider: str, model: str, kind: str) -> str:
+    return f"{provider or 'none'}|{model or '-'}|{kind}"
+
+
+def current_timing_key(kind: str) -> str:
+    """Schluessel fuer das aktuell konfigurierte Provider/Modell-Setting."""
+    try:
+        from src.utils.config import get_config
+
+        llm = get_config().get_llm_config()
+        return timing_key(llm.get("provider", "none"), llm.get("model", ""), kind)
+    except Exception:  # noqa: BLE001 - Anzeige darf nie am Config-Zugriff scheitern
+        return timing_key("none", "", kind)
+
+
+class LLMTimingStore:
+    """Dauern abgeschlossener Aufrufe je Setting, persistent als JSON."""
+
+    def __init__(self, path: Path | None = None):
+        self._path = Path(path) if path else None
+        self._lock = threading.Lock()
+        self._data: dict[str, list[float]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self._path or not self._path.exists():
+            return
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                self._data = {
+                    str(k): [float(x) for x in v][-MAX_SAMPLES:]
+                    for k, v in raw.items()
+                    if isinstance(v, list)
+                }
+        except (OSError, ValueError) as e:
+            logger.warning("KI-Zeitstatistik konnte nicht gelesen werden: %s", e)
+
+    def _save(self) -> None:
+        if not self._path:
+            return
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(json.dumps(self._data), encoding="utf-8")
+        except OSError as e:
+            logger.warning("KI-Zeitstatistik konnte nicht gespeichert werden: %s", e)
+
+    def record(self, key: str, seconds: float) -> None:
+        if seconds <= 0:
+            return
+        with self._lock:
+            samples = self._data.setdefault(key, [])
+            samples.append(round(float(seconds), 3))
+            del samples[:-MAX_SAMPLES]
+            self._save()
+
+    def samples(self, key: str) -> list[float]:
+        with self._lock:
+            return list(self._data.get(key, []))
+
+    def estimate(self, key: str) -> float | None:
+        """Median der letzten Dauern - robust gegen einzelne Ausreisser."""
+        samples = self.samples(key)
+        if len(samples) < MIN_SAMPLES_FOR_ESTIMATE:
+            return None
+        return float(statistics.median(samples))
+
+
+@dataclass
+class LLMJob:
+    token: int
+    kind: str
+    label: str
+    key: str
+    # perf_counter statt monotonic: Letzteres hat unter Windows nur ~16 ms
+    # Aufloesung, sehr kurze Aufrufe kaemen als 0 s in die Statistik.
+    started: float = field(default_factory=time.perf_counter)
+
+    @property
+    def elapsed(self) -> float:
+        return time.perf_counter() - self.started
+
+
+class LLMActivity(QObject):
+    """Prozessweiter Zaehler laufender KI-Aufrufe.
+
+    Signals:
+        changed(): ein Aufruf hat begonnen oder geendet (auch aus Worker-Threads)
+    """
+
+    changed = pyqtSignal()
+
+    def __init__(self, store: LLMTimingStore | None = None, parent=None):
+        super().__init__(parent)
+        self._store = store or LLMTimingStore()
+        self._lock = threading.Lock()
+        self._jobs: dict[int, LLMJob] = {}
+        self._next_token = 1
+
+    @property
+    def store(self) -> LLMTimingStore:
+        return self._store
+
+    def begin(self, kind: str, label: str = "", key: str | None = None) -> int:
+        """Meldet einen startenden Aufruf; Rueckgabe ist das Token fuer ``end``."""
+        job_key = key or current_timing_key(kind)
+        with self._lock:
+            token = self._next_token
+            self._next_token += 1
+            self._jobs[token] = LLMJob(token=token, kind=kind, label=label, key=job_key)
+        self.changed.emit()
+        return token
+
+    def end(self, token: int, success: bool = True) -> float | None:
+        """Beendet einen Aufruf; erfolgreiche Dauern fliessen in die Schaetzung."""
+        with self._lock:
+            job = self._jobs.pop(token, None)
+        if job is None:
+            return None
+        elapsed = job.elapsed
+        if success:
+            self._store.record(job.key, elapsed)
+        self.changed.emit()
+        return elapsed
+
+    def jobs(self) -> list[LLMJob]:
+        with self._lock:
+            return sorted(self._jobs.values(), key=lambda j: j.started)
+
+    def is_busy(self) -> bool:
+        with self._lock:
+            return bool(self._jobs)
+
+    def estimate(self, kind: str, key: str | None = None) -> float | None:
+        return self._store.estimate(key or current_timing_key(kind))
+
+    def describe(self, kind: str | None = None) -> str:
+        """Kurztext fuer die Statusleiste, z.B. 'seit 0:42 · ca. 30 s'.
+
+        Bei mehreren laufenden Aufrufen zaehlt der aelteste.
+        """
+        jobs = [j for j in self.jobs() if kind is None or j.kind == kind]
+        if not jobs:
+            return ""
+        job = jobs[0]
+        text = f"seit {format_elapsed(job.elapsed)}"
+        estimate = format_estimate(self._store.estimate(job.key))
+        if estimate:
+            text += f" · {estimate}"
+        return text
+
+
+_activity: LLMActivity | None = None
+_activity_lock = threading.Lock()
+
+
+def _default_store() -> LLMTimingStore:
+    try:
+        from src.utils.platform_paths import get_app_data_dir
+
+        return LLMTimingStore(get_app_data_dir() / TIMING_FILENAME)
+    except Exception as e:  # noqa: BLE001 - dann eben ohne Persistenz
+        logger.warning("KI-Zeitstatistik ohne Datei (Datenverzeichnis nicht erreichbar): %s", e)
+        return LLMTimingStore(None)
+
+
+def get_llm_activity() -> LLMActivity:
+    """Prozessweite Instanz (lazy)."""
+    global _activity
+    with _activity_lock:
+        if _activity is None:
+            _activity = LLMActivity(_default_store())
+        return _activity
+
+
+def reset_llm_activity(store: LLMTimingStore | None = None) -> LLMActivity:
+    """Fuer Tests: neue Instanz mit eigenem (z.B. temporaerem) Store."""
+    global _activity
+    with _activity_lock:
+        _activity = LLMActivity(store or LLMTimingStore(None))
+        return _activity

--- a/src/core/llm_activity.py
+++ b/src/core/llm_activity.py
@@ -224,12 +224,30 @@ def _default_store() -> LLMTimingStore:
         return LLMTimingStore(None)
 
 
+def _bind_to_main_thread(activity: LLMActivity) -> None:
+    """QObject in den GUI-Thread verschieben, egal welcher Thread es anlegt.
+
+    Der erste Aufruf kommt oft aus einem Worker-Thread (Pre-Cache); ein
+    QObject mit Affinitaet zu einem spaeter beendeten Thread darf weder
+    Signale queuen noch aus dem Hauptthread geloescht werden (Abort auf macOS).
+    """
+    try:
+        from PyQt6.QtCore import QCoreApplication
+
+        app = QCoreApplication.instance()
+        if app is not None and activity.thread() is not app.thread():
+            activity.moveToThread(app.thread())
+    except Exception:  # noqa: BLE001 - ohne QApplication (reine Unit-Tests) egal
+        pass
+
+
 def get_llm_activity() -> LLMActivity:
     """Prozessweite Instanz (lazy)."""
     global _activity
     with _activity_lock:
         if _activity is None:
             _activity = LLMActivity(_default_store())
+            _bind_to_main_thread(_activity)
         return _activity
 
 
@@ -238,4 +256,5 @@ def reset_llm_activity(store: LLMTimingStore | None = None) -> LLMActivity:
     global _activity
     with _activity_lock:
         _activity = LLMActivity(store or LLMTimingStore(None))
+        _bind_to_main_thread(_activity)
         return _activity

--- a/src/core/pdf_cache.py
+++ b/src/core/pdf_cache.py
@@ -21,6 +21,8 @@ from typing import Optional, Callable
 
 from PyQt6.QtCore import QThread, pyqtSignal, QObject
 
+from src.core.llm_activity import KIND_SUGGEST, get_llm_activity
+
 logger = logging.getLogger("pdf_sortier_meister.cache")
 
 
@@ -207,7 +209,6 @@ class LLMSuggestionWorker(QThread):
                     logger.debug(f"LLM-Pre-Cache: Rufe LLM ab für {pdf_path.name}...")
                     # Aktivitaetsanzeige (Issue #68): laufenden Aufruf melden,
                     # Dauer fliesst in die Schaetzung fuer die Statusleiste.
-                    from src.core.llm_activity import KIND_SUGGEST, get_llm_activity
                     activity = get_llm_activity()
                     activity_token = activity.begin(KIND_SUGGEST, pdf_path.name)
                     llm_ok = False

--- a/src/core/pdf_cache.py
+++ b/src/core/pdf_cache.py
@@ -205,14 +205,24 @@ class LLMSuggestionWorker(QThread):
                         detected_date = str(analysis_result.dates[0])
 
                     logger.debug(f"LLM-Pre-Cache: Rufe LLM ab für {pdf_path.name}...")
-                    suggestions = self._hybrid_classifier.suggest_filename(
-                        text=analysis_result.extracted_text or "",
-                        current_filename=pdf_path.name,
-                        keywords=analysis_result.keywords,
-                        detected_date=detected_date,
-                        use_llm=True,
-                        file_date=file_date,
-                    )
+                    # Aktivitaetsanzeige (Issue #68): laufenden Aufruf melden,
+                    # Dauer fliesst in die Schaetzung fuer die Statusleiste.
+                    from src.core.llm_activity import KIND_SUGGEST, get_llm_activity
+                    activity = get_llm_activity()
+                    activity_token = activity.begin(KIND_SUGGEST, pdf_path.name)
+                    llm_ok = False
+                    try:
+                        suggestions = self._hybrid_classifier.suggest_filename(
+                            text=analysis_result.extracted_text or "",
+                            current_filename=pdf_path.name,
+                            keywords=analysis_result.keywords,
+                            detected_date=detected_date,
+                            use_llm=True,
+                            file_date=file_date,
+                        )
+                        llm_ok = True
+                    finally:
+                        activity.end(activity_token, success=llm_ok)
 
                     # Nur LLM-Vorschläge behalten (nicht lokale)
                     llm_suggestions = []

--- a/src/gui/chat_view.py
+++ b/src/gui/chat_view.py
@@ -13,6 +13,8 @@ MIT License - Copyright (c) 2026
 from html import escape
 from typing import Optional
 
+import time
+
 from PyQt6.QtCore import Qt, QThread, QTimer, pyqtSignal
 from PyQt6.QtGui import QKeyEvent
 from PyQt6.QtWidgets import (
@@ -106,6 +108,12 @@ class ChatView(QWidget):
         # Referenzen auf Thread + Worker, damit sie nicht vom GC
         # eingesammelt werden, solange der Aufruf laeuft (Architektur R3).
         self._chat_thread: Optional[QThread] = None
+        # Laufende Uhr in der Statuszeile waehrend eines KI-Aufrufs (Issue #68)
+        self._status_timer = QTimer(self)
+        self._status_timer.setInterval(1000)
+        self._status_timer.timeout.connect(self._tick_status)
+        self._status_base = ""
+        self._request_started = None
         self._chat_worker: Optional[ChatWorker] = None
 
         self._build_ui()
@@ -331,7 +339,10 @@ class ChatView(QWidget):
         self.send_btn.setEnabled(True)
         self.send_btn.setText("Abbrechen")
         self.reset_btn.setEnabled(False)
-        self.status_label.setText("Suche läuft…")
+        self._status_base = "Suche läuft…"
+        self._request_started = time.monotonic()
+        self._tick_status()
+        self._status_timer.start()
 
         # Thread + Worker aufsetzen (moveToThread-Pattern)
         self._chat_thread = QThread()
@@ -347,7 +358,22 @@ class ChatView(QWidget):
 
     def _on_worker_progress(self, message: str) -> None:
         """Aktualisiert die Status-Zeile waehrend des Aufrufs."""
-        self.status_label.setText(message)
+        self._status_base = message
+        self._tick_status()
+
+    def _tick_status(self) -> None:
+        """Statuszeile mit laufender Uhr und Schaetzung (Issue #68)."""
+        if self._request_started is None:
+            return
+        from src.core.llm_activity import (
+            KIND_CHAT, format_elapsed, format_estimate, get_llm_activity,
+        )
+        elapsed = time.monotonic() - self._request_started
+        text = f"{self._status_base} seit {format_elapsed(elapsed)}"
+        estimate = format_estimate(get_llm_activity().estimate(KIND_CHAT))
+        if estimate:
+            text += f" · {estimate}"
+        self.status_label.setText(text)
 
     def _on_worker_finished(self, response) -> None:
         """Rendert die Antwort und raeumt den Thread auf."""
@@ -481,6 +507,8 @@ class ChatView(QWidget):
 
     def _teardown_thread(self) -> None:
         """Stoppt den QThread und gibt die Referenzen frei."""
+        self._status_timer.stop()
+        self._request_started = None
         thread = self._chat_thread
         worker = self._chat_worker
         self._chat_thread = None

--- a/src/gui/chat_worker.py
+++ b/src/gui/chat_worker.py
@@ -70,8 +70,17 @@ class ChatWorker(QObject):
             return
         self.started.emit()
         try:
-            self.progress.emit("LLM antwortet…")
-            response = self.controller.ask(self.question)
+            self.progress.emit("KI denkt…")
+            # Aktivitaetsanzeige (Issue #68)
+            from src.core.llm_activity import KIND_CHAT, get_llm_activity
+            activity = get_llm_activity()
+            token = activity.begin(KIND_CHAT, self.question[:40])
+            ok = False
+            try:
+                response = self.controller.ask(self.question)
+                ok = True
+            finally:
+                activity.end(token, success=ok)
         except Exception as exc:  # noqa: BLE001 - Fehler an GUI melden
             if not self._cancelled and not self._failed_emitted:
                 self._failed_emitted = True

--- a/src/gui/chat_worker.py
+++ b/src/gui/chat_worker.py
@@ -14,6 +14,8 @@ import threading
 
 from PyQt6.QtCore import QObject, pyqtSignal, pyqtSlot
 
+from src.core.llm_activity import KIND_CHAT, get_llm_activity
+
 
 class ChatWorker(QObject):
     """Asynchroner LLM-/Retrieval-Aufruf ohne UI-Freeze.
@@ -72,7 +74,6 @@ class ChatWorker(QObject):
         try:
             self.progress.emit("KI denkt…")
             # Aktivitaetsanzeige (Issue #68)
-            from src.core.llm_activity import KIND_CHAT, get_llm_activity
             activity = get_llm_activity()
             token = activity.begin(KIND_CHAT, self.question[:40])
             ok = False

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -31,6 +31,12 @@ from PyQt6.QtWidgets import (
     QSplitter,
 )
 
+from src.core.llm_activity import (
+    KIND_SUGGEST,
+    format_elapsed,
+    format_estimate,
+    get_llm_activity,
+)
 from src.gui.pdf_preview_widget import PdfPreviewWidget
 from src.gui.rename_dialog import RenameSuggestion
 
@@ -80,8 +86,6 @@ class _LLMMetadataWorker(QThread):
         self._file_date = file_date
 
     def run(self):
-        from src.core.llm_activity import KIND_SUGGEST, get_llm_activity
-
         activity = get_llm_activity()
         token = activity.begin(KIND_SUGGEST, self._pdf_path.name)
         ok = False
@@ -954,9 +958,6 @@ class DetailPanel(QWidget):
         """Button zeigt laufende Uhr + Schaetzung, solange die KI arbeitet."""
         if self._llm_started is None:
             return
-        from src.core.llm_activity import (
-            KIND_SUGGEST, format_elapsed, format_estimate, get_llm_activity,
-        )
         text = f"KI arbeitet… {format_elapsed(time.monotonic() - self._llm_started)}"
         estimate = format_estimate(get_llm_activity().estimate(KIND_SUGGEST))
         if estimate:

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -9,7 +9,9 @@ und klickt rechts auf einen Zielordner zum Verschieben+Umbenennen.
 from pathlib import Path
 from typing import Optional
 
-from PyQt6.QtCore import Qt, pyqtSignal, QThread
+import time
+
+from PyQt6.QtCore import Qt, QTimer, pyqtSignal, QThread
 from PyQt6.QtGui import QFont
 from PyQt6.QtWidgets import (
     QWidget,
@@ -56,6 +58,51 @@ class _PdfMetadataReader(QThread):
         self.finished_meta.emit(self._pdf_path, meta)
 
 
+class _LLMMetadataWorker(QThread):
+    """Ruft die KI fuer Dateiname + Metadaten im Hintergrund auf (Issue #68).
+
+    Vorher lief der Aufruf im GUI-Thread und fror das Fenster fuer die Dauer
+    der Anfrage ein - auf langsamen Rechnern oder bei haengender Cloud
+    minutenlang, ohne dass man sah, ob noch etwas passiert.
+    """
+
+    # (pdf_path, suggestions, fehlertext)
+    result_ready = pyqtSignal(Path, list, str)
+
+    def __init__(self, classifier, pdf_path: Path, text: str, keywords: list,
+                 detected_date, file_date, parent=None):
+        super().__init__(parent)
+        self._classifier = classifier
+        self._pdf_path = pdf_path
+        self._text = text
+        self._keywords = keywords
+        self._detected_date = detected_date
+        self._file_date = file_date
+
+    def run(self):
+        from src.core.llm_activity import KIND_SUGGEST, get_llm_activity
+
+        activity = get_llm_activity()
+        token = activity.begin(KIND_SUGGEST, self._pdf_path.name)
+        ok = False
+        try:
+            suggestions = self._classifier.suggest_filename(
+                text=self._text,
+                current_filename=self._pdf_path.name,
+                keywords=self._keywords,
+                detected_date=self._detected_date,
+                use_llm=True,
+                file_date=self._file_date,
+            )
+            ok = True
+        except Exception as e:  # noqa: BLE001 - Fehler an die GUI melden
+            self.result_ready.emit(self._pdf_path, [], str(e))
+            return
+        finally:
+            activity.end(token, success=ok)
+        self.result_ready.emit(self._pdf_path, list(suggestions or []), "")
+
+
 class DetailPanel(QWidget):
     """Mittleres Panel: Zeigt Rename-Vorschläge + Metadaten für ausgewählte PDF."""
 
@@ -81,6 +128,12 @@ class DetailPanel(QWidget):
         self._saved_metadata_snapshot: dict = {}
         # Flag um textChanged-Signale während des programmatischen Füllens zu ignorieren
         self._loading_metadata: bool = False
+        # KI-Aufruf "Metadaten neu generieren" laeuft im Hintergrund (Issue #68)
+        self._llm_worker: Optional[_LLMMetadataWorker] = None
+        self._llm_started: Optional[float] = None
+        self._llm_timer = QTimer(self)
+        self._llm_timer.setInterval(1000)
+        self._llm_timer.timeout.connect(self._tick_llm_button)
 
         # Feste Größenpolitik: Panel ändert seine Größe nicht beim Befüllen
         from PyQt6.QtWidgets import QSizePolicy
@@ -848,9 +901,13 @@ class DetailPanel(QWidget):
 
         self.preview_label.setText(preview_name)
 
+    LLM_BTN_TEXT = "KI-Metadaten neu generieren"
+
     def _request_llm_metadata(self):
-        """Ruft das LLM erneut auf um Metadaten zu extrahieren."""
+        """Startet den KI-Aufruf fuer Metadaten im Hintergrund (Issue #68)."""
         if not self._current_pdf:
+            return
+        if self._llm_worker is not None and self._llm_worker.isRunning():
             return
 
         try:
@@ -859,10 +916,6 @@ class DetailPanel(QWidget):
             classifier = get_hybrid_classifier()
             if not classifier.is_llm_available():
                 return
-
-            self.llm_btn.setEnabled(False)
-            self.llm_btn.setText("KI arbeitet...")
-            QApplication.processEvents()
 
             detected_date = self._metadata.get("buchungsdatum")
 
@@ -875,20 +928,56 @@ class DetailPanel(QWidget):
                 pass
 
             # Aktuellen extrahierten Text aus dem Cache holen
-            from src.core.pdf_cache import get_pdf_cache, LLMSuggestion as CacheLLMSuggestion
+            from src.core.pdf_cache import get_pdf_cache
             cached = get_pdf_cache().get(self._current_pdf)
             extracted_text = cached.extracted_text if cached else ""
             keywords = cached.keywords if cached else []
+        except Exception as e:
+            print(f"LLM-Metadaten Fehler: {e}")
+            return
 
-            suggestions = classifier.suggest_filename(
-                text=extracted_text,
-                current_filename=self._current_pdf.name,
-                keywords=keywords,
-                detected_date=detected_date,
-                use_llm=True,
-                file_date=file_date,
-            )
+        self.llm_btn.setEnabled(False)
+        self._llm_started = time.monotonic()
+        self._tick_llm_button()
+        self._llm_timer.start()
 
+        worker = _LLMMetadataWorker(
+            classifier, self._current_pdf, extracted_text, keywords,
+            detected_date, file_date, self,
+        )
+        worker.result_ready.connect(self._on_llm_metadata_ready)
+        worker.finished.connect(worker.deleteLater)
+        self._llm_worker = worker
+        worker.start()
+
+    def _tick_llm_button(self):
+        """Button zeigt laufende Uhr + Schaetzung, solange die KI arbeitet."""
+        if self._llm_started is None:
+            return
+        from src.core.llm_activity import (
+            KIND_SUGGEST, format_elapsed, format_estimate, get_llm_activity,
+        )
+        text = f"KI arbeitet… {format_elapsed(time.monotonic() - self._llm_started)}"
+        estimate = format_estimate(get_llm_activity().estimate(KIND_SUGGEST))
+        if estimate:
+            text += f" ({estimate})"
+        self.llm_btn.setText(text)
+
+    def _on_llm_metadata_ready(self, pdf_path: Path, suggestions: list, error: str):
+        """Traegt das KI-Ergebnis ein - nur, wenn die PDF noch ausgewaehlt ist."""
+        self._llm_timer.stop()
+        self._llm_started = None
+        self._llm_worker = None
+        self.llm_btn.setEnabled(True)
+        self.llm_btn.setText(self.LLM_BTN_TEXT)
+
+        if error:
+            print(f"LLM-Metadaten Fehler: {error}")
+            return
+        if pdf_path != self._current_pdf:
+            return
+
+        try:
             for s in suggestions:
                 if s.source == "llm" and s.metadata:
                     self.name_input.setText(s.filename.replace('.pdf', ''))
@@ -927,15 +1016,12 @@ class DetailPanel(QWidget):
                         self.name_input.setText(s.filename.replace('.pdf', ''))
                         break
 
+            from src.core.pdf_cache import get_pdf_cache, LLMSuggestion as CacheLLMSuggestion
             llm_cached = [
                 CacheLLMSuggestion(filename=s.filename, confidence=s.confidence, source=s.source, metadata=s.metadata)
                 for s in suggestions if s.source == "llm"
             ]
             if llm_cached:
-                get_pdf_cache().update_llm_suggestions(self._current_pdf, llm_cached)
-
+                get_pdf_cache().update_llm_suggestions(pdf_path, llm_cached)
         except Exception as e:
             print(f"LLM-Metadaten Fehler: {e}")
-        finally:
-            self.llm_btn.setEnabled(True)
-            self.llm_btn.setText("KI-Metadaten neu generieren")

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -140,6 +140,13 @@ class MainWindow(QMainWindow):
         # PDF-Cache Signale verbinden
         self.pdf_cache.pdf_analyzed.connect(self._on_pdf_analyzed)
         self.pdf_cache.llm_suggestions_ready.connect(self._on_llm_suggestions_ready)
+        # Aktivitaetsanzeige (Issue #68): solange die KI arbeitet, tickt die
+        # Statusleiste sekuendlich mit laufender Uhr und Schaetzung.
+        from src.core.llm_activity import get_llm_activity
+        self._activity_timer = QTimer(self)
+        self._activity_timer.setInterval(1000)
+        self._activity_timer.timeout.connect(self._update_cache_status)
+        get_llm_activity().changed.connect(self._on_llm_activity_changed)
         self.pdf_cache.llm_suggestions_failed.connect(self._on_llm_suggestions_failed)
         self._last_llm_error: Optional[tuple[str, str]] = None  # (pdf_name, fehler)
         # Wiederverwendetes Vorschau-Fenster (Issue #76), erst bei Bedarf erzeugt
@@ -734,21 +741,37 @@ class MainWindow(QMainWindow):
                     llm_done += 1
         return analyzed, llm_done, total
 
+    def _on_llm_activity_changed(self):
+        """KI-Aufruf hat begonnen oder geendet: Uhr starten/stoppen."""
+        from src.core.llm_activity import get_llm_activity
+        if get_llm_activity().is_busy():
+            if not self._activity_timer.isActive():
+                self._activity_timer.start()
+        else:
+            self._activity_timer.stop()
+        self._update_cache_status()
+
     def _update_cache_status(self):
         """Aktualisiert die Fortschrittsanzeige der Hintergrund-Analyse."""
+        from src.core.llm_activity import get_llm_activity
+        activity = get_llm_activity()
         analyzed, llm_done, total = self._precache_progress()
-        if total == 0:
-            self.cache_status_label.setText("")
-            return
         parts = []
-        if analyzed < total:
-            parts.append(f"Durchsuche PDFs… {analyzed}/{total}")
-        llm_active = (
-            self.hybrid_classifier.is_llm_available()
-            and self.config.get("llm_precache_enabled", True)
-        )
-        if llm_active and llm_done < total:
-            parts.append(f"KI verschlagwortet Ihre PDFs… {llm_done}/{total} abgeschlossen")
+        if total > 0:
+            if analyzed < total:
+                parts.append(f"Durchsuche PDFs… {analyzed}/{total}")
+            llm_active = (
+                self.hybrid_classifier.is_llm_available()
+                and self.config.get("llm_precache_enabled", True)
+            )
+            if llm_active and llm_done < total:
+                parts.append(f"KI verschlagwortet Ihre PDFs… {llm_done}/{total} abgeschlossen")
+        # Laufender KI-Aufruf (Pre-Cache, Metadaten, Chat): Uhr + Schaetzung (Issue #68)
+        jobs = activity.jobs()
+        if jobs:
+            job = jobs[0]
+            label = f" „{job.label}“" if job.label else ""
+            parts.append(f"KI arbeitet{label} {activity.describe()}")
         if self._last_llm_error:
             parts.append("⚠ Fehler")
         self.cache_status_label.setText(" | ".join(parts))
@@ -1368,7 +1391,8 @@ class MainWindow(QMainWindow):
         # Fenstergebundene Timer anhalten: Nach dem Schliessen darf kein
         # verzoegerter Callback (Pre-Caching, Modell-Warten, Raster-Relayout)
         # mehr auf ein halb zerstoertes Fenster treffen.
-        for name in ("_precache_timer", "_model_wait_timer", "_grid_relayout_timer"):
+        for name in ("_precache_timer", "_model_wait_timer", "_grid_relayout_timer",
+                     "_activity_timer"):
             timer = getattr(self, name, None)
             if timer is not None:
                 timer.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,18 @@ def patch_singletons(monkeypatch: pytest.MonkeyPatch, factories: dict[str, objec
     for name in _MODULES_WITH_FACTORY_IMPORTS:
         importlib.import_module(name)
 
-    for mod_name, mod in list(sys.modules.items()):
+    # Hintergrund-Threads (Warmup, Modell-Laden, Pre-Cache) importieren evtl.
+    # gerade ein Modul -> sys.modules aendert sich waehrend list(): kurz erneut
+    # versuchen statt den Test mit "dictionary changed size" abzubrechen.
+    for _ in range(50):
+        try:
+            modules = list(sys.modules.items())
+            break
+        except RuntimeError:
+            continue
+    else:
+        modules = list(sys.modules.items())
+    for mod_name, mod in modules:
         if mod is None or not mod_name.startswith("src"):
             continue
         for attr, factory in factories.items():

--- a/tests/test_llm_activity.py
+++ b/tests/test_llm_activity.py
@@ -1,0 +1,138 @@
+"""Tests fuer die KI-Aktivitaetsanzeige (Issue #68): Zeitformat, Statistik, Zaehler."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.core import llm_activity as la
+
+# --------------------------------------------------------------------- #
+# Formatierung
+# --------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("seconds, expected", [
+    (0, "0:00"), (7.9, "0:07"), (42, "0:42"), (65, "1:05"), (750, "12:30"), (-3, "0:00"),
+])
+def test_format_elapsed(seconds, expected):
+    assert la.format_elapsed(seconds) == expected
+
+
+@pytest.mark.parametrize("seconds, expected", [
+    (None, ""), (0, ""), (0.4, "ca. 1 s"), (29.6, "ca. 30 s"), (59.4, "ca. 59 s"),
+    (90, "ca. 1:30 min"), (125, "ca. 2:05 min"),
+])
+def test_format_estimate(seconds, expected):
+    assert la.format_estimate(seconds) == expected
+
+
+def test_timing_key_and_current_key(fresh_config):
+    assert la.timing_key("ollama", "gemma3:4b", "suggest") == "ollama|gemma3:4b|suggest"
+    assert la.timing_key("", "", "chat") == "none|-|chat"
+    fresh_config.set_llm_provider("ollama")
+    llm = fresh_config.get_llm_config()
+    llm["model"] = "gemma3:4b"
+    fresh_config.set("llm", llm)
+    assert la.current_timing_key("chat") == "ollama|gemma3:4b|chat"
+
+
+# --------------------------------------------------------------------- #
+# Statistik
+# --------------------------------------------------------------------- #
+
+
+def test_store_estimate_needs_two_samples_and_uses_median(tmp_path):
+    store = la.LLMTimingStore(tmp_path / "t.json")
+    assert store.estimate("k") is None
+    store.record("k", 10)
+    assert store.estimate("k") is None
+    store.record("k", 30)
+    assert store.estimate("k") == 20
+    store.record("k", 600)  # Ausreisser (haengende Cloud) verzerrt den Median kaum
+    assert store.estimate("k") == 30
+
+
+def test_store_persists_and_trims(tmp_path):
+    path = tmp_path / "t.json"
+    store = la.LLMTimingStore(path)
+    for i in range(30):
+        store.record("k", i + 1)
+    assert len(store.samples("k")) == la.MAX_SAMPLES
+    assert store.samples("k")[0] == 11  # die aeltesten sind weg
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert len(data["k"]) == la.MAX_SAMPLES
+
+    reloaded = la.LLMTimingStore(path)
+    assert reloaded.samples("k") == store.samples("k")
+
+
+def test_store_ignores_nonpositive_and_bad_file(tmp_path):
+    path = tmp_path / "kaputt.json"
+    path.write_text("{nicht json", encoding="utf-8")
+    store = la.LLMTimingStore(path)  # darf nicht werfen
+    store.record("k", 0)
+    store.record("k", -5)
+    assert store.samples("k") == []
+
+
+def test_store_without_path_works_in_memory():
+    store = la.LLMTimingStore(None)
+    store.record("k", 1)
+    store.record("k", 3)
+    assert store.estimate("k") == 2
+
+
+# --------------------------------------------------------------------- #
+# Aktivitaetszaehler
+# --------------------------------------------------------------------- #
+
+
+def test_activity_begin_end_records_and_signals(tmp_path):
+    store = la.LLMTimingStore(tmp_path / "t.json")
+    activity = la.LLMActivity(store)
+    changes = []
+    activity.changed.connect(lambda: changes.append(1))
+
+    assert not activity.is_busy()
+    assert activity.describe() == ""
+
+    token = activity.begin(la.KIND_SUGGEST, "a.pdf", key="k")
+    assert activity.is_busy()
+    jobs = activity.jobs()
+    assert len(jobs) == 1 and jobs[0].label == "a.pdf" and jobs[0].kind == la.KIND_SUGGEST
+    assert activity.describe().startswith("seit 0:0")
+    assert len(changes) == 1
+
+    elapsed = activity.end(token)
+    assert elapsed is not None and elapsed >= 0
+    assert not activity.is_busy()
+    assert len(store.samples("k")) == 1
+    assert len(changes) == 2
+
+
+def test_activity_failed_call_is_not_recorded():
+    activity = la.LLMActivity(la.LLMTimingStore(None))
+    token = activity.begin(la.KIND_CHAT, key="k")
+    activity.end(token, success=False)
+    assert activity.store.samples("k") == []
+    assert activity.end(999) is None  # unbekanntes Token ist harmlos
+
+
+def test_activity_describe_includes_estimate_and_filters_kind():
+    store = la.LLMTimingStore(None)
+    store.record("k", 20)
+    store.record("k", 40)
+    activity = la.LLMActivity(store)
+    activity.begin(la.KIND_CHAT, "Frage", key="k")
+    assert "ca. 30 s" in activity.describe()
+    assert activity.describe(la.KIND_SUGGEST) == ""
+    assert activity.describe(la.KIND_CHAT).startswith("seit ")
+
+
+def test_singleton_reset_for_tests(tmp_path):
+    a = la.reset_llm_activity(la.LLMTimingStore(tmp_path / "x.json"))
+    assert la.get_llm_activity() is a
+    b = la.reset_llm_activity()
+    assert la.get_llm_activity() is b and b is not a

--- a/tests/test_llm_activity_gui.py
+++ b/tests/test_llm_activity_gui.py
@@ -1,0 +1,257 @@
+"""GUI-Tests fuer die KI-Aktivitaetsanzeige (Issue #68).
+
+* Detail-Panel: "KI-Metadaten neu generieren" laeuft im Hintergrund, der Button
+  zeigt die laufende Uhr, das Ergebnis wird eingetragen.
+* Hauptfenster: Statusleiste zeigt laufende KI-Aufrufe mit Uhr, Timer laeuft
+  nur waehrend der Aktivitaet.
+* Chat: Statuszeile zeigt "seit m:ss" und ggf. die Schaetzung.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from src.core import llm_activity as la
+
+
+@pytest.fixture
+def activity(tmp_path):
+    """Frischer Aktivitaets-Zaehler mit temporaerem Store (kein Zugriff auf %APPDATA%)."""
+    return la.reset_llm_activity(la.LLMTimingStore(tmp_path / "timing.json"))
+
+
+@pytest.fixture
+def fresh_singletons(monkeypatch, tmp_path):
+    from src.core import pdf_cache as pc_mod
+    from src.ml import classifier as cl_mod
+    from src.ml import hybrid_classifier as hc_mod
+    from src.utils import config as cfg_mod
+    from src.utils import database as db_mod
+    from tests.conftest import patch_singletons
+
+    fresh_config = cfg_mod.Config(config_path=tmp_path / "config.json")
+    fresh_config.set("persist_pdf_cache", False)
+    monkeypatch.setattr(pc_mod.PDFCache, "_instance", None)
+    patch_singletons(monkeypatch, {
+        "get_config": lambda: fresh_config,
+        "get_database": lambda: db_mod.Database(db_path=str(tmp_path / "a.db")),
+        "get_classifier": cl_mod.PDFClassifier,
+        "get_hybrid_classifier": hc_mod.HybridClassifier,
+        "get_pdf_cache": pc_mod.PDFCache,
+    })
+    return fresh_config
+
+
+# --------------------------------------------------------------------- #
+# Detail-Panel
+# --------------------------------------------------------------------- #
+
+
+class _FakeClassifier:
+    def __init__(self, delay: float = 0.3, fail: bool = False):
+        self.delay = delay
+        self.fail = fail
+        self.calls = 0
+
+    def is_llm_available(self):
+        return True
+
+    def suggest_filename(self, **kwargs):
+        self.calls += 1
+        time.sleep(self.delay)
+        if self.fail:
+            raise RuntimeError("Cloud haengt")
+        return [SimpleNamespace(
+            filename="2026-08-28_Rechnung_Stadtwerke.pdf",
+            confidence=0.9,
+            source="llm",
+            metadata={"subject": "Rechnung", "korrespondent": "Stadtwerke",
+                      "description": "Stromrechnung August"},
+        )]
+
+
+class _FakeCache:
+    def __init__(self):
+        self.updated = []
+
+    def get(self, path):
+        return None
+
+    def update_llm_suggestions(self, path, suggestions):
+        self.updated.append((path, suggestions))
+
+
+@pytest.fixture
+def panel_with_fake_llm(qtbot, monkeypatch, activity, tmp_path):
+    from src.core import pdf_cache as pc_mod
+    from src.core.pdf_metadata import PDFMetadata
+    from src.gui import detail_panel as dp
+    from src.ml import hybrid_classifier as hc_mod
+
+    classifier = _FakeClassifier()
+    cache = _FakeCache()
+    monkeypatch.setattr(hc_mod, "get_hybrid_classifier", lambda: classifier)
+    monkeypatch.setattr(pc_mod, "get_pdf_cache", lambda: cache)
+    monkeypatch.setattr("src.core.pdf_metadata.read_metadata", lambda p: PDFMetadata())
+
+    panel = dp.DetailPanel()
+    qtbot.addWidget(panel)
+    pdf = tmp_path / "beleg.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    panel.set_pdf(pdf_path=pdf, suggestions=[], extracted_text="", keywords=[])
+    qtbot.waitUntil(lambda: panel._metadata_source is not None or True, timeout=1000)
+    return panel, classifier, cache, pdf
+
+
+def test_metadata_request_runs_in_background_and_fills_fields(qtbot, panel_with_fake_llm, activity):
+    panel, classifier, cache, pdf = panel_with_fake_llm
+
+    panel._request_llm_metadata()
+
+    # Sofort: Button gesperrt, Uhr laeuft, Aufruf ist als Aktivitaet sichtbar
+    assert not panel.llm_btn.isEnabled()
+    assert panel.llm_btn.text().startswith("KI arbeitet… 0:0")
+    qtbot.waitUntil(activity.is_busy, timeout=1000)
+    assert activity.jobs()[0].label == "beleg.pdf"
+
+    qtbot.waitUntil(lambda: panel.llm_btn.isEnabled(), timeout=5000)
+
+    assert panel.llm_btn.text() == panel.LLM_BTN_TEXT
+    assert panel.name_input.text() == "2026-08-28_Rechnung_Stadtwerke"
+    assert panel.get_metadata()["korrespondent"] == "Stadtwerke"
+    assert panel.get_metadata()["description"] == "Stromrechnung August"
+    assert panel._metadata_source == "llm"
+    assert len(cache.updated) == 1 and cache.updated[0][0] == pdf
+    assert not activity.is_busy()
+    # Dauer wurde fuer die Schaetzung gemerkt
+    assert any(activity.store.samples(k) for k in [la.current_timing_key(la.KIND_SUGGEST)])
+
+
+def test_metadata_request_error_reenables_button_without_recording(qtbot, panel_with_fake_llm, activity):
+    panel, classifier, cache, pdf = panel_with_fake_llm
+    classifier.fail = True
+
+    panel._request_llm_metadata()
+    qtbot.waitUntil(lambda: panel.llm_btn.isEnabled(), timeout=5000)
+
+    assert panel.name_input.text() != "2026-08-28_Rechnung_Stadtwerke"
+    assert cache.updated == []
+    assert activity.store.samples(la.current_timing_key(la.KIND_SUGGEST)) == []
+
+
+def test_metadata_result_for_other_pdf_is_ignored(qtbot, panel_with_fake_llm, tmp_path):
+    panel, classifier, cache, pdf = panel_with_fake_llm
+
+    panel._request_llm_metadata()
+    # Nutzer waehlt inzwischen eine andere PDF
+    other = tmp_path / "andere.pdf"
+    other.write_bytes(b"%PDF-1.4")
+    panel.set_pdf(pdf_path=other, suggestions=[], extracted_text="", keywords=[])
+
+    qtbot.waitUntil(lambda: panel.llm_btn.isEnabled(), timeout=5000)
+
+    assert panel.name_input.text() != "2026-08-28_Rechnung_Stadtwerke"
+    assert cache.updated == []
+
+
+def test_second_click_while_running_is_ignored(qtbot, panel_with_fake_llm):
+    panel, classifier, cache, pdf = panel_with_fake_llm
+    panel._request_llm_metadata()
+    panel._request_llm_metadata()
+    qtbot.waitUntil(lambda: panel.llm_btn.isEnabled(), timeout=5000)
+    assert classifier.calls == 1
+
+
+def test_button_shows_estimate_when_history_exists(qtbot, panel_with_fake_llm, activity):
+    panel, classifier, cache, pdf = panel_with_fake_llm
+    key = la.current_timing_key(la.KIND_SUGGEST)
+    activity.store.record(key, 20)
+    activity.store.record(key, 40)
+
+    panel._request_llm_metadata()
+    assert "(ca. 30 s)" in panel.llm_btn.text()
+    qtbot.waitUntil(lambda: panel.llm_btn.isEnabled(), timeout=5000)
+
+
+# --------------------------------------------------------------------- #
+# Hauptfenster / Statusleiste
+# --------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def main_window(qtbot, fresh_singletons, monkeypatch, activity):
+    from PyQt6.QtCore import QSettings
+    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+
+    from src.gui import main_window as mw_mod
+    monkeypatch.setattr(mw_mod.MainWindow, "showMaximized", lambda self: None)
+    monkeypatch.setattr(mw_mod.MainWindow, "show", lambda self: None)
+
+    win = mw_mod.MainWindow()
+    qtbot.addWidget(win)
+    yield win
+    win.close()
+
+
+def test_statusbar_shows_running_llm_call_and_ticks(qtbot, main_window, activity):
+    assert main_window.cache_status_label.text() == ""
+    assert not main_window._activity_timer.isActive()
+
+    token = activity.begin(la.KIND_SUGGEST, "rechnung.pdf")
+    qtbot.waitUntil(lambda: "KI arbeitet" in main_window.cache_status_label.text(), timeout=1000)
+
+    text = main_window.cache_status_label.text()
+    assert "rechnung.pdf" in text and "seit 0:0" in text
+    assert main_window._activity_timer.isActive()
+
+    activity.end(token)
+    qtbot.waitUntil(lambda: main_window.cache_status_label.text() == "", timeout=1000)
+    assert not main_window._activity_timer.isActive()
+
+
+def test_statusbar_includes_estimate(qtbot, main_window, activity):
+    activity.store.record("k", 10)
+    activity.store.record("k", 20)
+    token = activity.begin(la.KIND_CHAT, "Frage", key="k")
+    qtbot.waitUntil(lambda: "ca. 15 s" in main_window.cache_status_label.text(), timeout=1000)
+    activity.end(token)
+
+
+# --------------------------------------------------------------------- #
+# Chat
+# --------------------------------------------------------------------- #
+
+
+def test_chat_status_line_ticks_with_elapsed_and_estimate(qtbot, tmp_path, activity):
+    from src.gui.chat_view import ChatView
+    from src.utils.config import ChatConfig
+    from src.utils.database import Database
+
+    class _StubLLM:
+        llm_provider = None
+
+        def is_llm_available(self):
+            return False
+
+    view = ChatView(db=Database(db_path=str(tmp_path / "c.db")),
+                    hybrid_classifier=_StubLLM(), chat_config=ChatConfig())
+    qtbot.addWidget(view)
+
+    key = la.current_timing_key(la.KIND_CHAT)
+    activity.store.record(key, 20)
+    activity.store.record(key, 20)
+
+    view._status_base = "KI denkt…"
+    view._request_started = time.monotonic() - 65
+    view._tick_status()
+
+    assert view.status_label.text() == "KI denkt… seit 1:05 · ca. 20 s"
+
+    view._on_worker_progress("Suche läuft…")
+    assert view.status_label.text().startswith("Suche läuft… seit 1:05")
+
+    view._teardown_thread()
+    assert view._request_started is None
+    assert not view._status_timer.isActive()


### PR DESCRIPTION
Closes #68

## Was
- Neues Modul `src/core/llm_activity.py`: `LLMActivity` zaehlt laufende KI-Aufrufe (`begin`/`end` aus den Worker-Threads, Signal in den GUI-Thread); `LLMTimingStore` merkt die Dauer je `provider|modell|art` (letzte 20, **Median** als Schaetzung - robust gegen eine haengende Cloud-Anfrage) in `llm_timing.json` im Datenverzeichnis.
- **Statusleiste**: "KI arbeitet „rechnung.pdf“ seit 0:42 · ca. 30 s" - tickt sekuendlich, nur solange etwas laeuft (Pre-Cache, Metadaten, Chat).
- **Chat**: "KI denkt… seit 0:05 · ca. 20 s".
- **Detail-Panel**: Button "KI arbeitet… 0:12 (ca. 30 s)". Der Aufruf "KI-Metadaten neu generieren" laeuft jetzt in einem QThread - vorher blockierte er den GUI-Thread fuer die gesamte Anfrage (das war der eigentliche Grund, warum man "nichts sah"). Ergebnis wird nur eingetragen, wenn die PDF noch ausgewaehlt ist; Doppelklick startet keinen zweiten Aufruf.
- Schaetzung erscheint ab dem 2. Aufruf mit demselben Provider/Modell; fehlgeschlagene Aufrufe fliessen nicht ein.

## Verifikation
- 615/615 Tests gruen (30 neu: Zeitformat, Statistik/Persistenz, Zaehler/Signale, Detail-Panel im Hintergrund inkl. Fehler-/Stale-Faelle, Statusleiste tickt/stoppt, Chat-Statuszeile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
