### PR TITLE
chore(release): v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-08-28
+
 ### Hinzugefuegt
 - **Ollama-Empfehlung fuer Laptops ohne dedizierte GPU** (Issue #62): hat das
   System genug Arbeitsspeicher (ab 16 GB, z.B. schneller Shared-RAM), empfiehlt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdf-sortier-meister"
-version = "0.19.0"
+version = "0.20.0"
 description = "Ein intelligentes Programm zum Sortieren und Umbenennen von gescannten PDF-Dokumenten"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,7 @@ from src.utils.single_instance import (
 from src.utils.explorer_integration import update_launcher_script
 
 # Versionsnummer zentral definiert
-__version__ = "0.19.0"
+__version__ = "0.20.0"
 
 
 def _apply_wizard_result(window, config):


### PR DESCRIPTION
Versions-Bump auf 0.20.0 (src/main.py, pyproject.toml), CHANGELOG-Abschnitt [0.20.0] - 2026-08-28. Inhalt: Aktivitaetsanzeige (#68), Wizard Default-/Zielordner (#61/#64), Ollama-Empfehlung ohne GPU + Release-Checkliste (#62/#63), Poe.com wieder verfuegbar (#66). Tests gruen.