### PR TITLE
fix: Mac-Feedback 2026-08-28 (Reasoning, leere KI-Antworten, gpt-oss, Panel-Refresh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,15 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 - **Nachdenken minimiert**: OpenRouter `reasoning.effort=low`, OpenAI
   o*/gpt-5 `reasoning_effort=minimal`, Ollama `think:false` - jeweils mit
   Rueckfall, falls ein Modell den Parameter ablehnt. Gemessen: 3-4 s statt
-  10-18 s pro PDF.
+  10-18 s pro PDF. Modelle, die das Denken nicht abschalten koennen (gpt-oss:
+  nur low/medium/high) antworten auf `think:false` mit leerem Inhalt oder
+  Denktext statt JSON; gpt-oss wird am Namen erkannt und direkt mit
+  `think:"low"` gefragt, andere Modelle fallen bei unbrauchbarer Antwort
+  einmalig auf `low` zurueck (gemerkt pro Sitzung). Die Anzeige „KI-Fehler“
+  in der Statusleiste verschwindet von selbst, sobald die betroffene PDF ein
+  Ergebnis bekommt oder der Pre-Cache-Lauf nach dem Fehler ohne weitere
+  Fehler zu Ende laeuft. PDFs, deren KI-Abruf gescheitert ist, werden
+  einmalig neu eingereiht, sobald danach ein Abruf gelingt.
 - **Fremde PDF-Metadaten**: eine `dc:description`, die nur ein Dateiname ist
   (z.B. HUK-COBURG-Dokumente), landet nicht mehr als "Zusammenfassung" im
   Panel. "Quelle: aus PDF gelesen" nur noch, wenn alle Felder wirklich aus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Behoben
+- **KI-Vorschlaege fehlten still** bei Reasoning-Modellen (z.B. GLM-5.3-flash
+  via OpenRouter): das Modell verbrauchte das Token-Budget fuers Nachdenken,
+  die leere Antwort wurde als Erfolg ohne Vorschlag gecacht und nie wieder
+  versucht. Leere/abgeschnittene Antworten gelten jetzt als Fehler (sichtbar
+  in der Statusleiste und im Detail-Panel), leere Ergebnisse werden nicht mehr
+  als "abgerufen" gespeichert, `max_tokens` Default 2000 (alter Wert 500 wird
+  beim Laden angehoben).
+- **Nachdenken minimiert**: OpenRouter `reasoning.effort=low`, OpenAI
+  o*/gpt-5 `reasoning_effort=minimal`, Ollama `think:false` - jeweils mit
+  Rueckfall, falls ein Modell den Parameter ablehnt. Gemessen: 3-4 s statt
+  10-18 s pro PDF.
+- **Fremde PDF-Metadaten**: eine `dc:description`, die nur ein Dateiname ist
+  (z.B. HUK-COBURG-Dokumente), landet nicht mehr als "Zusammenfassung" im
+  Panel. "Quelle: aus PDF gelesen" nur noch, wenn alle Felder wirklich aus
+  dem PDF stammen; sonst "teils aus PDF gelesen, teils Vorschlag".
+- **Detail-Panel aktualisiert sich**, wenn KI-Vorschlaege fuer die gerade
+  ausgewaehlte PDF im Hintergrund eintreffen (vorher: andere PDF anklicken
+  und zurueck). Eigene Eingaben werden dabei nicht ueberschrieben.
+- **Checkbox-Kaestchen** waren auf Retina-Macs praktisch unsichtbar
+  (Fusion-Stil); jetzt kontrastreiche Indikatoren auf allen Plattformen.
+  Einstellungen > Dateinamen-Muster: Initialen/Vorlage sind immer editierbar,
+  Eintippen von Initialen schaltet die Funktion ein.
+
+### Geaendert
+- Statusleiste zeigt Provider und Modell (`LLM: OpenRouter/glm-5.3-flash`);
+  KI-Fehler als "⚠ KI-Fehler (Doppelklick)" mit Fehlertext im Tooltip; der
+  Doppelklick-Dialog hat einen Button "Log-Datei oeffnen".
+
 ## [0.20.0] - 2026-08-28
 
 ### Hinzugefuegt

--- a/src/core/pdf_cache.py
+++ b/src/core/pdf_cache.py
@@ -300,6 +300,11 @@ class PDFCache(QObject):
         # Betrieb -> Absturz (Access Violation).
         self._stopping_workers: list[QThread] = []
         self._llm_queued: set[Path] = set()  # PDFs, die in der LLM-Queue stehen
+        # Gescheiterte LLM-Abrufe: werden einmalig neu eingereiht, sobald
+        # danach ein Abruf gelingt (Provider hat sich z.B. per Rueckfall
+        # "gefangen"). _llm_retried verhindert Endlosschleifen.
+        self._llm_failed: set[Path] = set()
+        self._llm_retried: set[Path] = set()
         self._pending_callbacks: dict[Path, list[Callable]] = {}
         self._persist_cache = True  # Standardmäßig persistenten Cache nutzen
         self._db_path: Optional[Path] = None
@@ -705,6 +710,11 @@ class PDFCache(QObject):
         self._llm_worker.add_task(pdf_path, analysis_result, priority=10)
         return True
 
+    def llm_pending_count(self) -> int:
+        """Anzahl PDFs, die noch in der LLM-Queue stehen (0 = Lauf beendet)."""
+        with self._lock:
+            return len(self._llm_queued)
+
     def _on_llm_suggestions_complete(self, pdf_path: Path, suggestions: list):
         """Wird aufgerufen wenn LLM-Vorschläge abgerufen wurden."""
         logger.debug(f"LLM-Pre-Cache: {len(suggestions)} Vorschläge für {pdf_path.name}")
@@ -721,15 +731,35 @@ class PDFCache(QObject):
 
                 # Aktualisiert in persistentem Cache speichern
                 self._save_to_db(self._cache[pdf_path])
+            self._llm_failed.discard(pdf_path)
+            retry = [p for p in self._llm_failed if p not in self._llm_retried]
+            self._llm_failed.clear()
+            self._llm_retried.update(retry)
 
         # Signal emittieren
         self.llm_suggestions_ready.emit(pdf_path)
+        self._retry_failed_llm(retry)
+
+    def _retry_failed_llm(self, pdf_paths: list[Path]):
+        """Reiht zuvor gescheiterte PDFs erneut ein (niedrige Prioritaet = ans Ende)."""
+        for failed in pdf_paths:
+            cached = self.get(failed)
+            if not cached or cached.llm_fetched:
+                continue
+            with self._lock:
+                if failed in self._llm_queued:
+                    continue
+                self._llm_queued.add(failed)
+            logger.info(f"LLM-Pre-Cache: {failed.name} nach Fehler erneut eingereiht")
+            self.start_llm_worker()
+            self._llm_worker.add_task(failed, cached, priority=20)
 
     def _on_llm_suggestions_error(self, pdf_path: Path, error: str):
         """Wird aufgerufen wenn LLM-Abruf fehlschlägt."""
         logger.warning(f"LLM-Pre-Cache Fehler für {pdf_path.name}: {error}")
         with self._lock:
             self._llm_queued.discard(pdf_path)
+            self._llm_failed.add(pdf_path)
         self.llm_suggestions_failed.emit(pdf_path, error)
 
     def _on_llm_suggestions_skipped(self, pdf_path: Path):

--- a/src/core/pdf_cache.py
+++ b/src/core/pdf_cache.py
@@ -236,6 +236,15 @@ class LLMSuggestionWorker(QThread):
                                 metadata=getattr(s, 'metadata', None),
                             ))
 
+                    if not llm_suggestions:
+                        # Kein KI-Vorschlag: als Fehler melden statt still als
+                        # "abgerufen" zu cachen (sonst nie wieder ein Versuch)
+                        err = getattr(self._hybrid_classifier, "last_llm_error", None)
+                        self.suggestions_error.emit(
+                            pdf_path, err or "KI hat keinen Vorschlag geliefert."
+                        )
+                        continue
+
                     self.suggestions_complete.emit(pdf_path, llm_suggestions)
 
                 except Exception as e:
@@ -411,7 +420,11 @@ class PDFCache(QObject):
                                 # Roh-Schluessel des Modells (category, beschreibung)
                                 metadata=normalize_llm_metadata(s.get("metadata")) or None,
                             ))
-                        llm_fetched = bool(len(row) > 7 and row[7])
+                        # Aeltere Versionen haben leere KI-Ergebnisse (z.B. bei
+                        # zu kleinem Token-Limit) als "abgerufen" gespeichert.
+                        # Solche Eintraege gelten als offen, damit die
+                        # Vorabfrage sie erneut versucht.
+                        llm_fetched = bool(len(row) > 7 and row[7]) and bool(llm_suggestions)
                         if llm_suggestions:
                             llm_count += 1
                     except Exception:
@@ -697,6 +710,11 @@ class PDFCache(QObject):
         logger.debug(f"LLM-Pre-Cache: {len(suggestions)} Vorschläge für {pdf_path.name}")
         with self._lock:
             self._llm_queued.discard(pdf_path)
+            if not suggestions:
+                # Leeres Ergebnis nicht als "abgerufen" persistieren - die PDF
+                # darf beim naechsten Mal erneut angefragt werden
+                logger.info(f"LLM-Pre-Cache: kein Vorschlag für {pdf_path.name}, nicht gecacht")
+                return
             if pdf_path in self._cache:
                 self._cache[pdf_path].llm_suggestions = suggestions
                 self._cache[pdf_path].llm_fetched = True

--- a/src/core/pdf_metadata.py
+++ b/src/core/pdf_metadata.py
@@ -5,6 +5,7 @@ Schreibt Metadaten direkt in PDF-Dateien (dual: XMP in PDF + SQLite-Index).
 Kompatibel mit Paperless-ngx, DEVONthink, Adobe Acrobat.
 """
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -125,7 +126,9 @@ def read_metadata(pdf_path: Path) -> Optional[PDFMetadata]:
             with pdf.open_metadata() as meta:
                 metadata.title = meta.get("dc:title", None)
                 metadata.subject = meta.get("dc:subject", None)
-                metadata.description = meta.get("dc:description", None)
+                metadata.description = _clean_foreign_description(
+                    meta.get("dc:description", None)
+                )
                 metadata.keywords = meta.get("pdf:Keywords", None)
 
             # Custom-Felder lesen
@@ -138,6 +141,31 @@ def read_metadata(pdf_path: Path) -> Optional[PDFMetadata]:
     except Exception as e:
         print(f"Fehler beim Lesen der Metadaten aus {pdf_path.name}: {e}")
         return None
+
+
+_FILENAME_LIKE = re.compile(r"[^\s/\\]+\.pdf", re.IGNORECASE)
+
+
+def looks_like_filename(value) -> bool:
+    """True, wenn ein Text nur aus einem Dateinamen wie ``2024-01-31_Brief.pdf`` besteht."""
+    if value is None:
+        return False
+    return bool(_FILENAME_LIKE.fullmatch(str(value).strip()))
+
+
+def _clean_foreign_description(value):
+    """Verwirft dc:description-Werte, die kein Inhalt sind.
+
+    Manche Dokumentensysteme (z.B. M/TEXT bei Versicherungen) schreiben ihren
+    internen Dateinamen in dc:description. Das ist keine Zusammenfassung und
+    wuerde sonst als "aus PDF gelesen" im Feld Zusammenfassung landen.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or looks_like_filename(text):
+        return None
+    return text
 
 
 def _write_custom_fields(pdf, metadata: PDFMetadata):

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -128,8 +128,14 @@ class DetailPanel(QWidget):
         self._has_learned_overrides: bool = False
         # Quelle der aktuell angezeigten Metadaten: "pdf", "llm", "user", None
         self._metadata_source: Optional[str] = None
+        # Zuletzt automatisch (aus Vorschlag) gesetzter Dateiname - dient zur
+        # Erkennung, ob der Nutzer den Namen selbst geaendert hat
+        self._auto_name: str = ""
         # Snapshot der zuletzt gespeicherten Metadaten (entspricht PDF-Stand)
         self._saved_metadata_snapshot: dict = {}
+        # Felder, die tatsaechlich aus dem PDF (XMP/Info) gelesen wurden - nur
+        # diese gelten als "gespeichert"; Analyse-/KI-Werte daneben nicht
+        self._pdf_field_keys: set = set()
         # Flag um textChanged-Signale während des programmatischen Füllens zu ignorieren
         self._loading_metadata: bool = False
         # KI-Aufruf "Metadaten neu generieren" laeuft im Hintergrund (Issue #68)
@@ -469,6 +475,7 @@ class DetailPanel(QWidget):
         # 1. Gespeicherte XMP-Metadaten werden im Hintergrund gelesen und danach
         #    nachgetragen (siehe _on_pdf_metadata_read). Bis dahin: Basis aus Analyse.
         self._saved_metadata_snapshot = {}
+        self._pdf_field_keys = set()
         pdf_had_data = False
         self._start_metadata_reader(pdf_path)
 
@@ -520,9 +527,11 @@ class DetailPanel(QWidget):
         self._refresh_save_btn()
 
         # Ersten Vorschlag als Name setzen
+        self._auto_name = ""
         if self._suggestions:
             name = self._suggestions[0].name.replace('.pdf', '')
             self.name_input.setText(name)
+            self._auto_name = name
 
         # UI umschalten
         self.placeholder.hide()
@@ -655,6 +664,16 @@ class DetailPanel(QWidget):
                 metadata[field_key] = value
         return metadata
 
+    def has_user_edits(self) -> bool:
+        """True, wenn der Nutzer Dateiname oder Metadaten selbst geaendert hat.
+
+        Wird genutzt, um das Panel nicht ueber Nutzereingaben hinweg zu
+        aktualisieren, wenn spaeter KI-Vorschlaege aus dem Hintergrund eintreffen.
+        """
+        if self._metadata_source == "user":
+            return True
+        return self.name_input.text().strip() != self._auto_name
+
     def get_current_pdf(self) -> Optional[Path]:
         """Gibt den Pfad der aktuell angezeigten PDF zurück."""
         return self._current_pdf
@@ -690,6 +709,7 @@ class DetailPanel(QWidget):
         """Uebertraegt PDFMetadata in die Felder und setzt Quelle auf 'pdf'."""
         if pdf_meta is None or not pdf_meta.has_any_data():
             self._saved_metadata_snapshot = {}
+            self._pdf_field_keys = set()
             return
 
         # Felder aus PDFMetadata in _metadata-Dict übertragen
@@ -704,22 +724,39 @@ class DetailPanel(QWidget):
             "steuerjahr": pdf_meta.steuerjahr,
             "description": pdf_meta.description,
         }
+        pdf_keys = set()
         for key, value in field_map.items():
             if value:
                 self._metadata[key] = value
+                pdf_keys.add(key)
+        if not pdf_keys:
+            # Nur Felder vorhanden, die das Panel nicht anzeigt (z.B. Titel)
+            self._saved_metadata_snapshot = {}
+            self._pdf_field_keys = set()
+            return
 
         self._loading_metadata = True
         self._apply_metadata_to_fields()
         self._loading_metadata = False
 
-        self._metadata_source = "pdf"
-        self._saved_metadata_snapshot = self.get_metadata()
+        # Als "gespeichert" gilt nur, was wirklich im PDF steht. Werte aus
+        # Analyse/KI, die daneben in den Feldern stehen, sind noch ungesichert.
+        self._pdf_field_keys = pdf_keys
+        current = self.get_metadata()
+        self._saved_metadata_snapshot = {
+            k: v for k, v in current.items() if k in pdf_keys
+        }
+        if set(current.keys()) <= pdf_keys:
+            self._metadata_source = "pdf"
+        else:
+            self._metadata_source = "pdf_partial"
         self._refresh_save_btn()
 
     def mark_metadata_saved(self):
         """Markiert den aktuellen Zustand als gespeichert (nach erfolgreichem Schreiben)."""
         self._metadata_source = "pdf"
         self._saved_metadata_snapshot = self.get_metadata()
+        self._pdf_field_keys = set(self._saved_metadata_snapshot.keys())
         self._refresh_save_btn()
 
     def _on_metadata_user_edit(self, *args):
@@ -780,6 +817,15 @@ class DetailPanel(QWidget):
             self.metadata_status_label.setStyleSheet(
                 "font-size: 10px; padding: 2px 6px; border-radius: 3px; "
                 "background-color: #e8f5e9; color: #2e7d32;"
+            )
+            self.metadata_status_label.show()
+        elif source == "pdf_partial":
+            self.metadata_status_label.setText(
+                "Quelle: teils aus PDF gelesen, teils Vorschlag (noch nicht gespeichert)"
+            )
+            self.metadata_status_label.setStyleSheet(
+                "font-size: 10px; padding: 2px 6px; border-radius: 3px; "
+                "background-color: #fff8e1; color: #e65100;"
             )
             self.metadata_status_label.show()
         elif source == "llm":
@@ -954,6 +1000,19 @@ class DetailPanel(QWidget):
         self._llm_worker = worker
         worker.start()
 
+    def _show_llm_error(self, error: str):
+        """Zeigt einen KI-Fehler im Status-Label des Metadaten-Bereichs an."""
+        text = str(error).strip().splitlines()[0] if error else "KI-Fehler"
+        if len(text) > 160:
+            text = text[:157] + "…"
+        self.metadata_status_label.setText(f"KI-Fehler: {text}")
+        self.metadata_status_label.setToolTip(str(error))
+        self.metadata_status_label.setStyleSheet(
+            "font-size: 10px; padding: 2px 6px; border-radius: 3px; "
+            "background-color: #ffebee; color: #b71c1c;"
+        )
+        self.metadata_status_label.show()
+
     def _tick_llm_button(self):
         """Button zeigt laufende Uhr + Schaetzung, solange die KI arbeitet."""
         if self._llm_started is None:
@@ -974,6 +1033,8 @@ class DetailPanel(QWidget):
 
         if error:
             print(f"LLM-Metadaten Fehler: {error}")
+            if pdf_path == self._current_pdf:
+                self._show_llm_error(error)
             return
         if pdf_path != self._current_pdf:
             return
@@ -1016,6 +1077,14 @@ class DetailPanel(QWidget):
                     if s.source == "llm":
                         self.name_input.setText(s.filename.replace('.pdf', ''))
                         break
+                else:
+                    # Kein KI-Vorschlag angekommen - Grund anzeigen (z.B. Token-Limit)
+                    try:
+                        from src.ml.hybrid_classifier import get_hybrid_classifier
+                        reason = get_hybrid_classifier().last_llm_error
+                    except Exception:
+                        reason = None
+                    self._show_llm_error(reason or "KI hat keinen Vorschlag geliefert.")
 
             from src.core.pdf_cache import get_pdf_cache, LLMSuggestion as CacheLLMSuggestion
             llm_cached = [

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -773,12 +773,55 @@ class MainWindow(QMainWindow):
             label = f" „{job.label}“" if job.label else ""
             parts.append(f"KI arbeitet{label} {activity.describe()}")
         if self._last_llm_error:
-            parts.append("⚠ Fehler")
+            name, error = self._last_llm_error
+            parts.append("⚠ KI-Fehler (Doppelklick)")
+            self.cache_status_label.setToolTip(
+                f"Letzter KI-Fehler bei „{name}“:\n{error}\n\n"
+                "Doppelklick zeigt Details und öffnet die Log-Datei."
+            )
+        else:
+            self.cache_status_label.setToolTip("Doppelklick zeigt Details zur Hintergrund-Analyse.")
         self.cache_status_label.setText(" | ".join(parts))
 
     def _on_llm_suggestions_ready(self, pdf_path: Path):
         """KI-Vorschläge für eine PDF wurden abgerufen (Cache-Signal)."""
         self._update_cache_status()
+        self._refresh_detail_panel_after_llm(pdf_path)
+
+    def _refresh_detail_panel_after_llm(self, pdf_path: Path) -> bool:
+        """Traegt frische KI-Vorschlaege ins Detail-Panel ein, wenn die PDF
+        gerade ausgewaehlt ist und der Nutzer dort noch nichts geaendert hat.
+
+        Vorher blieb das Panel auf dem Stand von vor der KI-Abfrage stehen; man
+        musste eine andere PDF und dann wieder diese anklicken.
+
+        Returns:
+            True, wenn das Panel aktualisiert wurde.
+        """
+        if self.selected_pdf != pdf_path or self.selected_pdfs:
+            return False
+        panel = getattr(self, "detail_panel", None)
+        if panel is None or panel.get_current_pdf() != pdf_path:
+            return False
+        if panel.has_user_edits():
+            return False
+        result = self.pdf_cache.get(pdf_path)
+        if result is None or not self.pdf_cache.get_llm_suggestions(pdf_path):
+            return False
+        detected_date = self._detected_date_from(result.dates)
+        self._populate_detail_panel(pdf_path, result, detected_date)
+        self.statusbar.showMessage(f"KI-Vorschläge für {pdf_path.name} eingetragen", 4000)
+        return True
+
+    @staticmethod
+    def _detected_date_from(dates) -> Optional[str]:
+        """Erstes erkanntes Datum als YYYY-MM-DD (oder None)."""
+        if not dates:
+            return None
+        first_date = dates[0]
+        if hasattr(first_date, "strftime"):
+            return first_date.strftime("%Y-%m-%d")
+        return str(first_date)
 
     def _on_llm_suggestions_failed(self, pdf_path: Path, error: str):
         """KI-Abruf für eine PDF ist fehlgeschlagen (Cache-Signal)."""
@@ -804,8 +847,22 @@ class MainWindow(QMainWindow):
         if self._last_llm_error:
             name, error = self._last_llm_error
             lines.append(f"\nLetzter KI-Fehler ({name}):\n{error}")
-        lines.append(f"\nLog-Datei: {get_log_directory() / 'pdf_sortier_meister.log'}")
-        QMessageBox.information(self, "Hintergrund-Analyse", "\n".join(lines))
+        log_file = get_log_directory() / "pdf_sortier_meister.log"
+        lines.append(f"\nLog-Datei: {log_file}")
+
+        box = QMessageBox(self)
+        box.setWindowTitle("Hintergrund-Analyse")
+        box.setIcon(QMessageBox.Icon.Warning if self._last_llm_error else QMessageBox.Icon.Information)
+        box.setText("\n".join(lines))
+        open_log_btn = box.addButton("Log-Datei öffnen", QMessageBox.ButtonRole.ActionRole)
+        box.addButton(QMessageBox.StandardButton.Ok)
+        box.exec()
+        if box.clickedButton() is open_log_btn:
+            from src.utils.platform_paths import open_with_default_app
+            try:
+                open_with_default_app(log_file)
+            except Exception as e:
+                QMessageBox.warning(self, "Log-Datei", f"Konnte die Log-Datei nicht öffnen:\n{e}")
 
     def _on_thumbnail_loaded(self):
         """Wird aufgerufen wenn ein Thumbnail fertig geladen ist."""
@@ -3978,10 +4035,16 @@ class MainWindow(QMainWindow):
         """Aktualisiert die LLM-Statusanzeige."""
         if self.hybrid_classifier.is_llm_available():
             provider = self.hybrid_classifier.get_llm_provider_name()
-            self.llm_status_label.setText(f"LLM: {provider}")
+            model_short = self.hybrid_classifier.get_llm_model_name(short=True)
+            model_full = self.hybrid_classifier.get_llm_model_name()
+            # z.B. "LLM: OpenRouter/glm-5.3-flash" - das Modell entscheidet
+            # ueber Tempo und Qualitaet, deshalb gehoert es in die Anzeige
+            text = f"LLM: {provider}/{model_short}" if model_short else f"LLM: {provider}"
+            self.llm_status_label.setText(text)
             self.llm_status_label.setStyleSheet("color: green;")
+            detail = f"{provider}, Modell: {model_full}" if model_full else provider
             self.llm_status_label.setToolTip(
-                f"KI-Assistent aktiv ({provider}).\nDoppelklick öffnet die Einstellungen."
+                f"KI-Assistent aktiv ({detail}).\nDoppelklick öffnet die Einstellungen."
             )
         else:
             from src.ml.llm_provider import is_cloud_provider

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -149,6 +149,7 @@ class MainWindow(QMainWindow):
         get_llm_activity().changed.connect(self._on_llm_activity_changed)
         self.pdf_cache.llm_suggestions_failed.connect(self._on_llm_suggestions_failed)
         self._last_llm_error: Optional[tuple[str, str]] = None  # (pdf_name, fehler)
+        self._llm_success_since_error = False  # seit dem letzten Fehler kam ein Erfolg
         # Wiederverwendetes Vorschau-Fenster (Issue #76), erst bei Bedarf erzeugt
         self._preview_window: Optional[PdfPreviewWindow] = None
         # Laufende Hintergrund-Schreibvorgaenge (XMP-Metadaten) je Zielpfad
@@ -785,8 +786,25 @@ class MainWindow(QMainWindow):
 
     def _on_llm_suggestions_ready(self, pdf_path: Path):
         """KI-Vorschläge für eine PDF wurden abgerufen (Cache-Signal)."""
+        self._clear_llm_error_if_recovered(pdf_path)
         self._update_cache_status()
         self._refresh_detail_panel_after_llm(pdf_path)
+
+    def _clear_llm_error_if_recovered(self, pdf_path: Path):
+        """Setzt „KI-Fehler“ zurück, wenn der Fehler behoben ist.
+
+        Behoben heißt: die betroffene PDF hat jetzt ein Ergebnis, oder der
+        Pre-Cache-Lauf ist zu Ende und nach dem Fehler kamen nur noch Erfolge
+        (z.B. weil der Provider auf einen Rückfall umgeschaltet hat).
+        """
+        if not self._last_llm_error:
+            return
+        self._llm_success_since_error = True
+        failed_name = self._last_llm_error[0]
+        run_finished = self.pdf_cache.llm_pending_count() == 0
+        if pdf_path.name == failed_name or run_finished:
+            self._last_llm_error = None
+            self._llm_success_since_error = False
 
     def _refresh_detail_panel_after_llm(self, pdf_path: Path) -> bool:
         """Traegt frische KI-Vorschlaege ins Detail-Panel ein, wenn die PDF
@@ -826,6 +844,7 @@ class MainWindow(QMainWindow):
     def _on_llm_suggestions_failed(self, pdf_path: Path, error: str):
         """KI-Abruf für eine PDF ist fehlgeschlagen (Cache-Signal)."""
         self._last_llm_error = (pdf_path.name, error)
+        self._llm_success_since_error = False
         self._update_cache_status()
 
     def _show_precache_details(self):

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -187,8 +187,13 @@ class SettingsDialog(QDialog):
         advanced_layout = QFormLayout(advanced_group)
 
         self.max_tokens_spin = QSpinBox()
-        self.max_tokens_spin.setRange(100, 2000)
-        self.max_tokens_spin.setValue(500)
+        self.max_tokens_spin.setRange(100, 8000)
+        self.max_tokens_spin.setValue(2000)
+        self.max_tokens_spin.setToolTip(
+            "Obergrenze fuer die Antwortlaenge. Reasoning-Modelle (z.B. GLM, "
+            "DeepSeek-R1) verbrauchen davon zuerst ihr 'Nachdenken' - bei zu "
+            "kleinem Wert kommt eine leere Antwort zurueck."
+        )
         self.max_tokens_spin.setSuffix(" Tokens")
         advanced_layout.addRow("Max. Tokens:", self.max_tokens_spin)
 
@@ -347,16 +352,21 @@ class SettingsDialog(QDialog):
 
         layout.addWidget(folder_group)
 
-        # Eingabefelder nur bei aktivierter Funktion bedienbar
-        self.folder_naming_check.toggled.connect(
-            self.folder_naming_initials_input.setEnabled
-        )
-        self.folder_naming_check.toggled.connect(
-            self.folder_naming_template_input.setEnabled
+        # Initialen/Vorlage bleiben immer editierbar. Frueher waren sie bis zum
+        # Setzen des Hakens ausgegraut - auf Retina-Macs war das Kaestchen
+        # kaum sichtbar, die Felder wirkten "kaputt" (nicht anklickbar).
+        # Beim Eintippen von Initialen wird die Funktion mit eingeschaltet.
+        self.folder_naming_initials_input.textEdited.connect(
+            self._on_folder_naming_initials_edited
         )
 
         layout.addStretch()
         return tab
+
+    def _on_folder_naming_initials_edited(self, text: str):
+        """Initialen eingetippt -> Funktion einschalten (nur bei Nutzereingabe)."""
+        if text.strip() and not self.folder_naming_check.isChecked():
+            self.folder_naming_check.setChecked(True)
 
     def _on_pattern_choice_changed(self, button_id: int, checked: bool):
         """Aktiviert/deaktiviert das Freitextfeld je nach Auswahl."""
@@ -1078,7 +1088,7 @@ class SettingsDialog(QDialog):
             else:
                 self.model_combo.setCurrentText(model)
 
-        self.max_tokens_spin.setValue(llm_config.get("max_tokens", 500))
+        self.max_tokens_spin.setValue(llm_config.get("max_tokens", 2000))
         self.temperature_spin.setValue(llm_config.get("temperature", 0.3))
         self.auto_use_check.setChecked(llm_config.get("auto_use", False))
         self.text_limit_spin.setValue(llm_config.get("text_limit", 1500))
@@ -1107,8 +1117,10 @@ class SettingsDialog(QDialog):
         self.folder_naming_template_input.setText(
             self.config.get("folder_naming_template", "")
         )
-        self.folder_naming_initials_input.setEnabled(folder_naming_enabled)
-        self.folder_naming_template_input.setEnabled(folder_naming_enabled)
+        self.folder_naming_initials_input.setToolTip(
+            "Ihre Initialen fuer den Platzhalter {initialen}. Beim Eintippen "
+            "wird 'Dateinamen aus dem Zielordner-Pfad aufbauen' aktiviert."
+        )
 
         # Cache-Einstellungen
         self.persist_cache_checkbox.setChecked(self.config.get("persist_pdf_cache", True))

--- a/src/main.py
+++ b/src/main.py
@@ -157,6 +157,23 @@ def main():
     light_palette.setColor(QPalette.ColorRole.PlaceholderText, QColor(120, 120, 120))
     app.setPalette(light_palette)
 
+    # Fusion zeichnet Checkbox-Kaestchen auf Retina-Macs praktisch ohne
+    # Rahmen (weisses Quadrat auf hellem Grund) - Nutzer sehen nicht, dass
+    # dort etwas anzuklicken ist. Eigene, kontrastreiche Indikatoren fuer
+    # alle Plattformen; Widgets mit eigenem Stylesheet (z.B. der
+    # Nur-verschieben-Schalter) behalten ihres.
+    app.setStyleSheet(
+        "QCheckBox::indicator { width: 16px; height: 16px; border-radius: 3px; "
+        "border: 1px solid #7a7a7a; background-color: #ffffff; }"
+        "QCheckBox::indicator:hover { border-color: #0078d7; }"
+        "QCheckBox::indicator:checked { background-color: #0078d7; "
+        "border-color: #005a9e; }"
+        "QCheckBox::indicator:disabled { border-color: #c0c0c0; "
+        "background-color: #f0f0f0; }"
+        "QCheckBox::indicator:checked:disabled { background-color: #9dc5e8; "
+        "border-color: #9dc5e8; }"
+    )
+
     # SplashScreen: im gefrorenen Build zeigt PyInstaller den Splash bereits
     # vom Bootloader aus an (siehe .spec). Der Qt-Splash dient nur als
     # Fallback fuer die Dev-Umgebung (python main.py).

--- a/src/ml/claude_provider.py
+++ b/src/ml/claude_provider.py
@@ -120,8 +120,18 @@ class ClaudeProvider(LLMProvider):
                 ]
             )
 
-            response_text = message.content[0].text
+            response_text = message.content[0].text if message.content else ""
+            problem = self._check_response_text(
+                response_text, getattr(message, "stop_reason", None)
+            )
+            if problem:
+                return LLMResponse(success=False, error_message=problem)
             parsed = self._parse_response(response_text)
+            if parsed.get("error"):
+                return LLMResponse(
+                    success=False,
+                    error_message=f"KI-Antwort nicht lesbar: {parsed['error']}",
+                )
 
             # Prüfen ob der vorgeschlagene Ordner existiert
             suggested_folder = parsed.get("folder")
@@ -205,8 +215,18 @@ class ClaudeProvider(LLMProvider):
                 ]
             )
 
-            response_text = message.content[0].text
+            response_text = message.content[0].text if message.content else ""
+            problem = self._check_response_text(
+                response_text, getattr(message, "stop_reason", None)
+            )
+            if problem:
+                return LLMResponse(success=False, error_message=problem)
             parsed = self._parse_response(response_text)
+            if parsed.get("error"):
+                return LLMResponse(
+                    success=False,
+                    error_message=f"KI-Antwort nicht lesbar: {parsed['error']}",
+                )
 
             # Dateiname validieren
             filename = parsed.get("filename")

--- a/src/ml/hybrid_classifier.py
+++ b/src/ml/hybrid_classifier.py
@@ -66,6 +66,9 @@ class HybridClassifier:
         self.llm_provider: Optional[LLMProvider] = None
         self.llm_enabled = False
         self.total_tokens_used = 0
+        # Letzter Fehler des KI-Aufrufs (Dateiname/Metadaten) - wird vom
+        # Pre-Cache-Worker und dem Detail-Panel angezeigt, statt still zu scheitern
+        self.last_llm_error: Optional[str] = None
 
         # LLM-Provider initialisieren falls konfiguriert
         self._init_llm_provider()
@@ -103,7 +106,7 @@ class HybridClassifier:
         config = LLMConfig(
             api_key=api_key,
             model=model,
-            max_tokens=llm_config.get("max_tokens", 500),
+            max_tokens=llm_config.get("max_tokens", 2000),
             temperature=llm_config.get("temperature", 0.3),
             text_limit=llm_config.get("text_limit", 1500),
             base_url=base_url,
@@ -464,6 +467,7 @@ class HybridClassifier:
         if not self.llm_provider:
             return None
 
+        self.last_llm_error = None
         response = self.llm_provider.suggest_filename(
             text=text,
             current_filename=current_filename,
@@ -475,8 +479,13 @@ class HybridClassifier:
 
         self.total_tokens_used += response.tokens_used
 
-        if not response.success or not response.filename_suggestion:
+        if not response.success:
+            self.last_llm_error = response.error_message or "KI-Aufruf fehlgeschlagen."
             return None
+        if not response.filename_suggestion:
+            self.last_llm_error = "KI hat keinen Dateinamen geliefert."
+            return None
+        self.last_llm_error = None
 
         return HybridFilename(
             filename=response.filename_suggestion,
@@ -520,6 +529,28 @@ class HybridClassifier:
     def is_llm_available(self) -> bool:
         """Prüft ob ein LLM-Provider verfügbar ist."""
         return self.llm_enabled
+
+    def get_llm_model_name(self, short: bool = False) -> str:
+        """Gibt die Modell-ID des aktiven Providers zurueck (leer, wenn keins).
+
+        Args:
+            short: Anbieter-Praefix wie "z-ai/" (OpenRouter) weglassen - fuer
+                   die knappe Anzeige in der Statusleiste.
+        """
+        if not self.llm_enabled or not self.llm_provider:
+            return ""
+        model = ""
+        getter = getattr(self.llm_provider, "_get_model_id", None)
+        if callable(getter):
+            try:
+                model = getter() or ""
+            except Exception:
+                model = ""
+        if not model:
+            model = getattr(getattr(self.llm_provider, "config", None), "model", "") or ""
+        if short and "/" in model:
+            model = model.rsplit("/", 1)[-1]
+        return model
 
     def get_llm_provider_name(self) -> str:
         """Gibt den Namen des aktuellen LLM-Providers zurück."""

--- a/src/ml/llm_provider.py
+++ b/src/ml/llm_provider.py
@@ -130,7 +130,7 @@ class LLMConfig:
     """Konfiguration für einen LLM-Provider."""
     api_key: str
     model: str
-    max_tokens: int = 700
+    max_tokens: int = 2000  # Reasoning-Modelle brauchen Luft fuers Nachdenken
     temperature: float = 0.3  # Niedrig für konsistente Antworten
     text_limit: int = 1500  # Max. Zeichen die an LLM gesendet werden
     # Optional: Basis-URL fuer lokale/selbst-gehostete Provider (z.B. Ollama).
@@ -488,6 +488,35 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
             return text
         return text[:max_chars] + "\n[... Text gekürzt ...]"
 
+    def _check_response_text(
+        self, response_text: Optional[str], finish_reason: Optional[str] = None
+    ) -> Optional[str]:
+        """Prueft, ob die Modellantwort ueberhaupt verwertbar ist.
+
+        Reasoning-Modelle (z.B. GLM-5.x, DeepSeek-R1, o-Serie) verbrauchen ihr
+        Token-Budget zuerst fuers "Nachdenken". Ist ``max_tokens`` zu klein,
+        kommt eine leere oder abgeschnittene Antwort mit finish_reason
+        ``length`` zurueck. Frueher wurde das als Erfolg ohne Vorschlag gewertet
+        und still im Cache abgelegt - der Nutzer sah nie einen KI-Vorschlag.
+
+        Returns:
+            Fehlertext oder None, wenn die Antwort brauchbar aussieht.
+        """
+        text = (response_text or "").strip()
+        truncated = str(finish_reason or "").lower() in ("length", "max_tokens")
+        hint = (
+            f"Token-Limit ({self.config.max_tokens}) erreicht. Bitte in den "
+            "Einstellungen 'Max. Tokens' erhoehen oder ein Modell ohne "
+            "Reasoning waehlen."
+        )
+        if not text:
+            if truncated:
+                return f"KI-Antwort leer - {hint}"
+            return "KI-Antwort leer (Modell hat keinen Text geliefert)."
+        if truncated:
+            return f"KI-Antwort abgeschnitten - {hint}"
+        return None
+
     def _parse_json_response(self, response_text: str) -> tuple[Optional[dict], Optional[str]]:
         """
         Extrahiert und parst das JSON aus einer Antwort.
@@ -538,6 +567,8 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
 
         data, error = self._parse_json_response(response_text)
         if error or not data:
+            # Fehler mitgeben, damit Provider das als Misserfolg melden koennen
+            result["error"] = error or "Keine JSON-Antwort gefunden"
             return result
 
         folder = data.get("folder")

--- a/src/ml/ollama_provider.py
+++ b/src/ml/ollama_provider.py
@@ -157,7 +157,32 @@ class OllamaProvider(LLMProvider):
         }
         if json_mode:
             payload["format"] = "json"
+        # Denk-Modelle (qwen3, deepseek-r1, gemma4, ...) sollen fuer die kurze
+        # Extraktionsaufgabe nicht "nachdenken": schneller, und das Budget
+        # (num_predict) geht nicht im Denkteil verloren. Lehnt ein Server
+        # oder Modell das Feld ab (HTTP 400), wird ohne wiederholt und die
+        # Ablehnung fuer diese Instanz gemerkt.
+        if not self._think_rejected:
+            payload["think"] = False
 
+        data, error = self._post_chat(url, payload)
+        if error and "HTTP 400" in error and "think" in payload:
+            self._think_rejected = True
+            payload.pop("think", None)
+            data, error = self._post_chat(url, payload)
+        if error:
+            return None, error
+
+        message = data.get("message") or {}
+        content = message.get("content", "")
+        if not content:
+            return None, "Ollama hat eine leere Antwort geliefert."
+        return content, None
+
+    _think_rejected = False
+
+    def _post_chat(self, url: str, payload: dict) -> tuple[Optional[dict], Optional[str]]:
+        """POST an /api/chat; liefert (JSON-Antwort, Fehlertext)."""
         body = json.dumps(payload).encode("utf-8")
         req = urllib.request.Request(
             url,
@@ -165,22 +190,15 @@ class OllamaProvider(LLMProvider):
             headers=self._headers(),
             method="POST",
         )
-
         try:
             with urllib.request.urlopen(req, timeout=self.REQUEST_TIMEOUT) as resp:
-                data = json.loads(resp.read().decode("utf-8"))
+                return json.loads(resp.read().decode("utf-8")), None
         except urllib.error.HTTPError as e:
             return None, f"Ollama HTTP {e.code}"
         except urllib.error.URLError as e:
             return None, f"Keine Verbindung zu Ollama ({self._get_base_url()}). Details: {e.reason}"
         except Exception as e:
             return None, f"Ollama-Fehler: {e}"
-
-        message = data.get("message") or {}
-        content = message.get("content", "")
-        if not content:
-            return None, "Ollama hat eine leere Antwort geliefert."
-        return content, None
 
     def _strip_code_fences(self, text: str) -> str:
         """Entfernt Markdown-Code-Fences."""

--- a/src/ml/ollama_provider.py
+++ b/src/ml/ollama_provider.py
@@ -54,7 +54,17 @@ class OllamaProvider(LLMProvider):
         super().__init__(config)
         # Einmaliger Auto-Start-Versuch pro Provider-Instanz.
         self._autostart_attempted = False
+        # gpt-oss kennt nur die Denkstufen low/medium/high; think=false liefert
+        # dort leeren oder mit Denktext vermischten Inhalt. Direkt "low" senden
+        # spart den vergeblichen ersten Versuch.
+        if self._is_gpt_oss():
+            self._think_mode = self.THINK_FALLBACK
         self._initialize_client()
+
+    def _is_gpt_oss(self) -> bool:
+        """Erkennt gpt-oss-Modelle am Namen (auch eigene Varianten wie gpt-oss-64k)."""
+        name = self._get_model_id().lower().replace("_", "-")
+        return "gpt-oss" in name or "gptoss" in name
 
     def _initialize_client(self):
         """
@@ -159,27 +169,58 @@ class OllamaProvider(LLMProvider):
             payload["format"] = "json"
         # Denk-Modelle (qwen3, deepseek-r1, gemma4, ...) sollen fuer die kurze
         # Extraktionsaufgabe nicht "nachdenken": schneller, und das Budget
-        # (num_predict) geht nicht im Denkteil verloren. Lehnt ein Server
-        # oder Modell das Feld ab (HTTP 400), wird ohne wiederholt und die
-        # Ablehnung fuer diese Instanz gemerkt.
-        if not self._think_rejected:
-            payload["think"] = False
+        # (num_predict) geht nicht im Denkteil verloren. Zwei Rueckfaelle,
+        # jeweils fuer diese Instanz gemerkt:
+        # - HTTP 400: Server/Modell kennt das Feld nicht -> ohne wiederholen.
+        # - HTTP 200 mit leerem Inhalt (oder im JSON-Modus ohne JSON-Objekt):
+        #   Modelle wie gpt-oss koennen das Denken nicht abschalten (nur
+        #   low/medium/high) und liefern bei think=false nichts oder Denktext
+        #   im Inhalt -> mit think="low" wiederholen.
+        if self._think_mode is not None:
+            payload["think"] = self._think_mode
 
         data, error = self._post_chat(url, payload)
         if error and "HTTP 400" in error and "think" in payload:
-            self._think_rejected = True
+            self._think_mode = None
             payload.pop("think", None)
             data, error = self._post_chat(url, payload)
         if error:
             return None, error
 
-        message = data.get("message") or {}
-        content = message.get("content", "")
+        content = self._extract_content(data)
+        unusable = not content or (json_mode and not self._contains_json_object(content))
+        if unusable and payload.get("think") is False:
+            self._think_mode = self.THINK_FALLBACK
+            payload["think"] = self.THINK_FALLBACK
+            data, error = self._post_chat(url, payload)
+            if error:
+                return None, error
+            content = self._extract_content(data)
         if not content:
             return None, "Ollama hat eine leere Antwort geliefert."
         return content, None
 
-    _think_rejected = False
+    # Aktueller Wert fuer das "think"-Feld: False = aus, "low" = minimal,
+    # None = Feld nicht senden (vom Server abgelehnt).
+    _think_mode: Any = False
+    THINK_FALLBACK = "low"
+
+    @staticmethod
+    def _extract_content(data: dict) -> str:
+        """Liest message.content aus einer /api/chat-Antwort."""
+        message = data.get("message") or {}
+        return message.get("content", "") or ""
+
+    @staticmethod
+    def _contains_json_object(text: str) -> bool:
+        """True, wenn im Text ein parsebares JSON-Objekt steckt."""
+        start, end = text.find("{"), text.rfind("}")
+        if start < 0 or end <= start:
+            return False
+        try:
+            return isinstance(json.loads(text[start:end + 1]), dict)
+        except ValueError:
+            return False
 
     def _post_chat(self, url: str, payload: dict) -> tuple[Optional[dict], Optional[str]]:
         """POST an /api/chat; liefert (JSON-Antwort, Fehlertext)."""

--- a/src/ml/openai_provider.py
+++ b/src/ml/openai_provider.py
@@ -9,6 +9,7 @@ MIT License - Copyright (c) 2026
 import json
 import urllib.error
 import urllib.request
+import re
 from typing import Optional
 
 from src.ml.llm_provider import LLMProvider, LLMConfig, LLMResponse
@@ -116,7 +117,7 @@ class OpenAIProvider(LLMProvider):
         )
 
         try:
-            response = self._client.chat.completions.create(
+            response = self._create_chat_completion(
                 model=self._get_model_id(),
                 max_tokens=self.config.max_tokens,
                 temperature=self.config.temperature,
@@ -130,8 +131,19 @@ class OpenAIProvider(LLMProvider):
                 ]
             )
 
-            response_text = response.choices[0].message.content
+            choice = response.choices[0]
+            response_text = choice.message.content
+            problem = self._check_response_text(
+                response_text, getattr(choice, "finish_reason", None)
+            )
+            if problem:
+                return LLMResponse(success=False, error_message=problem)
             parsed = self._parse_response(response_text)
+            if parsed.get("error"):
+                return LLMResponse(
+                    success=False,
+                    error_message=f"KI-Antwort nicht lesbar: {parsed['error']}",
+                )
 
             # Prüfen ob der vorgeschlagene Ordner existiert
             suggested_folder = parsed.get("folder")
@@ -205,7 +217,7 @@ class OpenAIProvider(LLMProvider):
         )
 
         try:
-            response = self._client.chat.completions.create(
+            response = self._create_chat_completion(
                 model=self._get_model_id(),
                 max_tokens=self.config.max_tokens,
                 temperature=self.config.temperature,
@@ -219,8 +231,19 @@ class OpenAIProvider(LLMProvider):
                 ]
             )
 
-            response_text = response.choices[0].message.content
+            choice = response.choices[0]
+            response_text = choice.message.content
+            problem = self._check_response_text(
+                response_text, getattr(choice, "finish_reason", None)
+            )
+            if problem:
+                return LLMResponse(success=False, error_message=problem)
             parsed = self._parse_response(response_text)
+            if parsed.get("error"):
+                return LLMResponse(
+                    success=False,
+                    error_message=f"KI-Antwort nicht lesbar: {parsed['error']}",
+                )
 
             # Dateiname validieren
             filename = parsed.get("filename")
@@ -243,6 +266,40 @@ class OpenAIProvider(LLMProvider):
                 success=False,
                 error_message=f"{self.API_NAME} API Fehler: {str(e)}"
             )
+
+    # Reasoning-Modelle bei OpenAI direkt: o1/o3/o4-mini, gpt-5-Familie.
+    # Fuer die kurze Extraktionsaufgabe reicht minimales Nachdenken; das
+    # spart Zeit und Tokens. Klassische Modelle (gpt-4o, gpt-4.1) kennen den
+    # Parameter nicht - sie bekommen ihn gar nicht erst.
+    _REASONING_MODEL_RE = re.compile(r"^(o\d|gpt-5)", re.IGNORECASE)
+
+    def _extra_request_kwargs(self) -> dict:
+        """Zusaetzliche Parameter fuer chat.completions.create."""
+        if self._REASONING_MODEL_RE.match(self._get_model_id() or ""):
+            return {"reasoning_effort": "minimal"}
+        return {}
+
+    # Nach einer Ablehnung (HTTP 400) werden Extras fuer diese Instanz nicht
+    # mehr mitgeschickt - sonst kostet jeder Aufruf einen Fehlversuch extra.
+    _extras_rejected = False
+
+    def _create_chat_completion(self, **kwargs):
+        """Ruft die Chat-API auf; provider-spezifische Extras mit Rueckfall.
+
+        Lehnt das Modell einen Zusatzparameter ab (HTTP 400), wird der Aufruf
+        ohne die Extras wiederholt und die Ablehnung gemerkt.
+        """
+        extras = {} if self._extras_rejected else self._extra_request_kwargs()
+        if not extras:
+            return self._client.chat.completions.create(**kwargs)
+        try:
+            return self._client.chat.completions.create(**kwargs, **extras)
+        except Exception as e:  # noqa: BLE001 - nur 400er auf Extras zurueckfallen
+            status = getattr(e, "status_code", None)
+            if status == 400 or "400" in str(e):
+                self._extras_rejected = True
+                return self._client.chat.completions.create(**kwargs)
+            raise
 
     def _find_similar_folder(
         self, suggested: str, available: list[str]

--- a/src/ml/openrouter_provider.py
+++ b/src/ml/openrouter_provider.py
@@ -52,6 +52,17 @@ class OpenRouterProvider(OpenAIProvider):
             print(f"Fehler bei {self.API_NAME}-Initialisierung: {e}")
             self._client = None
 
+    # Reasoning-Modelle (GLM-5.x, DeepSeek-R1, ...) denken bei der kurzen
+    # Dateinamen-/Metadaten-Aufgabe sonst tausende Tokens lang - langsam und
+    # bei kleinem max_tokens kommt gar kein Text mehr. "low" begrenzt das
+    # Nachdenken (gemessen: 3-4 s statt 10-18 s, gleiche Qualitaet). Modelle
+    # ohne Reasoning ignorieren den Parameter; lehnt eines ihn ab, wiederholt
+    # OpenAIProvider._create_chat_completion den Aufruf ohne ihn.
+    REASONING_EFFORT = "low"
+
+    def _extra_request_kwargs(self) -> dict:
+        return {"extra_body": {"reasoning": {"effort": self.REASONING_EFFORT}}}
+
     def _get_model_id(self) -> str:
         """OpenRouter-IDs werden unverändert durchgereicht ("anbieter/modell")."""
         model = (self.config.model or "").strip()

--- a/src/ml/poe_provider.py
+++ b/src/ml/poe_provider.py
@@ -165,8 +165,19 @@ class PoeProvider(LLMProvider):
                 ]
             )
 
-            response_text = response.choices[0].message.content
+            choice = response.choices[0]
+            response_text = choice.message.content
+            problem = self._check_response_text(
+                response_text, getattr(choice, "finish_reason", None)
+            )
+            if problem:
+                return LLMResponse(success=False, error_message=problem)
             parsed = self._parse_response(response_text)
+            if parsed.get("error"):
+                return LLMResponse(
+                    success=False,
+                    error_message=f"KI-Antwort nicht lesbar: {parsed['error']}",
+                )
 
             # Prüfen ob der vorgeschlagene Ordner existiert
             suggested_folder = parsed.get("folder")
@@ -254,8 +265,19 @@ class PoeProvider(LLMProvider):
                 ]
             )
 
-            response_text = response.choices[0].message.content
+            choice = response.choices[0]
+            response_text = choice.message.content
+            problem = self._check_response_text(
+                response_text, getattr(choice, "finish_reason", None)
+            )
+            if problem:
+                return LLMResponse(success=False, error_message=problem)
             parsed = self._parse_response(response_text)
+            if parsed.get("error"):
+                return LLMResponse(
+                    success=False,
+                    error_message=f"KI-Antwort nicht lesbar: {parsed['error']}",
+                )
 
             # Dateiname validieren
             filename = parsed.get("filename")

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -79,7 +79,7 @@ class Config:
             "api_key": "",  # Key des aktiven Providers (Spiegel von api_keys)
             "api_keys": {},  # API-Keys pro Provider, z.B. {"openrouter": "...", "poe": "..."}
             "model": "",  # z.B. "haiku", "sonnet", "gpt-4o-mini", "llama3.1"
-            "max_tokens": 500,
+            "max_tokens": 2000,  # Reasoning-Modelle (GLM, DeepSeek-R1, ...) brauchen Luft
             "temperature": 0.3,
             "auto_use": False,  # LLM automatisch bei niedriger Konfidenz
             "base_url": "",  # nur fuer Ollama (lokaler Server)
@@ -132,6 +132,26 @@ class Config:
             except (json.JSONDecodeError, IOError) as e:
                 logger.error(f"Fehler beim Laden der Konfiguration: {e}")
                 self._config = copy.deepcopy(self.DEFAULTS)
+            else:
+                self._migrate()
+
+    # Alter App-Default fuer llm.max_tokens (bis 0.20.0). Reasoning-Modelle
+    # verbrauchen damit das ganze Budget fuers Nachdenken und liefern leere
+    # Antworten - deshalb wird der alte Default beim Laden angehoben.
+    LEGACY_MAX_TOKENS = 500
+
+    def _migrate(self) -> None:
+        """Hebt veraltete Werte aus aelteren Versionen an."""
+        llm = self._config.get("llm")
+        if not isinstance(llm, dict):
+            return
+        if llm.get("max_tokens") == self.LEGACY_MAX_TOKENS:
+            llm["max_tokens"] = self.DEFAULTS["llm"]["max_tokens"]
+            logger.info(
+                f"Konfiguration: llm.max_tokens {self.LEGACY_MAX_TOKENS} -> "
+                f"{llm['max_tokens']} angehoben (alter Default, zu klein fuer Reasoning-Modelle)"
+            )
+            self.save()
 
     def save(self) -> None:
         """Speichert die Konfiguration in die Datei."""

--- a/tests/test_config_max_tokens_migration.py
+++ b/tests/test_config_max_tokens_migration.py
@@ -1,0 +1,29 @@
+"""Alter Default llm.max_tokens=500 wird beim Laden auf den neuen Default angehoben."""
+import json
+
+
+def _load(tmp_path, llm):
+    from src.utils.config import Config
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"llm": llm}), encoding="utf-8")
+    cfg = Config.__new__(Config)
+    cfg.config_path = cfg_path
+    cfg._config = {}
+    cfg.load()
+    return cfg, cfg_path
+
+
+def test_default_is_2000():
+    from src.utils.config import Config
+    assert Config.DEFAULTS["llm"]["max_tokens"] == 2000
+
+
+def test_legacy_500_is_raised_and_persisted(tmp_path):
+    cfg, path = _load(tmp_path, {"provider": "openrouter", "max_tokens": 500})
+    assert cfg.get("llm")["max_tokens"] == 2000
+    assert json.loads(path.read_text(encoding="utf-8"))["llm"]["max_tokens"] == 2000
+
+
+def test_user_chosen_value_is_kept(tmp_path):
+    cfg, _ = _load(tmp_path, {"provider": "openrouter", "max_tokens": 1200})
+    assert cfg.get("llm")["max_tokens"] == 1200

--- a/tests/test_detail_panel_llm_refresh_gui.py
+++ b/tests/test_detail_panel_llm_refresh_gui.py
@@ -1,0 +1,55 @@
+"""Detail-Panel zieht KI-Vorschlaege nach, die im Hintergrund fuer die gerade
+ausgewaehlte PDF eintreffen - ohne dass man eine andere PDF anklicken muss."""
+from PyQt6.QtTest import QTest
+
+from tests.test_main_window_gui import fresh_singletons, main_window  # noqa: F401 - Fixtures
+
+
+def _prepare(win, tmp_path, name="scan.pdf"):
+    from src.core.pdf_cache import PDFAnalysisResult
+    pdf = tmp_path / name
+    pdf.write_bytes(b"%PDF-1.4")
+    result = PDFAnalysisResult(pdf_path=pdf, extracted_text="Rechnung Testfirma", keywords=["rechnung"], dates=[], file_modified=pdf.stat().st_mtime)
+    win.pdf_cache._cache[pdf] = result
+    win.selected_pdf = pdf
+    win.selected_pdfs = []
+    win.detail_panel.set_pdf(pdf_path=pdf, suggestions=[], extracted_text=result.extracted_text, keywords=result.keywords)
+    return pdf
+
+
+def _llm_arrives(win, pdf):
+    from src.core.pdf_cache import LLMSuggestion
+    win.pdf_cache._cache[pdf].llm_suggestions = [LLMSuggestion(
+        filename="2024-01-31_Rechnung_Testfirma.pdf", confidence=0.95, source="llm",
+        metadata={"korrespondent": "Testfirma GmbH", "subject": "Rechnung"},
+    )]
+    win.pdf_cache._cache[pdf].llm_fetched = True
+    win._on_llm_suggestions_ready(pdf)
+
+
+def test_panel_updates_when_llm_result_arrives(main_window, tmp_path):
+    pdf = _prepare(main_window, tmp_path)
+    assert main_window.detail_panel.name_input.text() == ""
+    _llm_arrives(main_window, pdf)
+    assert main_window.detail_panel.name_input.text() == "2024-01-31_Rechnung_Testfirma"
+    assert main_window.detail_panel.get_metadata()["korrespondent"] == "Testfirma GmbH"
+
+
+def test_no_update_when_user_already_edited(main_window, tmp_path):
+    pdf = _prepare(main_window, tmp_path)
+    QTest.keyClicks(main_window.detail_panel._metadata_inputs["korrespondent"], "Meine Firma")
+    assert main_window.detail_panel.has_user_edits()
+    _llm_arrives(main_window, pdf)
+    assert main_window.detail_panel.name_input.text() == ""
+    assert main_window.detail_panel.get_metadata()["korrespondent"] == "Meine Firma"
+
+
+def test_no_update_for_other_pdf(main_window, tmp_path):
+    pdf = _prepare(main_window, tmp_path)
+    other = tmp_path / "andere.pdf"
+    other.write_bytes(b"%PDF-1.4")
+    from src.core.pdf_cache import PDFAnalysisResult
+    main_window.pdf_cache._cache[other] = PDFAnalysisResult(pdf_path=other, extracted_text="x", keywords=[], dates=[])
+    _llm_arrives(main_window, other)
+    assert main_window.detail_panel.name_input.text() == ""
+    assert main_window.detail_panel.get_current_pdf() == pdf

--- a/tests/test_detail_panel_metadata_async.py
+++ b/tests/test_detail_panel_metadata_async.py
@@ -13,8 +13,10 @@ def test_metadata_applied_after_background_read(qtbot, tmp_path, monkeypatch):
     pdf = tmp_path / "a.pdf"; pdf.write_bytes(b"%PDF")
     panel.set_pdf(pdf_path=pdf, suggestions=[], extracted_text="x", keywords=["rechnung"])
     assert panel._current_pdf == pdf
-    qtbot.waitUntil(lambda: panel._metadata_source == "pdf", timeout=5000)
+    # Kategorie "Rechnung" kommt aus der Analyse, nicht aus dem PDF -> "pdf_partial"
+    qtbot.waitUntil(lambda: panel._metadata_source == "pdf_partial", timeout=5000)
     assert panel.get_metadata().get("korrespondent") == "Stadtwerke"
+    assert panel._pdf_field_keys == {"korrespondent", "steuerjahr"}
 
 
 def test_stale_result_for_other_pdf_is_ignored(qtbot, tmp_path):

--- a/tests/test_detail_panel_pdf_source.py
+++ b/tests/test_detail_panel_pdf_source.py
@@ -1,0 +1,41 @@
+"""'Quelle: aus PDF gelesen' nur, wenn wirklich alle Felder aus dem PDF stammen."""
+
+
+def test_partial_pdf_metadata_is_not_marked_saved(qtbot, tmp_path, monkeypatch):
+    from src.gui import detail_panel as dp
+    from src.core.pdf_metadata import PDFMetadata
+
+    # PDF liefert nur eine Zusammenfassung; Kategorie/Steuerjahr kommen aus der Analyse
+    meta = PDFMetadata(); meta.description = "Leistungsabrechnung der HUK."
+    monkeypatch.setattr("src.core.pdf_metadata.read_metadata", lambda p: meta)
+
+    panel = dp.DetailPanel(); qtbot.addWidget(panel)
+    pdf = tmp_path / "a.pdf"; pdf.write_bytes(b"%PDF")
+    panel.set_pdf(pdf_path=pdf, suggestions=[], extracted_text="x",
+                  keywords=["rechnung"], detected_date="2024-01-31")
+    qtbot.waitUntil(lambda: panel._metadata_source in ("pdf", "pdf_partial"), timeout=5000)
+
+    assert panel._metadata_source == "pdf_partial"
+    assert panel.get_metadata()["subject"] == "Rechnung"
+    assert panel._saved_metadata_snapshot == {"description": "Leistungsabrechnung der HUK."}
+    assert panel.save_metadata_btn.isEnabled()
+    assert panel.save_metadata_btn.text() == "Metadaten speichern"
+    assert "teils" in panel.metadata_status_label.text()
+
+
+def test_full_pdf_metadata_is_marked_saved(qtbot, tmp_path, monkeypatch):
+    from src.gui import detail_panel as dp
+    from src.core.pdf_metadata import PDFMetadata
+
+    meta = PDFMetadata(); meta.subject = "Rechnung"; meta.steuerjahr = "2024"
+    monkeypatch.setattr("src.core.pdf_metadata.read_metadata", lambda p: meta)
+
+    panel = dp.DetailPanel(); qtbot.addWidget(panel)
+    pdf = tmp_path / "a.pdf"; pdf.write_bytes(b"%PDF")
+    panel.set_pdf(pdf_path=pdf, suggestions=[], extracted_text="x",
+                  keywords=["rechnung"], detected_date="2024-05-01")
+    qtbot.waitUntil(lambda: panel._metadata_source == "pdf", timeout=5000)
+
+    assert not panel.save_metadata_btn.isEnabled()
+    assert panel.save_metadata_btn.text() == "Metadaten gespeichert"
+    assert panel.metadata_status_label.text() == "Quelle: aus PDF gelesen"

--- a/tests/test_hybrid_classifier.py
+++ b/tests/test_hybrid_classifier.py
@@ -86,3 +86,26 @@ def test_set_cloud_provider_with_consent_returns_true(monkeypatch):
     ok = hc.set_llm_provider(LLMProviderType.CLAUDE, api_key="sk-x")
     assert ok is True
     assert hc.llm_enabled is True
+
+
+# --- Modellname fuer die Statusleiste ("LLM: OpenRouter/glm-5.3-flash") ---
+
+def test_model_name_short_strips_vendor_prefix():
+    from src.ml.hybrid_classifier import HybridClassifier
+    from src.ml.llm_provider import LLMConfig
+    from src.ml.openrouter_provider import OpenRouterProvider
+
+    hc = HybridClassifier.__new__(HybridClassifier)
+    hc.llm_enabled = True
+    hc.llm_provider = OpenRouterProvider(LLMConfig(api_key="sk-or-x", model="z-ai/glm-5.3-flash"))
+    assert hc.get_llm_model_name() == "z-ai/glm-5.3-flash"
+    assert hc.get_llm_model_name(short=True) == "glm-5.3-flash"
+    assert hc.get_llm_provider_name() == "OpenRouter"
+
+
+def test_model_name_empty_without_provider():
+    from src.ml.hybrid_classifier import HybridClassifier
+    hc = HybridClassifier.__new__(HybridClassifier)
+    hc.llm_enabled = False
+    hc.llm_provider = None
+    assert hc.get_llm_model_name() == ""

--- a/tests/test_llm_error_status_reset_gui.py
+++ b/tests/test_llm_error_status_reset_gui.py
@@ -1,0 +1,43 @@
+"""„KI-Fehler“ in der Statusleiste setzt sich zurueck, wenn der Fehler behoben ist."""
+from tests.test_main_window_gui import fresh_singletons, main_window  # noqa: F401 - Fixtures
+
+
+def _pdf(tmp_path, name):
+    p = tmp_path / name
+    p.write_bytes(b"%PDF-1.4")
+    return p
+
+
+def test_error_stays_while_run_continues(main_window, tmp_path, monkeypatch):
+    a, b = _pdf(tmp_path, "a.pdf"), _pdf(tmp_path, "b.pdf")
+    monkeypatch.setattr(main_window.pdf_cache, "llm_pending_count", lambda: 3)
+    main_window._on_llm_suggestions_failed(a, "Kein gültiges JSON")
+    assert "KI-Fehler" in main_window.cache_status_label.text()
+    main_window._on_llm_suggestions_ready(b)
+    assert "KI-Fehler" in main_window.cache_status_label.text()
+
+
+def test_error_clears_when_run_finishes_without_new_errors(main_window, tmp_path, monkeypatch):
+    a, b = _pdf(tmp_path, "a.pdf"), _pdf(tmp_path, "b.pdf")
+    monkeypatch.setattr(main_window.pdf_cache, "llm_pending_count", lambda: 0)
+    main_window._on_llm_suggestions_failed(a, "Kein gültiges JSON")
+    main_window._on_llm_suggestions_ready(b)
+    assert main_window._last_llm_error is None
+    assert "KI-Fehler" not in main_window.cache_status_label.text()
+
+
+def test_error_clears_when_failed_pdf_succeeds(main_window, tmp_path, monkeypatch):
+    a = _pdf(tmp_path, "a.pdf")
+    monkeypatch.setattr(main_window.pdf_cache, "llm_pending_count", lambda: 5)
+    main_window._on_llm_suggestions_failed(a, "leere Antwort")
+    main_window._on_llm_suggestions_ready(a)
+    assert main_window._last_llm_error is None
+
+
+def test_error_stays_when_failure_is_last_in_run(main_window, tmp_path, monkeypatch):
+    a, b = _pdf(tmp_path, "a.pdf"), _pdf(tmp_path, "b.pdf")
+    monkeypatch.setattr(main_window.pdf_cache, "llm_pending_count", lambda: 0)
+    main_window._on_llm_suggestions_ready(b)
+    main_window._on_llm_suggestions_failed(a, "leere Antwort")
+    assert main_window._last_llm_error is not None
+    assert "KI-Fehler" in main_window.cache_status_label.text()

--- a/tests/test_llm_truncated_response.py
+++ b/tests/test_llm_truncated_response.py
@@ -1,0 +1,83 @@
+"""Leere/abgeschnittene KI-Antworten (Reasoning-Modelle + kleines max_tokens) sind Fehler.
+
+Hintergrund: z-ai/glm-5.3-flash verbrauchte mit max_tokens=500 sein ganzes
+Budget fuers Nachdenken, content war leer, finish_reason="length". Die App
+wertete das als Erfolg ohne Vorschlag und cachte es still - kein KI-Dateiname.
+"""
+import types
+
+
+def _make_provider(content, finish_reason, max_tokens=500):
+    from src.ml.llm_provider import LLMConfig
+    from src.ml.openai_provider import OpenAIProvider
+
+    p = OpenAIProvider(LLMConfig(api_key="sk-test", model="gpt-4.1-nano", max_tokens=max_tokens))
+    choice = types.SimpleNamespace(
+        finish_reason=finish_reason,
+        message=types.SimpleNamespace(content=content),
+    )
+    response = types.SimpleNamespace(choices=[choice], usage=None)
+    p._openai = types.SimpleNamespace(
+        APIConnectionError=type("A", (Exception,), {}),
+        RateLimitError=type("B", (Exception,), {}),
+        AuthenticationError=type("C", (Exception,), {}),
+    )
+    p._client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=lambda **kw: response)
+        )
+    )
+    p.is_available = lambda: True
+    return p
+
+
+def test_empty_content_with_length_is_failure_and_mentions_max_tokens():
+    p = _make_provider("", "length", max_tokens=500)
+    r = p.suggest_filename(text="Rechnung", current_filename="scan.pdf")
+    assert r.success is False
+    assert r.filename_suggestion is None
+    assert "500" in r.error_message
+    assert "Max. Tokens" in r.error_message
+
+
+def test_truncated_json_is_failure():
+    p = _make_provider('{"filename": "2024-01-31_Rech', "length")
+    r = p.suggest_filename(text="Rechnung", current_filename="scan.pdf")
+    assert r.success is False
+    assert "abgeschnitten" in r.error_message
+
+
+def test_unparseable_answer_is_failure():
+    p = _make_provider("Hier ist mein Vorschlag: Rechnung.pdf", "stop")
+    r = p.suggest_filename(text="Rechnung", current_filename="scan.pdf")
+    assert r.success is False
+    assert "nicht lesbar" in r.error_message
+
+
+def test_valid_answer_still_succeeds():
+    p = _make_provider(
+        '{"filename": "2024-01-31_Rechnung_HUK.pdf", "reason": "ok", "confidence": 0.9,'
+        ' "metadata": {"category": "Rechnung", "beschreibung": "Leistungsabrechnung"}}',
+        "stop",
+    )
+    r = p.suggest_filename(text="Rechnung", current_filename="scan.pdf")
+    assert r.success is True
+    assert r.filename_suggestion == "2024-01-31_Rechnung_HUK.pdf"
+    assert r.metadata["description"] == "Leistungsabrechnung"
+
+
+def test_folder_classification_empty_answer_is_failure():
+    p = _make_provider("", "length")
+    r = p.classify_document("text", ["Rechnungen"])
+    assert r.success is False
+
+
+def test_hybrid_records_last_llm_error():
+    from src.ml.hybrid_classifier import HybridClassifier
+
+    hc = HybridClassifier.__new__(HybridClassifier)
+    hc.llm_provider = _make_provider("", "length")
+    hc.total_tokens_used = 0
+    hc.last_llm_error = None
+    assert hc._get_llm_filename_suggestion("t", "a.pdf", None, None, None) is None
+    assert "Max. Tokens" in hc.last_llm_error

--- a/tests/test_openrouter_provider.py
+++ b/tests/test_openrouter_provider.py
@@ -43,3 +43,48 @@ def test_client_created_with_openrouter_base_url(monkeypatch):
     p = _make("openai/gpt-4.1-nano", api_key="sk-or-test")
     assert p.is_available()
     assert captured == {"api_key": "sk-or-test", "base_url": "https://openrouter.ai/api/v1"}
+
+
+def _fake_client(calls, fail_with_extras=False):
+    import types
+
+    def create(**kw):
+        calls.append(kw)
+        if fail_with_extras and "extra_body" in kw:
+            raise Exception("Error code: 400 - {'error': {'message': 'Reasoning not supported'}}")
+        choice = types.SimpleNamespace(
+            finish_reason="stop",
+            message=types.SimpleNamespace(content='{"filename": "2024-01-31_Test.pdf", "confidence": 0.9}'),
+        )
+        return types.SimpleNamespace(choices=[choice], usage=None)
+
+    return types.SimpleNamespace(chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=create)))
+
+
+def test_openrouter_sends_low_reasoning_effort():
+    p = _make("z-ai/glm-5.3-flash", api_key="sk-or-test")
+    calls = []
+    p._client = _fake_client(calls)
+    r = p.suggest_filename(text="Rechnung", current_filename="scan.pdf")
+    assert r.success is True and r.filename_suggestion == "2024-01-31_Test.pdf"
+    assert calls[0]["extra_body"] == {"reasoning": {"effort": "low"}}
+
+
+def test_openrouter_retries_without_extras_on_400():
+    p = _make("some/model-without-reasoning", api_key="sk-or-test")
+    calls = []
+    p._client = _fake_client(calls, fail_with_extras=True)
+    r = p.suggest_filename(text="Rechnung", current_filename="scan.pdf")
+    assert r.success is True
+    assert len(calls) == 2
+    assert "extra_body" in calls[0] and "extra_body" not in calls[1]
+
+
+def test_plain_openai_provider_sends_no_extras():
+    from src.ml.llm_provider import LLMConfig
+    from src.ml.openai_provider import OpenAIProvider
+    p = OpenAIProvider(LLMConfig(api_key="sk-test", model="gpt-4.1-nano"))
+    calls = []
+    p._client = _fake_client(calls)
+    p.suggest_filename(text="Rechnung", current_filename="scan.pdf")
+    assert "extra_body" not in calls[0]

--- a/tests/test_pdf_cache_llm_queue.py
+++ b/tests/test_pdf_cache_llm_queue.py
@@ -125,3 +125,49 @@ def test_persisted_empty_llm_result_counts_as_not_fetched(cache, tmp_path):
     cache._load_from_db()
     assert cache._cache[pdf].llm_fetched is False
     assert cache._cache[pdf].llm_suggestions == []
+
+
+def test_llm_pending_count_tracks_queue(cache):
+    from src.core.pdf_cache import PDFAnalysisResult
+    pdf = Path("x.pdf")
+    assert cache.llm_pending_count() == 0
+    cache._llm_queued.add(pdf)
+    assert cache.llm_pending_count() == 1
+    cache._on_llm_suggestions_error(pdf, "Fehler")
+    assert cache.llm_pending_count() == 0
+
+
+def _ok():
+    from src.core.pdf_cache import LLMSuggestion
+    return [LLMSuggestion(filename="2024-01-31_Rechnung.pdf", confidence=0.9, source="llm")]
+
+
+def test_failed_pdfs_are_requeued_once_after_next_success(cache, tmp_path):
+    """Provider faengt sich (z.B. think-Rueckfall): vorher gescheiterte PDFs nochmal."""
+    a, b, c = (tmp_path / n for n in ("a.pdf", "b.pdf", "c.pdf"))
+    for p in (a, b, c):
+        _cached(cache, p)
+    cache.pre_cache([a, b, c])
+    assert cache._llm_worker.tasks == [a, b, c]
+
+    cache._on_llm_suggestions_error(a, "leere Antwort")
+    cache._on_llm_suggestions_error(b, "Kein gültiges JSON")
+    assert cache._llm_worker.tasks == [a, b, c]  # noch kein Erfolg -> nichts
+
+    cache._on_llm_suggestions_complete(c, _ok())
+    assert cache._llm_worker.tasks[3:] == [a, b] or cache._llm_worker.tasks[3:] == [b, a]
+    assert cache.llm_pending_count() == 2
+
+    # Scheitert a erneut und danach gelingt b: a wird NICHT ein zweites Mal eingereiht
+    cache._on_llm_suggestions_error(a, "leere Antwort")
+    cache._on_llm_suggestions_complete(b, _ok())
+    assert len(cache._llm_worker.tasks) == 5
+    assert cache.llm_pending_count() == 0
+
+
+def test_success_without_prior_failure_requeues_nothing(cache, tmp_path):
+    a = tmp_path / "a.pdf"
+    _cached(cache, a)
+    cache.pre_cache([a])
+    cache._on_llm_suggestions_complete(a, _ok())
+    assert cache._llm_worker.tasks == [a]

--- a/tests/test_pdf_cache_llm_queue.py
+++ b/tests/test_pdf_cache_llm_queue.py
@@ -78,8 +78,16 @@ def test_llm_queue_dedupes_until_result_or_skip(cache, tmp_path):
     cache._on_llm_suggestions_skipped(pdf)
     assert cache.pre_cache([pdf]) == (0, 1)
 
-    # Erfolg -> llm_fetched, nichts mehr einzureihen
+    # Leeres Ergebnis -> NICHT als abgerufen merken, erneut einreihbar
     cache._on_llm_suggestions_complete(pdf, [])
+    assert cache._cache[pdf].llm_fetched is False
+    assert cache.pre_cache([pdf]) == (0, 1)
+
+    # Echter Vorschlag -> llm_fetched, nichts mehr einzureihen
+    from src.core.pdf_cache import LLMSuggestion
+    cache._on_llm_suggestions_complete(
+        pdf, [LLMSuggestion(filename="2024-01-31_Rechnung.pdf", confidence=0.9, source="llm")]
+    )
     assert cache.pre_cache([pdf]) == (0, 0)
     assert cache._cache[pdf].llm_fetched is True
 
@@ -93,3 +101,27 @@ def test_llm_error_emits_signal_and_frees_queue(cache, tmp_path, qtbot):
         cache._on_llm_suggestions_error(pdf, "HTTP 402: Guthaben aufgebraucht")
     assert blocker.args == [pdf, "HTTP 402: Guthaben aufgebraucht"]
     assert cache.pre_cache([pdf]) == (0, 1)  # erneut einreihbar
+
+
+def test_persisted_empty_llm_result_counts_as_not_fetched(cache, tmp_path):
+    """Alte Cache-Zeilen 'llm_fetched=1, llm_suggestions=[]' werden beim Laden als offen behandelt."""
+    import sqlite3
+    pdf = tmp_path / "leer.pdf"
+    pdf.write_bytes(b"%PDF")
+    db = tmp_path / "pdf_cache.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE pdf_cache (pdf_path TEXT PRIMARY KEY, extracted_text TEXT, keywords TEXT, "
+        "dates TEXT, analyzed_at TEXT, file_modified REAL, llm_suggestions TEXT, llm_fetched INTEGER DEFAULT 0)"
+    )
+    conn.execute(
+        "INSERT INTO pdf_cache VALUES (?, 'text', '[\"rechnung\"]', '[]', '2026-08-28T00:00:00', ?, '[]', 1)",
+        (str(pdf), pdf.stat().st_mtime),
+    )
+    conn.commit(); conn.close()
+
+    cache._db_path = db
+    cache._persist_cache = True
+    cache._load_from_db()
+    assert cache._cache[pdf].llm_fetched is False
+    assert cache._cache[pdf].llm_suggestions == []

--- a/tests/test_pdf_metadata_foreign_description.py
+++ b/tests/test_pdf_metadata_foreign_description.py
@@ -1,0 +1,43 @@
+"""Fremde dc:description, die nur ein Dateiname ist, gilt nicht als Zusammenfassung."""
+import pytest
+
+pikepdf = pytest.importorskip("pikepdf")
+
+
+def _pdf_with_description(tmp_path, description):
+    path = tmp_path / "huk.pdf"
+    pdf = pikepdf.new()
+    pdf.add_blank_page()
+    with pdf.open_metadata() as meta:
+        meta["dc:title"] = "Schriftwechsel_HUK"
+        meta["dc:description"] = description
+    pdf.save(path)
+    return path
+
+
+def test_filename_like_description_is_ignored(tmp_path):
+    from src.core.pdf_metadata import read_metadata
+
+    meta = read_metadata(_pdf_with_description(tmp_path, "2024-01-31_Schriftwechsel_HUK_23-13.pdf"))
+    assert meta is not None
+    assert meta.description is None
+
+
+def test_real_summary_is_kept(tmp_path):
+    from src.core.pdf_metadata import read_metadata
+
+    meta = read_metadata(_pdf_with_description(tmp_path, "Leistungsabrechnung der HUK vom 31.01.2024."))
+    assert meta.description == "Leistungsabrechnung der HUK vom 31.01.2024."
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("2024-01-31_Schriftwechsel_HUK_23-13.pdf", True),
+    ("Brief.PDF", True),
+    ("Rechnung von HUK.pdf", False),   # Leerzeichen -> Satz, kein reiner Dateiname
+    ("Zusammenfassung ohne Endung", False),
+    ("", False),
+    (None, False),
+])
+def test_looks_like_filename(value, expected):
+    from src.core.pdf_metadata import looks_like_filename
+    assert looks_like_filename(value) is expected

--- a/tests/test_reasoning_off.py
+++ b/tests/test_reasoning_off.py
@@ -85,3 +85,48 @@ def test_ollama_retries_without_think_on_400_and_remembers(monkeypatch):
     assert r2.success is True
     assert len(sent) == 3
     assert "think" in sent[0] and "think" not in sent[1] and "think" not in sent[2]
+
+
+def test_ollama_retries_with_think_low_on_empty_content_and_remembers(monkeypatch):
+    """gpt-oss kann das Denken nicht abschalten: think=false -> HTTP 200, aber leer."""
+    empty = {"message": {"content": ""}, "done_reason": "stop"}
+    ok = {"message": {"content": '{"filename": "2024-01-31_Test.pdf", "confidence": 0.9}'}}
+    p, sent = _ollama(monkeypatch, [(200, empty), (200, ok), (200, ok)])
+    r = p.suggest_filename(text="x", current_filename="a.pdf")
+    assert r.success is True
+    r2 = p.suggest_filename(text="x", current_filename="b.pdf")
+    assert r2.success is True
+    assert len(sent) == 3
+    assert sent[0]["think"] is False
+    assert sent[1]["think"] == "low"
+    assert sent[2]["think"] == "low"  # gemerkt: kein erneuter Leerlauf
+
+
+def test_ollama_empty_content_after_think_low_is_error(monkeypatch):
+    empty = {"message": {"content": ""}, "done_reason": "stop"}
+    p, sent = _ollama(monkeypatch, [(200, empty), (200, empty)])
+    r = p.suggest_filename(text="x", current_filename="a.pdf")
+    assert r.success is False
+    assert "leere Antwort" in r.error_message
+    assert len(sent) == 2
+
+
+def test_ollama_retries_with_think_low_on_leaked_reasoning(monkeypatch):
+    """gpt-oss bei think=false: Denktext statt JSON im Inhalt -> ebenfalls Rueckfall."""
+    leaked = {"message": {"content": 'The user wants a JSON object with fields: ": "x"  }'}}
+    ok = {"message": {"content": '{"filename": "2024-01-31_Test.pdf", "confidence": 0.9}'}}
+    p, sent = _ollama(monkeypatch, [(200, leaked), (200, ok)])
+    r = p.suggest_filename(text="x", current_filename="a.pdf")
+    assert r.success is True
+    assert sent[0]["think"] is False and sent[1]["think"] == "low"
+
+
+def test_ollama_gpt_oss_starts_with_think_low(monkeypatch):
+    from src.ml.llm_provider import LLMConfig
+    from src.ml.ollama_provider import OllamaProvider
+    ok = {"message": {"content": '{"filename": "2024-01-31_Test.pdf", "confidence": 0.9}'}}
+    p, sent = _ollama(monkeypatch, [(200, ok)])
+    p = OllamaProvider(LLMConfig(api_key="", model="gpt-oss-64k:latest"))
+    r = p.suggest_filename(text="x", current_filename="a.pdf")
+    assert r.success is True
+    assert len(sent) == 1 and sent[0]["think"] == "low"

--- a/tests/test_reasoning_off.py
+++ b/tests/test_reasoning_off.py
@@ -1,0 +1,87 @@
+"""Reasoning/Thinking wird fuer die kurze Extraktionsaufgabe abgeschaltet oder minimiert."""
+import io
+import json
+import types
+import urllib.error
+
+
+# ---------- OpenAI direkt ----------
+
+def _openai_client(calls, reject_extras=False):
+    def create(**kw):
+        calls.append(kw)
+        if reject_extras and "reasoning_effort" in kw:
+            raise Exception("Error code: 400 - Unrecognized request argument: reasoning_effort")
+        choice = types.SimpleNamespace(
+            finish_reason="stop",
+            message=types.SimpleNamespace(content='{"filename": "2024-01-31_Test.pdf", "confidence": 0.9}'),
+        )
+        return types.SimpleNamespace(choices=[choice], usage=None)
+    return types.SimpleNamespace(chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=create)))
+
+
+def _openai(model):
+    from src.ml.llm_provider import LLMConfig
+    from src.ml.openai_provider import OpenAIProvider
+    return OpenAIProvider(LLMConfig(api_key="sk-test", model=model))
+
+
+def test_openai_reasoning_model_gets_minimal_effort():
+    p = _openai("gpt-5-mini"); calls = []; p._client = _openai_client(calls)
+    p.suggest_filename(text="x", current_filename="a.pdf")
+    assert calls[0]["reasoning_effort"] == "minimal"
+
+
+def test_openai_classic_model_gets_no_effort_param():
+    p = _openai("gpt-4.1-nano"); calls = []; p._client = _openai_client(calls)
+    p.suggest_filename(text="x", current_filename="a.pdf")
+    assert "reasoning_effort" not in calls[0]
+
+
+def test_rejected_extras_are_remembered():
+    p = _openai("o3-mini"); calls = []; p._client = _openai_client(calls, reject_extras=True)
+    p.suggest_filename(text="x", current_filename="a.pdf")
+    p.suggest_filename(text="x", current_filename="b.pdf")
+    # 1. Aufruf: mit Extras (400) + Wiederholung ohne; 2. Aufruf: direkt ohne
+    assert len(calls) == 3
+    assert "reasoning_effort" in calls[0]
+    assert all("reasoning_effort" not in c for c in calls[1:])
+
+
+# ---------- Ollama ----------
+
+def _ollama(monkeypatch, responses):
+    """responses: Liste von (status, body_dict) pro Aufruf; sammelt gesendete Payloads."""
+    from src.ml.llm_provider import LLMConfig
+    from src.ml.ollama_provider import OllamaProvider
+    sent = []
+
+    def fake_urlopen(req, timeout=None):
+        sent.append(json.loads(req.data.decode("utf-8")))
+        status, body = responses.pop(0)
+        if status != 200:
+            raise urllib.error.HTTPError(req.full_url, status, "Bad Request", {}, io.BytesIO(b""))
+        return io.BytesIO(json.dumps(body).encode("utf-8"))
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    p = OllamaProvider(LLMConfig(api_key="", model="gemma3:4b"))
+    return p, sent
+
+
+def test_ollama_sends_think_false(monkeypatch):
+    ok = {"message": {"content": '{"filename": "2024-01-31_Test.pdf", "confidence": 0.9}'}}
+    p, sent = _ollama(monkeypatch, [(200, ok)])
+    r = p.suggest_filename(text="x", current_filename="a.pdf")
+    assert r.success is True
+    assert sent[0]["think"] is False
+
+
+def test_ollama_retries_without_think_on_400_and_remembers(monkeypatch):
+    ok = {"message": {"content": '{"filename": "2024-01-31_Test.pdf", "confidence": 0.9}'}}
+    p, sent = _ollama(monkeypatch, [(400, None), (200, ok), (200, ok)])
+    r = p.suggest_filename(text="x", current_filename="a.pdf")
+    assert r.success is True
+    r2 = p.suggest_filename(text="x", current_filename="b.pdf")
+    assert r2.success is True
+    assert len(sent) == 3
+    assert "think" in sent[0] and "think" not in sent[1] and "think" not in sent[2]

--- a/tests/test_settings_folder_naming_gui.py
+++ b/tests/test_settings_folder_naming_gui.py
@@ -1,0 +1,41 @@
+"""Einstellungen > Dateinamen-Muster: Initialen/Vorlage sind immer editierbar.
+
+Vorher waren die Felder bis zum Setzen des Hakens ausgegraut. Auf Retina-Macs
+war das Kaestchen kaum sichtbar - die Felder wirkten "nicht anklickbar".
+"""
+from PyQt6.QtTest import QTest
+
+
+def _dialog(qtbot, monkeypatch, tmp_path):
+    from src.utils import config as cfg_mod
+    from src.utils.config import Config
+    cfg = Config.__new__(Config)
+    cfg.config_path = tmp_path / "config.json"
+    cfg._config = {}
+    cfg.load()
+    monkeypatch.setattr(cfg_mod, "get_config", lambda: cfg)
+    monkeypatch.setattr("src.gui.settings_dialog.get_config", lambda: cfg, raising=False)
+    from src.gui.settings_dialog import SettingsDialog
+    dlg = SettingsDialog()
+    qtbot.addWidget(dlg)
+    return dlg
+
+
+def test_fields_editable_without_checkbox(qtbot, monkeypatch, tmp_path):
+    dlg = _dialog(qtbot, monkeypatch, tmp_path)
+    assert not dlg.folder_naming_check.isChecked()
+    assert dlg.folder_naming_initials_input.isEnabled()
+    assert dlg.folder_naming_template_input.isEnabled()
+
+
+def test_typing_initials_enables_feature(qtbot, monkeypatch, tmp_path):
+    dlg = _dialog(qtbot, monkeypatch, tmp_path)
+    QTest.keyClicks(dlg.folder_naming_initials_input, "JK")
+    assert dlg.folder_naming_initials_input.text() == "JK"
+    assert dlg.folder_naming_check.isChecked()
+
+
+def test_programmatic_fill_does_not_enable_feature(qtbot, monkeypatch, tmp_path):
+    dlg = _dialog(qtbot, monkeypatch, tmp_path)
+    dlg.folder_naming_initials_input.setText("JK")  # z.B. beim Laden der Config
+    assert not dlg.folder_naming_check.isChecked()


### PR DESCRIPTION
## Zusammenfassung

Sammel-Fix aus dem Mac-Feedback vom 2026-08-28, plus Nachbesserung fuer gpt-oss unter Ollama.

- **Leere/abgeschnittene KI-Antworten** gelten als Fehler (sichtbar in Statusleiste + Detail-Panel), werden nicht mehr als "abgerufen" gecacht; `max_tokens` Default 2000.
- **Reasoning minimiert**: OpenRouter `reasoning.effort=low`, OpenAI `reasoning_effort=minimal`, Ollama `think:false` mit Rueckfaellen:
  - HTTP 400 -> ohne `think`
  - **gpt-oss** (kann Denken nicht abschalten, liefert bei `think:false` leeren Inhalt oder Denktext statt JSON) -> am Namen erkannt, direkt `think:"low"`; andere Modelle fallen bei unbrauchbarer Antwort einmalig auf `low` zurueck.
- **"KI-Fehler" in der Statusleiste** setzt sich selbst zurueck, sobald die betroffene PDF ein Ergebnis bekommt oder der Pre-Cache-Lauf ohne weitere Fehler endet.
- **Gescheiterte PDFs** werden nach dem naechsten erfolgreichen Abruf einmalig neu eingereiht.
- Fremde PDF-Metadaten (`dc:description` = Dateiname) verworfen; Detail-Panel aktualisiert sich bei eintreffenden KI-Vorschlaegen; Checkboxen auf Retina-Macs sichtbar; Modell in der Statusleiste.

## Tests

- 483 Non-GUI-Tests, MainWindow-GUI-Tests gruen
- Live gegen Ollama 0.33.2 / `gpt-oss-64k`: vorher 21 Fehlschlaege im Pre-Cache, jetzt gueltige Vorschlaege in 1-2 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
