### PR TITLE
feat: Poe.com wieder als LLM-Provider aufnehmen (Refs #66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Geaendert
+- Poe.com ist wieder als KI-Anbieter waehlbar (poe.com vergibt wieder API-Keys;
+  in 0.19.0 entfernt).
+
 ## [0.19.0] - 2026-08-28
 
 ### Hinzugefuegt

--- a/scripts/qa_all_providers.py
+++ b/scripts/qa_all_providers.py
@@ -2,7 +2,7 @@
 QA Smoke-Test fuer alle LLM-Provider (PDF Sortier Meister).
 
 Zweck:
-    Verifiziert, dass ollama, claude und openai als Provider-Module
+    Verifiziert, dass ollama, claude, openai und poe als Provider-Module
     sauber geladen werden, mit ``LLMConfig`` instanziiert werden koennen
     und ohne konfigurierten API-Key ``graceful`` mit
     ``answer_with_context()`` umgehen - d.h. sie duerfen einen leeren
@@ -86,6 +86,13 @@ PROVIDERS: list[ProviderSpec] = [
         model="gpt-4.1-nano",
         mode="needs_api_key",
     ),
+    ProviderSpec(
+        name="poe",
+        module="src.ml.poe_provider",
+        class_name="PoeProvider",
+        model="GPT-4o-Mini",
+        mode="needs_api_key",
+    ),
 ]
 
 
@@ -96,14 +103,14 @@ def _get_provider_version(spec: ProviderSpec) -> Optional[str]:
     """Liefert (best-effort) die Version des Provider-Pakets.
 
     - ``anthropic``     -> claude
-    - ``openai``        -> openai
+    - ``openai``        -> openai + poe
     - Ollama hat kein separates Python-Paket (nur Server).
     """
     try:
         if spec.name == "claude":
             mod = importlib.import_module("anthropic")
             return getattr(mod, "__version__", None)
-        if spec.name == "openai":
+        if spec.name in ("openai", "poe"):
             mod = importlib.import_module("openai")
             return getattr(mod, "__version__", None)
         if spec.name == "ollama":
@@ -324,7 +331,7 @@ def _test_provider(spec: ProviderSpec) -> ProviderResult:
 # ---------------------------------------------------------------------------
 def main() -> int:
     print("=" * 72)
-    print("QA-Smoketest: LLM-Provider (ollama, claude, openai)")
+    print("QA-Smoketest: LLM-Provider (ollama, claude, openai, poe)")
     print("=" * 72)
     print()
 

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -36,6 +36,7 @@ class SettingsDialog(QDialog):
         ("ollama", "Ollama (lokal auf diesem Rechner, empfohlen — kein API-Key noetig)"),
         ("ollama_cloud", "Ollama Cloud (Ollama-Modelle in der Cloud, API-Key)"),
         ("openrouter", "OpenRouter (viele Modelle, ein API-Key)"),
+        ("poe", "Poe.com (viele KI-Modelle, ein API-Key)"),
         ("claude", "Anthropic Claude"),
         ("openai", "OpenAI GPT"),
         ("none", "Ohne KI-Assistent (nur einfache lokale Stichwort-Zuordnung — stark eingeschraenkt)"),
@@ -907,6 +908,24 @@ class SettingsDialog(QDialog):
             "gemma3 (Google)",
             "phi3 (Microsoft, sehr klein)",
         ],
+        "poe": [
+            "GPT-4o-Mini (schnell & günstig)",
+            "GPT-4o (OpenAI)",
+            "GPT-4.1-Mini (OpenAI, neu)",
+            "GPT-4.1 (OpenAI, neu)",
+            "o3-Mini (Reasoning)",
+            "o4-Mini (Reasoning, neu)",
+            "Claude-3.5-Haiku (schnell)",
+            "Claude-3.5-Sonnet (Anthropic)",
+            "Claude-Sonnet-4 (Anthropic, neu)",
+            "Claude-Sonnet-4.5 (Anthropic, neuestes)",
+            "Claude-Opus-4 (Anthropic, premium)",
+            "Gemini-2-Flash (Google)",
+            "Gemini-2.5-Flash (Google, neu)",
+            "Gemini-2.5-Pro (Google, premium)",
+            "Llama-3.1-405B (Meta)",
+            "Mistral-Large (Mistral)",
+        ],
         "openrouter": [
             "openai/gpt-4.1-nano (schnell & günstig)",
             "openai/gpt-4.1-mini (ausgewogen)",
@@ -931,12 +950,14 @@ class SettingsDialog(QDialog):
     _KEY_PROVIDER_LABELS = {
         "claude": "Anthropic Claude",
         "openai": "OpenAI",
+        "poe": "Poe.com",
         "openrouter": "OpenRouter",
         "ollama_cloud": "Ollama Cloud",
     }
     _API_KEY_PLACEHOLDERS = {
         "claude": "sk-ant-...",
         "openai": "sk-...",
+        "poe": "Poe API-Key von poe.com/api_key",
         "ollama": "Nicht noetig fuer Ollama",
         "openrouter": "sk-or-... von openrouter.ai/keys",
         "ollama_cloud": "API-Key von ollama.com/settings/keys",
@@ -1308,6 +1329,8 @@ class SettingsDialog(QDialog):
                 self._test_claude(api_key, model)
             elif provider_id == "openai":
                 self._test_openai(api_key, model)
+            elif provider_id == "poe":
+                self._test_poe(api_key, model)
             elif provider_id == "ollama":
                 self._test_ollama(base_url, model)
             elif provider_id == "openrouter":
@@ -1393,6 +1416,54 @@ class SettingsDialog(QDialog):
             QMessageBox.critical(
                 self, "Fehler",
                 "Ungültiger API-Key. Bitte überprüfen Sie Ihren Key."
+            )
+        except Exception as e:
+            QMessageBox.critical(
+                self, "Fehler",
+                f"Verbindungsfehler: {str(e)}"
+            )
+
+    def _test_poe(self, api_key: str, model: str):
+        """Testet die Poe API (OpenAI-kompatibel)."""
+        try:
+            import openai
+            from src.ml.poe_provider import PoeProvider
+            client = openai.OpenAI(
+                api_key=api_key,
+                base_url=PoeProvider.BASE_URL,
+            )
+            model_id = model or PoeProvider.DEFAULT_MODEL
+
+            # Claude-Modelle via Poe aktivieren Thinking automatisch. max_tokens
+            # muss deshalb hoch genug sein (>=2048), damit Poe's abgeleitetes
+            # budget_tokens nach Abzug der Response-Reserve >= 1024 bleibt.
+            max_tokens = 2048 if "claude" in model_id.lower() else 20
+
+            response = client.chat.completions.create(
+                model=model_id,
+                max_tokens=max_tokens,
+                messages=[
+                    {"role": "user", "content": "Sage 'OK'"}
+                ]
+            )
+
+            QMessageBox.information(
+                self, "Erfolg",
+                f"Verbindung zu Poe erfolgreich!\n"
+                f"Modell: {model_id}\n"
+                f"Antwort: {response.choices[0].message.content}"
+            )
+        except ImportError:
+            QMessageBox.critical(
+                self, "Fehler",
+                "Das 'openai' Paket ist nicht installiert.\n"
+                "Installieren mit: pip install openai"
+            )
+        except openai.AuthenticationError:
+            QMessageBox.critical(
+                self, "Fehler",
+                "Ungültiger Poe API-Key.\n"
+                "Holen Sie Ihren Key von: poe.com/api_key"
             )
         except Exception as e:
             QMessageBox.critical(
@@ -1552,6 +1623,8 @@ class SettingsDialog(QDialog):
                 models = self._fetch_claude_models(api_key)
             elif provider_id == "openai":
                 models = self._fetch_openai_models(api_key)
+            elif provider_id == "poe":
+                models = self._fetch_poe_models(api_key)
             elif provider_id == "ollama":
                 base_url = self.base_url_input.text().strip() or "http://localhost:11434"
                 models = self._fetch_ollama_models(base_url)
@@ -1622,6 +1695,20 @@ class SettingsDialog(QDialog):
             models.append(model_id)
 
         models.sort(reverse=True)
+        return models
+
+    def _fetch_poe_models(self, api_key: str) -> list[str]:
+        """Ruft verfügbare Modelle von der Poe API ab."""
+        import openai
+        from src.ml.poe_provider import PoeProvider
+        client = openai.OpenAI(
+            api_key=api_key,
+            base_url=PoeProvider.BASE_URL,
+        )
+
+        models_response = client.models.list()
+        models = [model.id for model in models_response.data]
+        models.sort()
         return models
 
     def _fetch_openrouter_models(self, api_key: str) -> list[str]:

--- a/src/gui/setup_wizard.py
+++ b/src/gui/setup_wizard.py
@@ -36,11 +36,12 @@ PAGE_DONE = 4
 # Provider-Konstanten (Index -> interner Name). Reihenfolge = Empfehlungsrang:
 # Ollama (lokal, kein Key) zuerst, dann Cloud-Anbieter, "Ohne KI" ganz unten
 # (Issue #67 - KI ist ein Hauptfeature, nicht "optional").
-_PROVIDER_IDS = ["ollama", "ollama_cloud", "openrouter", "claude", "openai", "none"]
+_PROVIDER_IDS = ["ollama", "ollama_cloud", "openrouter", "poe", "claude", "openai", "none"]
 _PROVIDER_LABELS = [
     "Ollama (lokal auf diesem Rechner, empfohlen — kein API-Key noetig)",
     "Ollama Cloud (Ollama-Modelle in der Cloud, API-Key)",
     "OpenRouter (viele KI-Modelle, ein API-Key)",
+    "Poe.com (viele KI-Modelle, ein API-Key)",
     "Anthropic Claude",
     "OpenAI GPT",
     "Ohne KI-Assistent (nur einfache lokale Stichwort-Zuordnung — stark eingeschraenkt)",
@@ -51,6 +52,7 @@ _PROVIDER_URLS = {
     "ollama": "https://ollama.com/download",
     "ollama_cloud": "https://ollama.com/settings/keys",
     "openrouter": "https://openrouter.ai/keys",
+    "poe": "https://poe.com/api_key",
 }
 _PROVIDER_KEY_HINTS = {
     "claude": 'Beginnt mit "sk-ant-..."',
@@ -58,6 +60,7 @@ _PROVIDER_KEY_HINTS = {
     "ollama": "Leer lassen fuer Standard (http://localhost:11434)",
     "ollama_cloud": "Zu finden auf ollama.com/settings/keys",
     "openrouter": 'Beginnt mit "sk-or-..."',
+    "poe": "Zu finden auf poe.com/api_key",
 }
 
 OLLAMA_LOCAL_URL = "http://localhost:11434"
@@ -499,6 +502,7 @@ class ApiKeyPage(QWizardPage):
             "ollama": "Ollama",
             "ollama_cloud": "Ollama Cloud",
             "openrouter": "OpenRouter",
+            "poe": "Poe.com",
         }
         name = provider_labels.get(self._provider_id, self._provider_id)
 
@@ -563,6 +567,13 @@ class ApiKeyPage(QWizardPage):
                 "2. Unter 'Keys' einen API-Key erstellen und kopieren.\n"
                 f"3. Fuegen Sie ihn unten ein. Standardmodell: {OLLAMA_CLOUD_DEFAULT_MODEL}\n"
                 "   (aenderbar unter Extras -> Einstellungen)."
+            ),
+            "poe": (
+                "1. Oeffnen Sie den Link unten (oder gehen Sie zu poe.com).\n"
+                "2. Melden Sie sich an oder erstellen Sie ein Konto.\n"
+                "3. Gehen Sie zu poe.com/api_key und kopieren Sie Ihren Key.\n"
+                "4. Fuegen Sie ihn unten ein. Modell waehlen Sie spaeter unter\n"
+                "   Extras -> Einstellungen (z.B. GPT-4o-Mini)."
             ),
             "openrouter": (
                 "1. Oeffnen Sie den Link unten (oder gehen Sie zu openrouter.ai).\n"

--- a/src/ml/hybrid_classifier.py
+++ b/src/ml/hybrid_classifier.py
@@ -15,6 +15,7 @@ from src.ml.classifier import PDFClassifier, Suggestion, get_classifier
 from src.ml.llm_provider import LLMProvider, LLMConfig, LLMResponse, LLMProviderType
 from src.ml.claude_provider import ClaudeProvider
 from src.ml.openai_provider import OpenAIProvider
+from src.ml.poe_provider import PoeProvider
 from src.ml.openrouter_provider import OpenRouterProvider
 from src.ml.ollama_provider import OllamaProvider, OllamaCloudProvider
 from src.utils.config import get_config
@@ -113,6 +114,8 @@ class HybridClassifier:
                 self.llm_provider = ClaudeProvider(config)
             elif provider_type == "openai":
                 self.llm_provider = OpenAIProvider(config)
+            elif provider_type == "poe":
+                self.llm_provider = PoeProvider(config)
             elif provider_type == "openrouter":
                 self.llm_provider = OpenRouterProvider(config)
             elif provider_type == "ollama":
@@ -139,7 +142,7 @@ class HybridClassifier:
         Setzt den LLM-Provider zur Laufzeit.
 
         Args:
-            provider_type: Art des Providers (claude, openai, openrouter, ollama, none)
+            provider_type: Art des Providers (claude, openai, poe, openrouter, ollama, none)
             api_key: API-Key (bei Ollama ignoriert)
             model: Modellname (optional)
             base_url: Server-URL (nur fuer Ollama relevant)
@@ -172,6 +175,7 @@ class HybridClassifier:
         default_models = {
             LLMProviderType.CLAUDE: "haiku",
             LLMProviderType.OPENAI: "gpt-4o-mini",
+            LLMProviderType.POE: "GPT-4o-Mini",
             LLMProviderType.OPENROUTER: OpenRouterProvider.DEFAULT_MODEL,
             LLMProviderType.OLLAMA: OllamaProvider.DEFAULT_MODEL,
             LLMProviderType.OLLAMA_CLOUD: OllamaCloudProvider.DEFAULT_MODEL,
@@ -187,6 +191,8 @@ class HybridClassifier:
                 self.llm_provider = ClaudeProvider(config)
             elif provider_type == LLMProviderType.OPENAI:
                 self.llm_provider = OpenAIProvider(config)
+            elif provider_type == LLMProviderType.POE:
+                self.llm_provider = PoeProvider(config)
             elif provider_type == LLMProviderType.OPENROUTER:
                 self.llm_provider = OpenRouterProvider(config)
             elif provider_type == LLMProviderType.OLLAMA:
@@ -525,6 +531,8 @@ class HybridClassifier:
             return "OpenRouter"
         if isinstance(self.llm_provider, OpenAIProvider):
             return "OpenAI"
+        if isinstance(self.llm_provider, PoeProvider):
+            return "Poe"
         if isinstance(self.llm_provider, OllamaCloudProvider):
             return "Ollama Cloud"
         if isinstance(self.llm_provider, OllamaProvider):

--- a/src/ml/llm_provider.py
+++ b/src/ml/llm_provider.py
@@ -16,7 +16,7 @@ from enum import Enum
 
 
 # Provider, die Dokumenteninhalte an externe (Cloud-)Dienste uebertragen.
-CLOUD_PROVIDERS = frozenset({"claude", "openai", "openrouter", "ollama_cloud"})
+CLOUD_PROVIDERS = frozenset({"claude", "openai", "poe", "openrouter", "ollama_cloud"})
 
 
 def is_cloud_provider(provider_type: str) -> bool:
@@ -103,6 +103,7 @@ class LLMProviderType(Enum):
     """Unterstützte LLM-Anbieter."""
     CLAUDE = "claude"
     OPENAI = "openai"
+    POE = "poe"  # Poe.com - Zugang zu vielen Modellen
     OPENROUTER = "openrouter"  # OpenRouter.ai - viele Modelle, OpenAI-kompatibel
     OLLAMA = "ollama"  # Lokaler Ollama-Server (kein API-Key noetig)
     OLLAMA_CLOUD = "ollama_cloud"  # Ollama-Modelle in der Cloud (ollama.com, API-Key)

--- a/src/ml/poe_provider.py
+++ b/src/ml/poe_provider.py
@@ -1,0 +1,436 @@
+"""
+Poe API Provider für PDF Sortier Meister
+
+Implementiert die LLM-Schnittstelle für Poe.com's API.
+Poe bietet Zugang zu verschiedenen Modellen (GPT, Claude, Gemini, etc.)
+über eine einheitliche OpenAI-kompatible API.
+
+MIT License - Copyright (c) 2026
+"""
+
+import json
+import urllib.error
+import urllib.request
+from typing import Optional
+
+from src.ml.llm_provider import LLMProvider, LLMConfig, LLMResponse
+
+
+class PoeProvider(LLMProvider):
+    """
+    LLM-Provider für Poe.com API.
+
+    Poe bietet Zugang zu vielen verschiedenen Modellen über eine
+    OpenAI-kompatible API. Unterstützt GPT, Claude, Gemini und mehr.
+    """
+
+    # Verfügbare Poe Modelle (Stand: März 2026)
+    # Hinweis: Poe-Bot-Namen können sich ändern. Bei Fehler auf poe.com prüfen.
+    MODELS = {
+        # Claude Modelle (Anthropic)
+        "claude-3.5-haiku": "Claude-3.5-Haiku",
+        "claude-3.5-sonnet": "Claude-3.5-Sonnet",
+        "claude-4-sonnet": "Claude-Sonnet-4",
+        "claude-4.5-sonnet": "Claude-Sonnet-4.5",
+        "claude-4-opus": "Claude-Opus-4",
+        # GPT Modelle (OpenAI)
+        "gpt-4o-mini": "GPT-4o-Mini",
+        "gpt-4o": "GPT-4o",
+        "gpt-4.1-mini": "GPT-4.1-Mini",
+        "gpt-4.1": "GPT-4.1",
+        "o3-mini": "o3-Mini",
+        "o4-mini": "o4-Mini",
+        # Gemini Modelle (Google)
+        "gemini-2-flash": "Gemini-2-Flash",
+        "gemini-2.5-flash": "Gemini-2.5-Flash",
+        "gemini-2.5-pro": "Gemini-2.5-Pro",
+        # Weitere
+        "llama-3.1-405b": "Llama-3.1-405B",
+        "mistral-large": "Mistral-Large",
+    }
+
+    # Standard-Modell (gutes Preis-Leistungs-Verhältnis)
+    DEFAULT_MODEL = "GPT-4o-Mini"
+
+    # Poe API Base URL
+    BASE_URL = "https://api.poe.com/v1"
+
+    def __init__(self, config: LLMConfig):
+        """
+        Initialisiert den Poe Provider.
+
+        Args:
+            config: Konfiguration mit API-Key und Modell
+        """
+        super().__init__(config)
+        self._openai = None
+        self._initialize_client()
+
+    def _initialize_client(self):
+        """Initialisiert den OpenAI-kompatiblen API-Client für Poe."""
+        if not self.config.api_key:
+            return
+
+        try:
+            import openai
+            self._openai = openai
+            self._client = openai.OpenAI(
+                api_key=self.config.api_key,
+                base_url=self.BASE_URL,
+            )
+        except ImportError:
+            print("Warnung: openai Paket nicht installiert. "
+                  "Installieren mit: pip install openai")
+            self._client = None
+        except Exception as e:
+            print(f"Fehler bei Poe-Initialisierung: {e}")
+            self._client = None
+
+    def is_available(self) -> bool:
+        """Prüft, ob Poe verfügbar ist."""
+        return self._client is not None and self.config.api_key
+
+    def _get_model_id(self) -> str:
+        """Gibt die Poe Modell-ID zurück."""
+        model = self.config.model.lower() if self.config.model else ""
+
+        # Prüfe ob Modellname in unserem Mapping ist
+        if model in self.MODELS:
+            return self.MODELS[model]
+
+        # Falls bereits ein Poe-Modellname (mit Großbuchstaben)
+        if self.config.model and "-" in self.config.model:
+            return self.config.model
+
+        return self.DEFAULT_MODEL
+
+    def _get_max_tokens(self) -> int:
+        """Gibt max_tokens zurück.
+
+        Claude-Modelle via Poe aktivieren Thinking automatisch. Damit Poe's
+        intern abgeleitetes budget_tokens >= 1024 ist, muss max_tokens deutlich
+        höher sein (Response-Reserve wird vorher abgezogen).
+        """
+        model_id = self._get_model_id().lower()
+        min_tokens = 2048 if "claude" in model_id else 0
+        return max(self.config.max_tokens, min_tokens)
+
+    def classify_document(
+        self,
+        text: str,
+        available_folders: list[str],
+        keywords: list[str] = None,
+        detected_date: str = None,
+    ) -> LLMResponse:
+        """
+        Klassifiziert ein Dokument mit Poe.
+
+        Args:
+            text: Extrahierter Text aus dem Dokument
+            available_folders: Liste der verfügbaren Zielordner
+            keywords: Erkannte Schlüsselwörter
+            detected_date: Erkanntes Datum im Dokument
+
+        Returns:
+            LLMResponse mit Ordnervorschlag
+        """
+        if not self.is_available():
+            return LLMResponse(
+                success=False,
+                error_message="Poe API nicht verfügbar. API-Key prüfen."
+            )
+
+        if not available_folders:
+            return LLMResponse(
+                success=False,
+                error_message="Keine Zielordner verfügbar."
+            )
+
+        prompt = self._build_classification_prompt(
+            text, available_folders, keywords, detected_date
+        )
+
+        try:
+            response = self._client.chat.completions.create(
+                model=self._get_model_id(),
+                max_tokens=self._get_max_tokens(),
+                temperature=self.config.temperature,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "Du bist ein Assistent zum Sortieren von Dokumenten. "
+                                   "Antworte präzise im geforderten Format."
+                    },
+                    {"role": "user", "content": prompt}
+                ]
+            )
+
+            response_text = response.choices[0].message.content
+            parsed = self._parse_response(response_text)
+
+            # Prüfen ob der vorgeschlagene Ordner existiert
+            suggested_folder = parsed.get("folder")
+            if suggested_folder and suggested_folder not in available_folders:
+                suggested_folder = self._find_similar_folder(
+                    suggested_folder, available_folders
+                )
+
+            tokens_used = response.usage.total_tokens if response.usage else 0
+
+            return LLMResponse(
+                success=True,
+                folder_suggestion=suggested_folder,
+                folder_reason=parsed.get("reason"),
+                confidence=parsed.get("confidence", 0.5),
+                tokens_used=tokens_used,
+            )
+
+        except self._openai.APIConnectionError:
+            return LLMResponse(
+                success=False,
+                error_message="Keine Verbindung zur Poe API."
+            )
+        except self._openai.RateLimitError:
+            return LLMResponse(
+                success=False,
+                error_message="Poe API Rate-Limit erreicht. Bitte später versuchen."
+            )
+        except self._openai.AuthenticationError:
+            return LLMResponse(
+                success=False,
+                error_message="Ungültiger Poe API-Key."
+            )
+        except Exception as e:
+            return LLMResponse(
+                success=False,
+                error_message=f"Poe API Fehler: {str(e)}"
+            )
+
+    def suggest_filename(
+        self,
+        text: str,
+        current_filename: str,
+        keywords: list[str] = None,
+        detected_date: str = None,
+        target_folder: str = None,
+        file_date: str = None,
+    ) -> LLMResponse:
+        """
+        Schlägt einen Dateinamen mit Poe vor.
+
+        Args:
+            text: Extrahierter Text aus dem Dokument
+            current_filename: Aktueller Dateiname
+            keywords: Erkannte Schlüsselwörter
+            detected_date: Erkanntes Datum im Dokument
+            target_folder: Zielordner
+            file_date: Änderungsdatum der Datei (Fallback)
+
+        Returns:
+            LLMResponse mit Dateinamenvorschlag
+        """
+        if not self.is_available():
+            return LLMResponse(
+                success=False,
+                error_message="Poe API nicht verfügbar. API-Key prüfen."
+            )
+
+        prompt = self._build_filename_prompt(
+            text, current_filename, keywords, detected_date, target_folder, file_date
+        )
+
+        try:
+            response = self._client.chat.completions.create(
+                model=self._get_model_id(),
+                max_tokens=self._get_max_tokens(),
+                temperature=self.config.temperature,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "Du bist ein Assistent zum Benennen von Dokumenten. "
+                                   "Antworte präzise im geforderten Format."
+                    },
+                    {"role": "user", "content": prompt}
+                ]
+            )
+
+            response_text = response.choices[0].message.content
+            parsed = self._parse_response(response_text)
+
+            # Dateiname validieren
+            filename = parsed.get("filename")
+            if filename:
+                filename = self._sanitize_filename(filename)
+
+            tokens_used = response.usage.total_tokens if response.usage else 0
+
+            return LLMResponse(
+                success=True,
+                filename_suggestion=filename,
+                filename_reason=parsed.get("reason"),
+                confidence=parsed.get("confidence", 0.5),
+                tokens_used=tokens_used,
+                metadata=parsed.get("metadata"),
+            )
+
+        except Exception as e:
+            return LLMResponse(
+                success=False,
+                error_message=f"Poe API Fehler: {str(e)}"
+            )
+
+    def _find_similar_folder(
+        self, suggested: str, available: list[str]
+    ) -> Optional[str]:
+        """
+        Findet einen ähnlichen Ordner aus der Liste.
+
+        Args:
+            suggested: Vorgeschlagener Ordnername
+            available: Verfügbare Ordner
+
+        Returns:
+            Ähnlicher Ordnername oder None
+        """
+        suggested_lower = suggested.lower()
+
+        # Exakte Übereinstimmung (case-insensitive)
+        for folder in available:
+            if folder.lower() == suggested_lower:
+                return folder
+
+        # Teilübereinstimmung
+        for folder in available:
+            if suggested_lower in folder.lower() or folder.lower() in suggested_lower:
+                return folder
+
+        return None
+
+    def _sanitize_filename(self, filename: str) -> str:
+        """
+        Bereinigt einen Dateinamen.
+
+        Args:
+            filename: Roher Dateiname
+
+        Returns:
+            Bereinigter Dateiname
+        """
+        # Entferne ungültige Zeichen
+        invalid_chars = '<>:"/\\|?*'
+        for char in invalid_chars:
+            filename = filename.replace(char, "_")
+
+        # Umlaute ersetzen
+        replacements = {
+            "ä": "ae", "ö": "oe", "ü": "ue",
+            "Ä": "Ae", "Ö": "Oe", "Ü": "Ue",
+            "ß": "ss"
+        }
+        for old, new in replacements.items():
+            filename = filename.replace(old, new)
+
+        # Leerzeichen durch Unterstriche
+        filename = filename.replace(" ", "_")
+
+        # Sicherstellen, dass .pdf Endung vorhanden
+        if not filename.lower().endswith(".pdf"):
+            filename += ".pdf"
+
+        # Maximale Länge
+        if len(filename) > 84:  # 80 + .pdf
+            filename = filename[:80] + ".pdf"
+
+        return filename
+
+    @classmethod
+    def get_available_models(cls) -> list[tuple[str, str]]:
+        """
+        Gibt eine Liste der verfügbaren Modelle zurück.
+
+        Returns:
+            Liste von (display_name, model_id) Tupeln
+        """
+        return [(f"{v} ({k})", v) for k, v in cls.MODELS.items()]
+
+    # ------------------------------------------------------------------ #
+    # RAG-Chat (Phase 19, M1)                                            #
+    # ------------------------------------------------------------------ #
+
+    REQUEST_TIMEOUT = 120
+
+    def _http_post_json(
+        self,
+        url: str,
+        body: dict,
+        headers: dict,
+        timeout: int = None,
+    ) -> tuple[Optional[dict], Optional[str]]:
+        """
+        Minimaler HTTP-POST-Wrapper. Liefert (parsed_dict, error_str).
+        Bei urllib-Fehlern wird ``(None, fehlertext)`` zurueckgegeben.
+        """
+        if timeout is None:
+            timeout = self.REQUEST_TIMEOUT
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode("utf-8")), None
+        except urllib.error.HTTPError as e:
+            try:
+                detail = e.read().decode("utf-8", errors="replace")
+            except Exception:
+                detail = ""
+            return None, f"Poe HTTP {e.code}: {detail}"
+        except urllib.error.URLError as e:
+            return None, f"Keine Verbindung zur Poe API: {e.reason}"
+        except Exception as e:
+            return None, f"Poe-Fehler: {e}"
+
+    def answer_with_context(
+        self,
+        system_prompt: str,
+        context_docs: list[dict],
+        user_question: str,
+        max_tokens: int = 1000,
+    ) -> str:
+        """
+        Beantwortet eine Nutzerfrage im Kontext der uebergebenen Dokumente.
+
+        Poe nutzt eine OpenAI-kompatible ``chat/completions`` API -
+        der einzige Unterschied ist die Basis-URL (``self.BASE_URL``).
+        Wir gehen ebenfalls ueber ``urllib``, um keine zusaetzliche
+        Dependency einzufuehren.
+        """
+        if not self.config.api_key:
+            return ""
+
+        from src.rag.prompts import build_context_block, build_user_prompt
+
+        context_block = build_context_block(context_docs)
+        user_prompt = build_user_prompt(user_question, context_block=context_block)
+
+        body = {
+            "model": self._get_model_id(),
+            "max_tokens": self._get_max_tokens(),
+            "temperature": self.config.temperature,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.config.api_key}",
+        }
+        url = f"{self.BASE_URL}/chat/completions"
+        data, error = self._http_post_json(url, body, headers)
+        if error or not data:
+            return f"[Poe-Fehler: {error}]"
+
+        choices = data.get("choices") or []
+        if not choices:
+            return ""
+        message = choices[0].get("message") or {}
+        return message.get("content", "") or ""

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -71,9 +71,13 @@ class Config:
         "folder_naming_initials": "",
         # LLM-Konfiguration
         "llm": {
-            "provider": "none",  # "none", "claude", "openai", "openrouter", "ollama", "ollama_cloud"
+            # Gueltige Werte: "none", "claude", "openai", "poe",
+            # "openrouter", "ollama", "ollama_cloud".
+            # "poe" war in 0.19.0 kurzzeitig entfernt (Issue #66) und wird
+            # wieder unterstuetzt - poe.com vergibt wieder API-Keys.
+            "provider": "none",
             "api_key": "",  # Key des aktiven Providers (Spiegel von api_keys)
-            "api_keys": {},  # API-Keys pro Provider, z.B. {"openrouter": "...", "claude": "..."}
+            "api_keys": {},  # API-Keys pro Provider, z.B. {"openrouter": "...", "poe": "..."}
             "model": "",  # z.B. "haiku", "sonnet", "gpt-4o-mini", "llama3.1"
             "max_tokens": 500,
             "temperature": 0.3,
@@ -128,27 +132,6 @@ class Config:
             except (json.JSONDecodeError, IOError) as e:
                 logger.error(f"Fehler beim Laden der Konfiguration: {e}")
                 self._config = copy.deepcopy(self.DEFAULTS)
-        self._migrate_poe_provider()
-
-    def _migrate_poe_provider(self) -> None:
-        """Migriert alte Configs weg vom entfernten Poe-Provider (Issue #66).
-
-        Poe.com vergibt keine API-Keys mehr, der Provider wurde entfernt.
-        Bestehende Configs mit ``llm.provider == "poe"`` werden auf "none"
-        zurueckgesetzt, ein evtl. gespeicherter Poe-Key wird verworfen.
-        """
-        llm = self._config.get("llm")
-        if not isinstance(llm, dict) or llm.get("provider") != "poe":
-            return
-        logger.warning(
-            "LLM-Provider 'poe' ist nicht mehr verfuegbar (poe.com vergibt "
-            "keine API-Keys mehr) - Einstellung wird auf 'none' zurueckgesetzt."
-        )
-        llm["provider"] = "none"
-        llm["api_key"] = ""
-        api_keys = llm.get("api_keys")
-        if isinstance(api_keys, dict):
-            api_keys.pop("poe", None)
 
     def save(self) -> None:
         """Speichert die Konfiguration in die Datei."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,12 +29,13 @@ def test_set_llm_api_key_ollama_not_stored_per_provider(tmp_path):
     assert cfg.get_llm_config()["api_keys"] == {}
 
 
-def test_load_migrates_poe_provider_to_none(tmp_path):
-    """Issue #66: poe.com vergibt keine API-Keys mehr, Provider wurde entfernt.
+def test_load_keeps_poe_provider(tmp_path):
+    """Issue #66: poe.com vergibt wieder API-Keys, Poe ist wieder waehlbar.
 
-    Eine bestehende Config mit ``llm.provider == "poe"`` soll beim Laden
-    automatisch auf "none" zurueckgesetzt werden, inkl. Entfernen eines
-    evtl. gespeicherten Poe-Keys aus ``api_keys``.
+    Eine gespeicherte Config mit ``llm.provider == "poe"`` muss beim Laden
+    unveraendert erhalten bleiben - insbesondere darf sie nicht (wie in
+    0.19.0) still auf "none" heruntergestuft und der Poe-Key verworfen
+    werden.
     """
     import json
     from src.utils.config import Config
@@ -54,9 +55,9 @@ def test_load_migrates_poe_provider_to_none(tmp_path):
     cfg = Config(config_path=config_path)
     llm = cfg.get_llm_config()
 
-    assert llm["provider"] == "none"
-    assert llm["api_key"] == ""
-    assert "poe" not in llm["api_keys"]
+    assert llm["provider"] == "poe"
+    assert llm["api_key"] == "poe-key"
+    assert llm["api_keys"]["poe"] == "poe-key"
     assert llm["api_keys"]["openrouter"] == "sk-or-key"
 
 

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -6,6 +6,7 @@ def test_cloud_providers_set():
 
     assert is_cloud_provider("claude") is True
     assert is_cloud_provider("openai") is True
+    assert is_cloud_provider("poe") is True
     assert is_cloud_provider("openrouter") is True
     assert is_cloud_provider("ollama_cloud") is True
     assert is_cloud_provider("ollama") is False

--- a/tests/test_poe_provider.py
+++ b/tests/test_poe_provider.py
@@ -1,0 +1,74 @@
+"""Tests fuer src/ml/poe_provider.py (Issue #66: Provider wieder aufgenommen)."""
+
+
+def _make(model="", api_key=""):
+    from src.ml.llm_provider import LLMConfig
+    from src.ml.poe_provider import PoeProvider
+    return PoeProvider(LLMConfig(api_key=api_key, model=model))
+
+
+def test_uses_poe_base_url():
+    from src.ml.poe_provider import PoeProvider
+    assert PoeProvider.BASE_URL == "https://api.poe.com/v1"
+    assert PoeProvider.DEFAULT_MODEL == "GPT-4o-Mini"
+
+
+def test_model_id_mapping_and_default():
+    # Kurzname aus MODELS wird auf den Poe-Bot-Namen gemappt
+    assert _make("claude-3.5-haiku")._get_model_id() == "Claude-3.5-Haiku"
+    # Bereits ein Poe-Bot-Name -> unveraendert durchgereicht
+    assert _make("Gemini-2.5-Pro")._get_model_id() == "Gemini-2.5-Pro"
+    # Kein Modell gesetzt -> Default
+    assert _make("")._get_model_id() == "GPT-4o-Mini"
+
+
+def test_max_tokens_reserve_for_claude_models():
+    """Claude via Poe aktiviert Thinking - max_tokens muss dafuer reichen."""
+    from src.ml.llm_provider import LLMConfig
+    from src.ml.poe_provider import PoeProvider
+
+    claude = PoeProvider(LLMConfig(api_key="", model="claude-3.5-haiku", max_tokens=500))
+    assert claude._get_max_tokens() >= 2048
+
+    gpt = PoeProvider(LLMConfig(api_key="", model="gpt-4o-mini", max_tokens=500))
+    assert gpt._get_max_tokens() == 500
+
+
+def test_not_available_without_api_key():
+    p = _make("gpt-4o-mini", api_key="")
+    assert not p.is_available()
+    r = p.classify_document("text", ["Rechnungen"])
+    assert r.success is False
+    assert "Poe" in r.error_message
+
+
+def test_answer_with_context_without_key_returns_empty():
+    assert _make("gpt-4o-mini", api_key="").answer_with_context("sys", [], "Frage?") == ""
+
+
+def test_client_created_with_poe_base_url(monkeypatch):
+    import types
+    import sys
+    captured = {}
+
+    class _FakeOpenAI:
+        def __init__(self, api_key=None, base_url=None):
+            captured["api_key"] = api_key
+            captured["base_url"] = base_url
+
+    fake = types.SimpleNamespace(OpenAI=_FakeOpenAI)
+    monkeypatch.setitem(sys.modules, "openai", fake)
+
+    p = _make("gpt-4o-mini", api_key="poe-test-key")
+    assert p.is_available()
+    assert captured == {"api_key": "poe-test-key", "base_url": "https://api.poe.com/v1"}
+
+
+def test_hybrid_classifier_maps_poe_type():
+    """LLMProviderType.POE muss auf den PoeProvider zeigen."""
+    from src.ml.llm_provider import LLMProviderType
+    from src.ml.poe_provider import PoeProvider
+    import src.ml.hybrid_classifier as hc
+
+    assert LLMProviderType.POE.value == "poe"
+    assert hc.PoeProvider is PoeProvider

--- a/tests/test_settings_api_keys_gui.py
+++ b/tests/test_settings_api_keys_gui.py
@@ -119,6 +119,45 @@ def test_save_keeps_consent_and_cached_models(qtbot, fresh_config):
     assert saved["cached_models"] == {"openrouter": ["openai/gpt-4.1-nano"]}
 
 
+def test_poe_is_selectable_with_own_key(qtbot, fresh_config):
+    """Issue #66: Poe.com ist wieder waehlbar und haelt einen eigenen Key."""
+    d = _dialog(qtbot)
+
+    _select(d, "poe")
+    assert d._provider_id_at(d.provider_combo.currentIndex()) == "poe"
+    assert d.api_key_label.text() == "API-Key (Poe.com):"
+    assert d.cloud_consent_check.isEnabled()  # Poe ist ein Cloud-Anbieter
+    d.api_key_input.setText("poe-key")
+
+    _select(d, "openrouter")
+    assert d.api_key_input.text() == ""  # Poe-Key darf nicht mitwandern
+    d.api_key_input.setText("sk-or-key")
+
+    _select(d, "poe")
+    assert d.api_key_input.text() == "poe-key"
+    d._save_settings()
+
+    llm = fresh_config.get_llm_config()
+    assert llm["provider"] == "poe"
+    assert llm["api_key"] == "poe-key"
+    assert llm["api_keys"] == {"poe": "poe-key", "openrouter": "sk-or-key"}
+
+
+def test_poe_provider_from_config_is_preselected(qtbot, fresh_config):
+    """Ein gespeicherter Poe-Provider wird beim Oeffnen wieder angezeigt."""
+    llm = fresh_config.get_llm_config()
+    llm.update({
+        "provider": "poe",
+        "api_key": "poe-key",
+        "api_keys": {"poe": "poe-key"},
+    })
+    fresh_config.set("llm", llm)
+
+    d = _dialog(qtbot)
+    assert d.provider_combo.currentIndex() == d._index_for_provider("poe")
+    assert d.api_key_input.text() == "poe-key"
+
+
 def test_consent_checkbox_only_for_cloud_providers(qtbot, fresh_config):
     d = _dialog(qtbot)
     _select(d, "ollama")


### PR DESCRIPTION
## Warum

Issue #66 wurde in PR #79 damit geschlossen, dass der Poe-Provider komplett entfernt wurde - Begruendung: poe.com vergibt keine API-Keys mehr. Das stimmt nicht mehr: `poe.com/api_key` vergibt wieder Keys. Dieser PR nimmt die Entfernung zurueck.

## Was

`src/ml/poe_provider.py` ist **unveraendert aus v0.18.0** wiederhergestellt - das Provider-Interface (`LLMProvider`, `_build_*_prompt`, `_parse_response`) hat sich seitdem nicht geaendert, `git diff v0.18.0 HEAD -- src/ml/openai_provider.py` ist leer. Poe spricht die OpenAI-kompatible API unter `https://api.poe.com/v1`, es kommt keine neue Abhaengigkeit dazu (`openai` + `urllib`, beides schon im Einsatz).

Die Wiederanbindung erfolgt am **ID-basierten Auswahlschema aus PR #82**, nicht an der alten Combo-Index-Logik:

| Datei | Aenderung |
|---|---|
| `src/ml/poe_provider.py` | neu (Restore aus v0.18.0) |
| `src/ml/llm_provider.py` | `LLMProviderType.POE`, Poe in `CLOUD_PROVIDERS` (Consent-Gate greift) |
| `src/ml/hybrid_classifier.py` | Import, beide Provider-Zweige, Default-Modell `GPT-4o-Mini`, Anzeigename "Poe" |
| `src/gui/settings_dialog.py` | Eintrag in `_LLM_PROVIDERS` (nach OpenRouter), Key-Label/Platzhalter, Modell-Liste, `_test_poe()`, `_fetch_poe_models()` |
| `src/gui/setup_wizard.py` | `_PROVIDER_IDS`/Labels (nach OpenRouter), Key-URL `poe.com/api_key`, Hinweis- und Anleitungstext |
| `src/utils/config.py` | `_migrate_poe_provider()` inkl. Aufruf **entfernt** |
| `scripts/qa_all_providers.py` | Poe wieder im Smoke-Test |

**Wichtig fuer Bestandsnutzer:** `_migrate_poe_provider()` hat eine gespeicherte Config mit `provider: "poe"` still auf `"none"` heruntergestuft und den Key verworfen. Das ist raus - ein gespeicherter Poe-Provider bleibt jetzt erhalten.

## Tests

- `tests/test_config.py`: Migrationstest ersetzt durch `test_load_keeps_poe_provider` (Poe bleibt Poe, Key bleibt erhalten)
- `tests/test_llm_provider.py`: `is_cloud_provider("poe") is True`
- `tests/test_settings_api_keys_gui.py`: zwei Poe-Tests ueber `_index_for_provider("poe")` (Key-Isolation, Speichern, Vorauswahl beim Laden)
- `tests/test_poe_provider.py`: neu - Base-URL, Modell-Mapping, `max_tokens`-Reserve fuer Claude-Modelle, graceful ohne Key, Client-Konstruktion (gemockt)

Voller Lauf: **593 passed, 1 failed**. Der Fehlschlag ist `test_pdf_preview_widget_gui.py::test_preview_window_shows_pdf_and_remembers_geometry` (Fenster-Geometrie, bildschirmabhaengig) - er faellt auf `main` ohne diese Aenderungen genauso und ist unabhaengig von Poe.

`python scripts/qa_all_providers.py` -> `ALL_OK` (inkl. poe).

Nicht getestet: ein echter Poe-API-Call - dafuer liegt hier kein API-Key vor. Der Netzwerkpfad ist unveraenderter v0.18.0-Code, der davor produktiv lief.

Refs #66
