### PR TITLE
test: Vorschau-Fenster-Geometrie-Test unabhaengig von der Bildschirmgroesse

### DIFF
--- a/tests/test_pdf_preview_widget_gui.py
+++ b/tests/test_pdf_preview_widget_gui.py
@@ -202,12 +202,16 @@ def test_preview_window_shows_pdf_and_remembers_geometry(qtbot, tmp_path):
     assert "fenster.pdf" in win.windowTitle()
     assert win.current_path() == pdf
     assert win.preview.page_count() == 2
-    assert (win.width(), win.height()) == (700, 800)
+    # Der Fenstermanager darf die gewuenschte Groesse an den Bildschirm
+    # anpassen (kleine/skalierte Displays) - entscheidend ist, dass die
+    # tatsaechliche Groesse gemerkt wird, nicht der Wunschwert.
+    shown_size = (win.width(), win.height())
+    assert shown_size[0] > 200 and shown_size[1] > 200
 
     with qtbot.waitSignal(win.geometry_changed, timeout=1000) as blocker:
         win.close()
     geometry = blocker.args[0]
-    assert len(geometry) == 4 and geometry[2] == 700 and geometry[3] == 800
+    assert len(geometry) == 4 and (geometry[2], geometry[3]) == shown_size
 
 
 def test_preview_window_ignores_bad_geometry(qtbot):


### PR DESCRIPTION
Der Test aus #83 verglich mit dem Wunschwert 700x800; auf kleinen/skalierten Displays passt der Fenstermanager die Groesse an (im Worktree eines Agenten reproduziert). Jetzt wird die gemerkte Geometrie mit der tatsaechlichen Fenstergroesse verglichen. 15/15 Tests der Datei gruen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)