### PR TITLE
Release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-08-29
+
 ### Geaendert
 - **Einstellungen > Dateinamen** neu aufgebaut: Vorlage als Auswahlliste,
   die das Muster-Feld befuellt (Tippen schaltet auf „Eigenes Muster“),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdf-sortier-meister"
-version = "0.20.0"
+version = "0.21.0"
 description = "Ein intelligentes Programm zum Sortieren und Umbenennen von gescannten PDF-Dokumenten"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,7 @@ from src.utils.single_instance import (
 from src.utils.explorer_integration import update_launcher_script
 
 # Versionsnummer zentral definiert
-__version__ = "0.20.0"
+__version__ = "0.21.0"
 
 
 def _apply_wizard_result(window, config):


### PR DESCRIPTION
Version bump 0.20.0 -> 0.21.0, CHANGELOG-Abschnitt [0.21.0] - 2026-08-29 (Dateinamen-Tab, Platzhalter-Syntax, Sanitizer, Leerzeichen/Initialen fuer Beta-Tester-Schema, KI-Fixes aus #95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)