### PR TITLE
feat: Daten-Backup (#98), Vorschau-Zeile (#101), „Nur verschieben“ (#100) und Auto-LLM (#92) entfernt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,27 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   manueller KI-Aufruf im Detail-Panel), wird ihre Kachel im Scan-Ordner gruen
   hinterlegt; der Tooltip nennt den Grund. Die Auswahl (blau) bleibt sichtbar.
 
+- **Daten sichern und wiederherstellen** (#98): *Extras > Daten sichern
+  (ZIP)…* packt Datenbank (Verlauf, Suchindex/RAG, Korrespondenten, Regeln),
+  KI-Cache, ML-Modell und Einstellungen in ein ZIP - SQLite-Dateien als
+  konsistenter Schnappschuss auch bei laufender Anwendung. *Extras > Daten
+  aus Sicherung wiederherstellen…* merkt ein solches Archiv vor; beim
+  naechsten Start werden die Dateien eingespielt, die bisherigen bleiben
+  unter `restore_previous` im Datenordner erhalten. Gedacht fuer Umzug oder
+  Neuinstallation.
+
+### Geaendert
+- Detail-Panel: Die gruene Vorschau-Zeile unter „Neuer Dateiname“ erscheint
+  nur noch, wenn der endgueltige Name vom Eingetippten abweicht (ersetzte
+  Zeichen, E-Mail-Adresse) - sonst stand derselbe Name zweimal da (#101).
+
+### Entfernt
+- Der Schalter „Nur verschieben“ samt Hinweiszeile unter den Metadaten (#100):
+  unklar und Platzfresser. Reines Verschieben ohne Umbenennen geht weiter per
+  Drag & Drop oder Kontextmenue „Verschieben nach…“.
+- Einstellungen > LLM: die wirkungslose Option „Auto-LLM“ und der Hinweis
+  zu API-Kosten/TF-IDF (#92).
+
 ### Behoben
 - Die Muster-Vorschau „Mit aktueller PDF“ in den Einstellungen las die
   Zusammenfassung unter dem alten Schluessel `beschreibung` und fuellte

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -395,37 +395,8 @@ class DetailPanel(QWidget):
 
         detail_layout.addWidget(self.metadata_group)
 
-        # Hinweis-Zeile mit Move-Only-Toggle
-        hint_layout = QHBoxLayout()
-        hint_layout.setSpacing(8)
-        hint_layout.setContentsMargins(0, 0, 0, 0)
-
-        self.move_only_toggle = QCheckBox("Nur verschieben")
-        self.move_only_toggle.setToolTip(
-            "Wenn aktiv (rot): beim Klick auf einen Zielordner wird das PDF NUR "
-            "verschoben - ohne Umbenennen und ohne Metadaten in die PDF zu schreiben."
-        )
-        self.move_only_toggle.setStyleSheet(
-            "QCheckBox { font-size: 10px; color: #555; spacing: 6px; }"
-            "QCheckBox::indicator { width: 32px; height: 16px; border-radius: 8px; "
-            "background-color: #c8e6c9; border: 1px solid #66bb6a; }"
-            "QCheckBox::indicator:checked { background-color: #ef5350; "
-            "border: 1px solid #c62828; }"
-        )
-        self.move_only_toggle.toggled.connect(self._refresh_hint_label)
-        hint_layout.addWidget(self.move_only_toggle)
-
-        self.hint_label = QLabel()
-        self.hint_label.setWordWrap(True)
-        self.hint_label.setStyleSheet(
-            "color: #1976d2; font-weight: bold; padding: 4px 6px; "
-            "background-color: #e3f2fd; border-radius: 4px; font-size: 11px;"
-        )
-        hint_layout.addWidget(self.hint_label, stretch=1)
-
-        detail_layout.addLayout(hint_layout)
-        self._refresh_hint_label()
-
+        # Der Schalter "Nur verschieben" samt Hinweiszeile ist entfernt (Issue
+        # #100): reines Verschieben geht per Drag & Drop oder Kontextmenue.
         detail_layout.addStretch()
 
         self.detail_container.hide()
@@ -800,23 +771,6 @@ class DetailPanel(QWidget):
             self._metadata_source = "user"
         self._refresh_save_btn()
 
-    def _refresh_hint_label(self):
-        """Aktualisiert den Hinweistext je nach Move-Only-Modus."""
-        if self.move_only_toggle.isChecked():
-            self.hint_label.setText(
-                'Jetzt rechts auf einen Zielordner klicken - dabei wird das PDF '
-                'verschoben, <s>umbenannt und die Metadaten gespeichert</s>'
-            )
-        else:
-            self.hint_label.setText(
-                'Jetzt rechts auf einen Zielordner klicken - dabei wird das PDF '
-                'verschoben, umbenannt und die Metadaten gespeichert'
-            )
-
-    def is_move_only_mode(self) -> bool:
-        """True wenn der Move-Only-Schalter aktiv ist."""
-        return self.move_only_toggle.isChecked()
-
     def _refresh_save_btn(self):
         """Aktualisiert Text und Status des Speichern-Buttons und des Status-Labels."""
         current = self.get_metadata()
@@ -1051,13 +1005,17 @@ class DetailPanel(QWidget):
                 widget.setText(str(value) if value else "")
 
     def _update_preview(self, text: str):
-        """Aktualisiert die Dateinamen-Vorschau."""
+        """Aktualisiert die Dateinamen-Vorschau.
+
+        Die Vorschau-Zeile erscheint nur, wenn der endgueltige Name vom
+        Eingetippten abweicht (ersetzte Zeichen, E-Mail, ungueltig) - sonst
+        stuende derselbe Name zweimal untereinander (Issue #101).
+        """
         if not text.strip():
-            self.preview_label.setText("(Name eingeben)")
-            self.preview_label.setStyleSheet(
-                "font-family: monospace; padding: 6px; background-color: #fff3e0; "
-                "border: 1px solid #ffcc80; border-radius: 3px; font-size: 11px;"
-            )
+            self.preview_label.clear()
+            self.preview_label.hide()
+            self.warning_label.hide()
+            self._refresh_save_btn()
             return
 
         from src.utils.filename_sanitizer import (
@@ -1099,6 +1057,9 @@ class DetailPanel(QWidget):
         self._refresh_save_btn()
 
         self.preview_label.setText(preview_name)
+        # Nur zeigen, wenn sich etwas aendert (".pdf" haengt ohnehin an)
+        unchanged = preview_name == f"{text.strip()}.pdf" or preview_name == text.strip()
+        self.preview_label.setVisible(not unchanged)
 
     LLM_BTN_TEXT = "KI-Metadaten neu generieren"
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1304,6 +1304,21 @@ class MainWindow(QMainWindow):
         backup_action.triggered.connect(self.check_backup_status)
         extras_menu.addAction(backup_action)
 
+        # Anwendungsdaten sichern/wiederherstellen (Issue #98)
+        self.backup_data_action = QAction("Daten sichern (ZIP)...", self)
+        self.backup_data_action.setToolTip(
+            "Datenbank, Suchindex, KI-Cache, Modell und Einstellungen als ZIP sichern"
+        )
+        self.backup_data_action.triggered.connect(self.backup_app_data)
+        extras_menu.addAction(self.backup_data_action)
+
+        self.restore_data_action = QAction("Daten aus Sicherung wiederherstellen...", self)
+        self.restore_data_action.setToolTip(
+            "Eine mit „Daten sichern“ erstellte ZIP-Datei beim nächsten Start einspielen"
+        )
+        self.restore_data_action.triggered.connect(self.restore_app_data)
+        extras_menu.addAction(self.restore_data_action)
+
         extras_menu.addSeparator()
 
         wizard_action = QAction("Einrichtungs-Assistent...", self)
@@ -1887,28 +1902,23 @@ class MainWindow(QMainWindow):
         """Verschiebt eine PDF mit optionaler Umbenennung und Metadaten (3-Spalten-Workflow)."""
         relative_path = self.folder_tree.get_relative_path(folder_path)
 
-        # Move-Only-Schalter im Detail-Panel: ueberspringt Umbenennen + Metadaten
-        if self.detail_panel.is_move_only_mode():
-            new_name = None
-            metadata = {}
-        else:
-            new_name = self.detail_panel.get_new_name()
-            metadata = self.detail_panel.get_metadata()
+        new_name = self.detail_panel.get_new_name()
+        metadata = self.detail_panel.get_metadata()
 
-            # Dateiname aus Ordnerstruktur aufbauen (Issue #42, Opt-in)
-            if self.config.get("folder_naming_enabled", False):
-                fallback_date = (
-                    coerce_date(self.selected_pdf_dates[0])
-                    if self.selected_pdf_dates else None
-                )
-                new_name = build_folder_based_name(
-                    new_name or pdf_path.name,
-                    folder_path,
-                    relative_path,
-                    template=self.config.get("folder_naming_template", "") or DEFAULT_TEMPLATE,
-                    initials=self.config.get("owner_initials", ""),
-                    fallback_date=fallback_date,
-                )
+        # Dateiname aus Ordnerstruktur aufbauen (Issue #42, Opt-in)
+        if self.config.get("folder_naming_enabled", False):
+            fallback_date = (
+                coerce_date(self.selected_pdf_dates[0])
+                if self.selected_pdf_dates else None
+            )
+            new_name = build_folder_based_name(
+                new_name or pdf_path.name,
+                folder_path,
+                relative_path,
+                template=self.config.get("folder_naming_template", "") or DEFAULT_TEMPLATE,
+                initials=self.config.get("owner_initials", ""),
+                fallback_date=fallback_date,
+            )
 
         # Prüfen ob umbenannt wird
         name_changed = new_name and new_name != pdf_path.name
@@ -3850,6 +3860,91 @@ class MainWindow(QMainWindow):
     def check_backup_status(self):
         """Zeigt den Backup-Hinweis (Menue). Macrium-Log-Parsing: Issue #14."""
         self.show_backup_hint(force=True)
+
+    # === Anwendungsdaten sichern / wiederherstellen (Issue #98) ===
+
+    @staticmethod
+    def _documents_dir() -> str:
+        from PyQt6.QtCore import QStandardPaths
+        return QStandardPaths.writableLocation(
+            QStandardPaths.StandardLocation.DocumentsLocation
+        ) or str(Path.home())
+
+    def backup_app_data(self):
+        """Extras > Daten sichern: ZIP mit Datenbank, Cache, Modell und Einstellungen."""
+        from src.utils.backup import create_backup, default_backup_name
+
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Daten sichern",
+            str(Path(self._documents_dir()) / default_backup_name()),
+            "ZIP-Archiv (*.zip)",
+        )
+        if not path:
+            return
+        version = QApplication.applicationVersion() or ""
+        QApplication.setOverrideCursor(Qt.CursorShape.BusyCursor)
+        try:
+            info = create_backup(self.config.data_dir, Path(path), version=version)
+        except Exception as e:
+            QApplication.restoreOverrideCursor()
+            QMessageBox.critical(self, "Sicherung fehlgeschlagen", str(e))
+            return
+        QApplication.restoreOverrideCursor()
+        size_mb = info.total_bytes / (1024 * 1024)
+        QMessageBox.information(
+            self,
+            "Daten gesichert",
+            f"{len(info.entries)} Dateien ({size_mb:.1f} MB) gesichert nach:\n{path}\n\n"
+            "Enthalten: Datenbank (Verlauf, Suchindex, Korrespondenten, Regeln), "
+            "KI-Cache, ML-Modell und Einstellungen.\n\n"
+            "Hinweis: Die Einstellungen enthalten Ihre API-Schlüssel – bewahren "
+            "Sie das Archiv entsprechend geschützt auf.",
+        )
+        self.statusbar.showMessage(f"Daten gesichert: {Path(path).name}", 5000)
+
+    def restore_app_data(self):
+        """Extras > Daten wiederherstellen: ZIP vormerken, beim naechsten Start einspielen."""
+        from src.utils.backup import PREVIOUS_DIR, inspect_backup, stage_restore
+
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Sicherung wiederherstellen", self._documents_dir(), "ZIP-Archiv (*.zip)"
+        )
+        if not path:
+            return
+        try:
+            info = inspect_backup(Path(path))
+        except Exception as e:
+            QMessageBox.critical(self, "Keine gültige Sicherung", str(e))
+            return
+
+        version = info.version or "unbekannt"
+        answer = QMessageBox.question(
+            self,
+            "Sicherung wiederherstellen?",
+            f"Sicherung vom {info.created_display} (Version {version}, "
+            f"{len(info.entries)} Dateien).\n\n"
+            "Beim nächsten Start ersetzen diese Daten die aktuelle Datenbank, den "
+            "KI-Cache, das Modell und die Einstellungen. Die bisherigen Dateien "
+            f"bleiben im Datenordner unter „{PREVIOUS_DIR}“ erhalten.\n\n"
+            "PDF Sortier Meister wird dazu jetzt beendet. Fortfahren?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if answer != QMessageBox.StandardButton.Yes:
+            return
+        try:
+            stage_restore(Path(path), self.config.data_dir)
+        except Exception as e:
+            QMessageBox.critical(self, "Wiederherstellung fehlgeschlagen", str(e))
+            return
+        QMessageBox.information(
+            self,
+            "Wiederherstellung vorbereitet",
+            "Bitte PDF Sortier Meister jetzt neu starten – die Sicherung wird "
+            "beim Start eingespielt.",
+        )
+        self.close()
 
     def show_first_steps_hint(self, force: bool = False):
         """

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -222,11 +222,6 @@ class SettingsDialog(QDialog):
         self.temperature_spin.setValue(0.3)
         advanced_layout.addRow("Temperatur:", self.temperature_spin)
 
-        self.auto_use_check = QCheckBox(
-            "Automatisch bei niedriger lokaler Konfidenz verwenden"
-        )
-        advanced_layout.addRow("Auto-LLM:", self.auto_use_check)
-
         self.text_limit_spin = QSpinBox()
         self.text_limit_spin.setRange(500, 5000)
         self.text_limit_spin.setValue(1500)
@@ -240,15 +235,6 @@ class SettingsDialog(QDialog):
         advanced_layout.addRow("Text-Limit:", self.text_limit_spin)
 
         layout.addWidget(advanced_group)
-
-        # Info-Label
-        info_label = QLabel(
-            "<i>Hinweis: Die LLM-Nutzung verursacht API-Kosten. "
-            "Das lokale TF-IDF-System funktioniert auch ohne LLM.</i>"
-        )
-        info_label.setWordWrap(True)
-        info_label.setStyleSheet("color: gray;")
-        layout.addWidget(info_label)
 
         layout.addStretch()
 
@@ -1274,7 +1260,6 @@ class SettingsDialog(QDialog):
 
         self.max_tokens_spin.setValue(llm_config.get("max_tokens", 2000))
         self.temperature_spin.setValue(llm_config.get("temperature", 0.3))
-        self.auto_use_check.setChecked(llm_config.get("auto_use", False))
         self.text_limit_spin.setValue(llm_config.get("text_limit", 1500))
         self.cloud_consent_check.setChecked(llm_config.get("cloud_consent", False))
 
@@ -1357,7 +1342,6 @@ class SettingsDialog(QDialog):
             "model": model,
             "max_tokens": self.max_tokens_spin.value(),
             "temperature": self.temperature_spin.value(),
-            "auto_use": self.auto_use_check.isChecked(),
             "text_limit": self.text_limit_spin.value(),
             "base_url": self.base_url_input.text().strip(),
             "cloud_consent": self.cloud_consent_check.isChecked(),

--- a/src/main.py
+++ b/src/main.py
@@ -98,6 +98,17 @@ def main():
         logger.info("Laufende Instanz benachrichtigt, beende Zweitstart.")
         sys.exit(0)
 
+    # Vorgemerkte Wiederherstellung (Extras > Daten wiederherstellen, Issue #98)
+    # einspielen, BEVOR Config und Datenbanken geoeffnet werden.
+    try:
+        from src.utils.backup import apply_pending_restore
+        from src.utils.platform_paths import get_app_data_dir
+        restored = apply_pending_restore(get_app_data_dir())
+        if restored:
+            logger.info(f"Sicherung eingespielt: {', '.join(restored)}")
+    except Exception as e:
+        logger.error(f"Wiederherstellung der Sicherung fehlgeschlagen: {e}")
+
     # Launcher-Skript fuer das Explorer-Kontextmenue aktualisieren.
     # Das passiert bei jedem Start, damit der Registry-Eintrag stets auf
     # die aktuell verwendete .exe bzw. python-Installation zeigt.

--- a/src/utils/backup.py
+++ b/src/utils/backup.py
@@ -1,0 +1,210 @@
+"""Sicherung und Wiederherstellung der Anwendungsdaten (Issue #98).
+
+Alles, was PDF Sortier Meister ueber die Zeit ansammelt, liegt im
+Datenverzeichnis (siehe ``platform_paths.get_app_data_dir``):
+
+- ``history.db``     Verlauf, Suchindex (FTS5 / RAG), Korrespondenten, Regeln
+- ``pdf_cache.db``   Analyse- und KI-Vorschlags-Cache
+- ``config.json``    Einstellungen inkl. API-Schluessel
+- ``llm_timing.json`` Laufzeit-Schaetzungen fuer die KI-Anzeige
+- ``model/``         trainiertes TF-IDF-Modell
+
+Ein Backup ist ein ZIP mit genau diesen Eintraegen plus ``backup_info.json``.
+SQLite-Dateien werden ueber die Backup-API kopiert, damit der Schnappschuss
+auch bei laufender Anwendung konsistent ist.
+
+Wiederherstellen laeuft zweistufig: ``stage_restore`` entpackt das Archiv
+nach ``restore_pending/``; beim naechsten Start (bevor Config/Datenbank
+geoeffnet werden) verschiebt ``apply_pending_restore`` die Dateien an ihren
+Platz und hebt die ersetzten Dateien unter ``restore_previous/`` auf.
+Thumbnails und Logs sind reine Caches und werden nicht gesichert.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import tempfile
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+
+BACKUP_FILES: tuple[str, ...] = ("config.json", "history.db", "pdf_cache.db", "llm_timing.json")
+BACKUP_DIRS: tuple[str, ...] = ("model",)
+INFO_NAME = "backup_info.json"
+PENDING_DIR = "restore_pending"
+PREVIOUS_DIR = "restore_previous"
+
+
+@dataclass
+class BackupInfo:
+    """Inhalt eines Backups (aus ``backup_info.json`` bzw. beim Erstellen)."""
+    created_at: str = ""
+    version: str = ""
+    entries: list[str] = field(default_factory=list)
+    total_bytes: int = 0
+    path: Path | None = None
+
+    @property
+    def created_display(self) -> str:
+        """``2026-08-29 18:30`` (oder der Rohwert, falls unlesbar)."""
+        try:
+            return datetime.fromisoformat(self.created_at).strftime("%Y-%m-%d %H:%M")
+        except ValueError:
+            return self.created_at or "unbekannt"
+
+
+def default_backup_name(now: datetime | None = None) -> str:
+    """``PDF_Sortier_Meister_Backup_2026-08-29_1830.zip``."""
+    now = now or datetime.now()
+    return f"PDF_Sortier_Meister_Backup_{now:%Y-%m-%d_%H%M}.zip"
+
+
+def _snapshot_sqlite(src: Path, dest: Path) -> None:
+    """Konsistente Kopie einer SQLite-Datenbank (auch bei offenen Verbindungen)."""
+    source = sqlite3.connect(str(src))
+    try:
+        target = sqlite3.connect(str(dest))
+        try:
+            source.backup(target)
+        finally:
+            target.close()
+    finally:
+        source.close()
+
+
+def _is_safe_entry(name: str) -> bool:
+    """Nur relative Pfade ohne ``..`` innerhalb der bekannten Eintraege."""
+    p = PurePosixPath(name)
+    if p.is_absolute() or ".." in p.parts or not p.parts:
+        return False
+    top = p.parts[0]
+    if len(p.parts) == 1:
+        return top in BACKUP_FILES
+    return top in BACKUP_DIRS
+
+
+def create_backup(data_dir: Path, zip_path: Path, version: str = "") -> BackupInfo:
+    """Packt die Anwendungsdaten aus ``data_dir`` in ``zip_path``.
+
+    Raises:
+        FileNotFoundError: wenn in ``data_dir`` keine bekannte Datei liegt.
+    """
+    data_dir = Path(data_dir)
+    zip_path = Path(zip_path)
+    with tempfile.TemporaryDirectory(prefix="pdfsm_backup_") as tmp:
+        staged: list[tuple[Path, str]] = []  # (Datei auf Platte, Name im Archiv)
+        for name in BACKUP_FILES:
+            src = data_dir / name
+            if not src.is_file():
+                continue
+            if src.suffix == ".db":
+                dest = Path(tmp) / name
+                _snapshot_sqlite(src, dest)
+                staged.append((dest, name))
+            else:
+                staged.append((src, name))
+        for dname in BACKUP_DIRS:
+            folder = data_dir / dname
+            if folder.is_dir():
+                for f in sorted(folder.rglob("*")):
+                    if f.is_file():
+                        staged.append((f, f.relative_to(data_dir).as_posix()))
+        if not staged:
+            raise FileNotFoundError(f"Keine Anwendungsdaten gefunden in {data_dir}")
+
+        info = BackupInfo(
+            created_at=datetime.now().isoformat(timespec="seconds"),
+            version=version,
+            entries=[arc for _f, arc in staged],
+            total_bytes=sum(f.stat().st_size for f, _a in staged),
+            path=zip_path,
+        )
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for f, arc in staged:
+                zf.write(f, arc)
+            zf.writestr(INFO_NAME, json.dumps({
+                "created_at": info.created_at,
+                "version": info.version,
+                "entries": info.entries,
+                "total_bytes": info.total_bytes,
+            }, indent=2, ensure_ascii=False))
+    return info
+
+
+def inspect_backup(zip_path: Path) -> BackupInfo:
+    """Liest ``backup_info.json`` und prueft, ob das Archiv ein Backup ist.
+
+    Raises:
+        ValueError: kein ZIP oder keine bekannten Eintraege.
+    """
+    zip_path = Path(zip_path)
+    if not zipfile.is_zipfile(zip_path):
+        raise ValueError(f"{zip_path.name} ist kein ZIP-Archiv.")
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+        entries = [n for n in names if not n.endswith("/") and _is_safe_entry(n)]
+        if not entries:
+            raise ValueError(
+                f"{zip_path.name} enthaelt keine Daten von PDF Sortier Meister "
+                f"(erwartet z.B. {BACKUP_FILES[1]} oder {BACKUP_FILES[0]})."
+            )
+        info = BackupInfo(entries=entries, path=zip_path)
+        if INFO_NAME in names:
+            try:
+                raw = json.loads(zf.read(INFO_NAME).decode("utf-8"))
+                info.created_at = str(raw.get("created_at", ""))
+                info.version = str(raw.get("version", ""))
+                info.total_bytes = int(raw.get("total_bytes", 0) or 0)
+            except (ValueError, UnicodeDecodeError):
+                pass
+        if not info.total_bytes:
+            info.total_bytes = sum(zf.getinfo(n).file_size for n in entries)
+    return info
+
+
+def stage_restore(zip_path: Path, data_dir: Path) -> BackupInfo:
+    """Entpackt das Backup nach ``data_dir/restore_pending`` (eingespielt beim Start)."""
+    info = inspect_backup(zip_path)
+    pending = Path(data_dir) / PENDING_DIR
+    if pending.exists():
+        shutil.rmtree(pending)
+    pending.mkdir(parents=True)
+    with zipfile.ZipFile(zip_path) as zf:
+        for name in info.entries:
+            zf.extract(name, pending)
+    return info
+
+
+def apply_pending_restore(data_dir: Path) -> list[str]:
+    """Spielt eine vorbereitete Wiederherstellung ein (vor dem Oeffnen von Config/DB).
+
+    Ersetzte Dateien und Ordner landen unter ``restore_previous/`` (wird
+    vorher geleert). Liefert die Namen der eingespielten Eintraege; ``[]``
+    wenn nichts ansteht.
+    """
+    data_dir = Path(data_dir)
+    pending = data_dir / PENDING_DIR
+    if not pending.is_dir():
+        return []
+    entries = sorted(pending.iterdir(), key=lambda p: p.name)
+    if not entries:
+        shutil.rmtree(pending, ignore_errors=True)
+        return []
+
+    previous = data_dir / PREVIOUS_DIR
+    if previous.exists():
+        shutil.rmtree(previous)
+    previous.mkdir()
+
+    restored: list[str] = []
+    for entry in entries:
+        target = data_dir / entry.name
+        if target.exists():
+            shutil.move(str(target), str(previous / entry.name))
+        shutil.move(str(entry), str(target))
+        restored.append(entry.name)
+    shutil.rmtree(pending, ignore_errors=True)
+    return restored

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,162 @@
+"""Issue #98: Anwendungsdaten sichern (ZIP) und wiederherstellen (kein Qt)."""
+import json
+import sqlite3
+import zipfile
+
+import pytest
+
+from src.utils.backup import (
+    INFO_NAME,
+    PENDING_DIR,
+    PREVIOUS_DIR,
+    apply_pending_restore,
+    create_backup,
+    default_backup_name,
+    inspect_backup,
+    stage_restore,
+)
+
+
+def _make_db(path, rows):
+    conn = sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE t (v TEXT)")
+    conn.executemany("INSERT INTO t VALUES (?)", [(r,) for r in rows])
+    conn.commit()
+    conn.close()
+
+
+def _rows(path):
+    conn = sqlite3.connect(str(path))
+    try:
+        return [r[0] for r in conn.execute("SELECT v FROM t ORDER BY v")]
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    d = tmp_path / "appdata"
+    d.mkdir()
+    (d / "config.json").write_text(json.dumps({"scan_folder": "C:/Scans"}), encoding="utf-8")
+    _make_db(d / "history.db", ["alpha", "beta"])
+    _make_db(d / "pdf_cache.db", ["cache"])
+    (d / "llm_timing.json").write_text("{}", encoding="utf-8")
+    (d / "model").mkdir()
+    (d / "model" / "classifier.pkl").write_bytes(b"MODEL")
+    # Caches, die NICHT ins Backup gehoeren
+    (d / "thumbnails").mkdir()
+    (d / "thumbnails" / "x.png").write_bytes(b"PNG")
+    (d / "logs").mkdir()
+    (d / "logs" / "app.log").write_text("log", encoding="utf-8")
+    (d / "launcher.cmd").write_text("rem", encoding="utf-8")
+    return d
+
+
+def test_create_backup_contains_data_but_not_caches(data_dir, tmp_path):
+    zip_path = tmp_path / "out" / "b.zip"
+    info = create_backup(data_dir, zip_path, version="0.22.0")
+
+    assert zip_path.exists()
+    assert set(info.entries) == {
+        "config.json", "history.db", "pdf_cache.db", "llm_timing.json", "model/classifier.pkl",
+    }
+    with zipfile.ZipFile(zip_path) as zf:
+        names = set(zf.namelist())
+        assert names == set(info.entries) | {INFO_NAME}
+        meta = json.loads(zf.read(INFO_NAME))
+    assert meta["version"] == "0.22.0"
+    assert meta["entries"] == info.entries
+    assert info.total_bytes > 0
+
+
+def test_sqlite_snapshot_is_consistent_while_connection_is_open(data_dir, tmp_path):
+    # Offene Verbindung mit unbestaetigter Aenderung: Backup sieht nur den Commit-Stand
+    conn = sqlite3.connect(str(data_dir / "history.db"))
+    conn.execute("INSERT INTO t VALUES ('uncommitted')")
+    try:
+        info = create_backup(data_dir, tmp_path / "b.zip")
+    finally:
+        conn.rollback()
+        conn.close()
+    with zipfile.ZipFile(info.path) as zf:
+        zf.extract("history.db", tmp_path / "x")
+    assert _rows(tmp_path / "x" / "history.db") == ["alpha", "beta"]
+
+
+def test_create_backup_without_data_raises(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(FileNotFoundError):
+        create_backup(empty, tmp_path / "b.zip")
+
+
+def test_inspect_backup_reads_info_and_rejects_foreign_zip(data_dir, tmp_path):
+    created = create_backup(data_dir, tmp_path / "b.zip", version="0.22.0")
+    info = inspect_backup(tmp_path / "b.zip")
+    assert info.version == "0.22.0"
+    assert info.created_at == created.created_at
+    assert info.created_display == created.created_at[:16].replace("T", " ")
+    assert set(info.entries) == set(created.entries)
+
+    foreign = tmp_path / "foreign.zip"
+    with zipfile.ZipFile(foreign, "w") as zf:
+        zf.writestr("readme.txt", "hi")
+        zf.writestr("../evil.db", "x")
+    with pytest.raises(ValueError):
+        inspect_backup(foreign)
+    (tmp_path / "not.zip").write_text("nope", encoding="utf-8")
+    with pytest.raises(ValueError):
+        inspect_backup(tmp_path / "not.zip")
+
+
+def test_stage_and_apply_restore_replaces_files_and_keeps_previous(data_dir, tmp_path):
+    zip_path = tmp_path / "b.zip"
+    create_backup(data_dir, zip_path)
+
+    # Danach veraendert sich der Bestand ...
+    _make_db(tmp_path / "new.db", ["gamma"])
+    (tmp_path / "new.db").replace(data_dir / "history.db")
+    (data_dir / "config.json").write_text("{}", encoding="utf-8")
+    (data_dir / "model" / "classifier.pkl").write_bytes(b"NEWMODEL")
+
+    info = stage_restore(zip_path, data_dir)
+    pending = data_dir / PENDING_DIR
+    assert (pending / "history.db").exists()
+    assert (pending / "model" / "classifier.pkl").read_bytes() == b"MODEL"
+    assert INFO_NAME not in {p.name for p in pending.iterdir()}
+    assert "history.db" in info.entries
+
+    restored = apply_pending_restore(data_dir)
+    assert set(restored) == {"config.json", "history.db", "pdf_cache.db", "llm_timing.json", "model"}
+    assert not pending.exists()
+    assert _rows(data_dir / "history.db") == ["alpha", "beta"]
+    assert json.loads((data_dir / "config.json").read_text(encoding="utf-8")) == {"scan_folder": "C:/Scans"}
+    assert (data_dir / "model" / "classifier.pkl").read_bytes() == b"MODEL"
+    # Ersetzte Dateien bleiben erhalten
+    previous = data_dir / PREVIOUS_DIR
+    assert _rows(previous / "history.db") == ["gamma"]
+    assert (previous / "model" / "classifier.pkl").read_bytes() == b"NEWMODEL"
+    # Caches unangetastet
+    assert (data_dir / "thumbnails" / "x.png").exists()
+
+
+def test_apply_without_pending_is_noop(data_dir):
+    assert apply_pending_restore(data_dir) == []
+    (data_dir / PENDING_DIR).mkdir()
+    assert apply_pending_restore(data_dir) == []
+    assert not (data_dir / PENDING_DIR).exists()
+
+
+def test_stage_restore_replaces_older_pending(data_dir, tmp_path):
+    zip_path = tmp_path / "b.zip"
+    create_backup(data_dir, zip_path)
+    pending = data_dir / PENDING_DIR
+    pending.mkdir()
+    (pending / "stale.txt").write_text("alt", encoding="utf-8")
+    stage_restore(zip_path, data_dir)
+    assert not (pending / "stale.txt").exists()
+
+
+def test_default_backup_name():
+    from datetime import datetime
+    assert default_backup_name(datetime(2026, 8, 29, 18, 30)) == "PDF_Sortier_Meister_Backup_2026-08-29_1830.zip"

--- a/tests/test_backup_gui.py
+++ b/tests/test_backup_gui.py
@@ -1,0 +1,82 @@
+"""Issue #98: Extras > Daten sichern / wiederherstellen im Hauptfenster."""
+from pathlib import Path
+
+from PyQt6.QtWidgets import QFileDialog, QMessageBox
+
+from tests.test_main_window_gui import fresh_singletons, main_window  # noqa: F401 - Fixtures
+
+
+def _menu_texts(win):
+    extras = next(m for m in win.menuBar().findChildren(type(win.menuBar().actions()[0].menu()))
+                  if m.title() == "Extras")
+    return [a.text() for a in extras.actions() if a.text()]
+
+
+def test_extras_menu_has_backup_actions(main_window):
+    texts = _menu_texts(main_window)
+    assert "Daten sichern (ZIP)..." in texts
+    assert "Daten aus Sicherung wiederherstellen..." in texts
+
+
+def test_backup_writes_zip(main_window, fresh_singletons, monkeypatch, tmp_path):
+    from src.utils.backup import inspect_backup
+    target = tmp_path / "sicherung.zip"
+    monkeypatch.setattr(QFileDialog, "getSaveFileName", staticmethod(lambda *a, **k: (str(target), "")))
+    shown = []
+    monkeypatch.setattr(QMessageBox, "information", staticmethod(lambda *a, **k: shown.append(a[2])))
+
+    main_window.backup_app_data()
+
+    assert target.exists()
+    info = inspect_backup(target)
+    assert "config.json" in info.entries
+    assert shown and "gesichert" in shown[0]
+
+
+def test_backup_cancelled_writes_nothing(main_window, monkeypatch, tmp_path):
+    monkeypatch.setattr(QFileDialog, "getSaveFileName", staticmethod(lambda *a, **k: ("", "")))
+    main_window.backup_app_data()
+    assert not list(tmp_path.glob("*.zip"))
+
+
+def test_restore_stages_backup_and_closes(main_window, fresh_singletons, monkeypatch, tmp_path):
+    from src.utils.backup import PENDING_DIR, create_backup
+    data_dir = fresh_singletons["config"].data_dir
+    zip_path = tmp_path / "b.zip"
+    create_backup(data_dir, zip_path)
+
+    monkeypatch.setattr(QFileDialog, "getOpenFileName", staticmethod(lambda *a, **k: (str(zip_path), "")))
+    monkeypatch.setattr(QMessageBox, "question",
+                        staticmethod(lambda *a, **k: QMessageBox.StandardButton.Yes))
+    monkeypatch.setattr(QMessageBox, "information", staticmethod(lambda *a, **k: None))
+    closed = []
+    monkeypatch.setattr(type(main_window), "close", lambda self: closed.append(True))
+
+    main_window.restore_app_data()
+
+    assert (Path(data_dir) / PENDING_DIR / "config.json").exists()
+    assert closed == [True]
+
+
+def test_restore_declined_does_nothing(main_window, fresh_singletons, monkeypatch, tmp_path):
+    from src.utils.backup import PENDING_DIR, create_backup
+    data_dir = fresh_singletons["config"].data_dir
+    zip_path = tmp_path / "b.zip"
+    create_backup(data_dir, zip_path)
+    monkeypatch.setattr(QFileDialog, "getOpenFileName", staticmethod(lambda *a, **k: (str(zip_path), "")))
+    monkeypatch.setattr(QMessageBox, "question",
+                        staticmethod(lambda *a, **k: QMessageBox.StandardButton.No))
+    main_window.restore_app_data()
+    assert not (Path(data_dir) / PENDING_DIR).exists()
+
+
+def test_restore_rejects_foreign_zip(main_window, monkeypatch, tmp_path):
+    import zipfile
+    foreign = tmp_path / "foreign.zip"
+    with zipfile.ZipFile(foreign, "w") as zf:
+        zf.writestr("readme.txt", "x")
+    monkeypatch.setattr(QFileDialog, "getOpenFileName", staticmethod(lambda *a, **k: (str(foreign), "")))
+    errors = []
+    monkeypatch.setattr(QMessageBox, "critical", staticmethod(lambda *a, **k: errors.append(a[1])))
+    main_window.restore_app_data()
+    assert errors == ["Keine gültige Sicherung"]

--- a/tests/test_detail_panel_preview_gui.py
+++ b/tests/test_detail_panel_preview_gui.py
@@ -1,0 +1,51 @@
+"""Issue #101: Die Vorschau-Zeile unter "Neuer Dateiname" erscheint nur, wenn
+der endgueltige Name vom Eingetippten abweicht."""
+
+
+def _panel(qtbot):
+    from src.gui import detail_panel as dp
+    panel = dp.DetailPanel()
+    qtbot.addWidget(panel)
+    panel.show()
+    return panel
+
+
+def test_preview_hidden_when_name_is_unchanged(qtbot):
+    panel = _panel(qtbot)
+    panel.name_input.setText("2013-02-25_Rechnung_Notar_Eisenburger")
+    assert panel.preview_label.isHidden()
+    assert panel.warning_label.isHidden()
+    assert panel.get_new_name() == "2013-02-25_Rechnung_Notar_Eisenburger.pdf"
+
+
+def test_preview_hidden_when_empty(qtbot):
+    panel = _panel(qtbot)
+    panel.name_input.setText("abc")
+    panel.name_input.setText("")
+    assert panel.preview_label.isHidden()
+    assert panel.warning_label.isHidden()
+
+
+def test_preview_shown_when_characters_are_replaced(qtbot):
+    panel = _panel(qtbot)
+    panel.name_input.setText("Rechnung: Müller/2024")
+    assert not panel.preview_label.isHidden()
+    assert panel.preview_label.text() == "Rechnung_Mueller_2024.pdf"
+    assert "Wird ersetzt" in panel.warning_label.text()
+
+    # Zurueck auf einen sauberen Namen -> Zeile verschwindet wieder
+    panel.name_input.setText("Rechnung_Mueller_2024")
+    assert panel.preview_label.isHidden()
+
+
+def test_preview_shown_for_email(qtbot):
+    panel = _panel(qtbot)
+    panel.name_input.setText("Meldung kathrin.haerle@web.de")
+    assert not panel.preview_label.isHidden()
+    assert "Kathrin" in panel.preview_label.text()
+
+
+def test_move_only_toggle_is_gone(qtbot):
+    panel = _panel(qtbot)
+    assert not hasattr(panel, "move_only_toggle")
+    assert not hasattr(panel, "hint_label")


### PR DESCRIPTION
Closes #98, closes #101, closes #100, closes #92.

> Setzt auf #102 auf (Basis-Branch `feat/81-99-ki-marker-muster-vorschlaege`) – bitte zuerst #102 mergen; GitHub stellt die Basis dann automatisch auf `main` um.

## #98 – Daten sichern und wiederherstellen
- Neues Modul `src/utils/backup.py`: **Extras > Daten sichern (ZIP)…** packt `history.db` (Verlauf, Suchindex/RAG, Korrespondenten, Regeln), `pdf_cache.db` (KI-Cache), `config.json`, `llm_timing.json` und `model/` in ein ZIP mit `backup_info.json`. SQLite-Dateien werden über die Backup-API kopiert → konsistenter Schnappschuss auch bei laufender App. Thumbnails/Logs bleiben draußen.
- **Extras > Daten aus Sicherung wiederherstellen…** prüft das Archiv, fragt nach und entpackt nach `restore_pending/`; beim nächsten Start spielt `apply_pending_restore()` (in `main.py`, vor Config/DB) die Dateien ein und hebt die ersetzten unter `restore_previous/` auf. Die App beendet sich nach der Bestätigung.
- Hinweis im Dialog, dass die Einstellungen API-Schlüssel enthalten.

## #101 – „Neuer Dateiname“ nur einmal
- Die grüne Vorschau-Zeile erscheint nur noch, wenn der bereinigte Name vom Eingetippten abweicht (ersetzte Zeichen, E-Mail, ungültig). Im Normalfall eine Zeile weniger.

## #100 – „Nur verschieben“ entfernt
- Schalter + blaue Hinweiszeile unter den Metadaten sind weg; `_move_rename_and_learn` nimmt immer Name + Metadaten aus dem Panel. Reines Verschieben weiterhin per Drag & Drop / Kontextmenü.

## #92 – Auto-LLM entfernt
- Die Option hatte keinerlei Wirkung im Code (`auto_use` wurde nirgends gelesen). Checkbox und Hinweistext raus; der Config-Key bleibt unangetastet.

## Tests
- 19 neue Tests (Backup-Kern ohne Qt, Menü/Dialog-Flows im MainWindow, Vorschau-Sichtbarkeit); Suite: **803 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
