### PR TITLE
chore(release): v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-08-29
+
 ### Neu
 - **Muster-Vorschlaege im Detail-Panel** (#99): Unter der Vorschlagsliste
   gibt es eine Auswahl „Muster“. Der Dateiname nach dem Muster aus
@@ -20,7 +22,6 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   ein KI-Vorschlag vorliegt (Hintergrund-Abruf, Cache vom letzten Start oder
   manueller KI-Aufruf im Detail-Panel), wird ihre Kachel im Scan-Ordner gruen
   hinterlegt; der Tooltip nennt den Grund. Die Auswahl (blau) bleibt sichtbar.
-
 - **Daten sichern und wiederherstellen** (#98): *Extras > Daten sichern
   (ZIP)…* packt Datenbank (Verlauf, Suchindex/RAG, Korrespondenten, Regeln),
   KI-Cache, ML-Modell und Einstellungen in ein ZIP - SQLite-Dateien als

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdf-sortier-meister"
-version = "0.21.0"
+version = "0.22.0"
 description = "Ein intelligentes Programm zum Sortieren und Umbenennen von gescannten PDF-Dokumenten"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,7 @@ from src.utils.single_instance import (
 from src.utils.explorer_integration import update_launcher_script
 
 # Versionsnummer zentral definiert
-__version__ = "0.21.0"
+__version__ = "0.22.0"
 
 
 def _apply_wizard_result(window, config):

--- a/tests/test_auto_next_after_move_gui.py
+++ b/tests/test_auto_next_after_move_gui.py
@@ -59,6 +59,12 @@ def main_window(qtbot, fresh_singletons, monkeypatch):
     monkeypatch.setattr(mw_mod.QMainWindow, "showMaximized", lambda self: None)
     monkeypatch.setattr(mw_mod.QMainWindow, "show", lambda self: None)
 
+    # Keine Thumbnail-Threads: die halten die PDF unter Windows kurz offen,
+    # und ein Verschieben waehrenddessen scheitert (PermissionError) - auf
+    # langsamen CI-Runnern schlug so der erste Test der Sitzung fehl.
+    from src.gui import pdf_thumbnail as th_mod
+    monkeypatch.setattr(th_mod.ThumbnailLoaderThread, "start", lambda self: None)
+
     # Modale Dialoge duerfen den Test nie blockieren: Verschieben immer
     # bestaetigen, Fehler-/Warn-Dialoge nur protokollieren.
     monkeypatch.setattr(


### PR DESCRIPTION
Versionsbump auf 0.22.0, CHANGELOG-Abschnitt, Fix für den flakigen Windows-CI-Test (`test_auto_next_after_move_gui`: Thumbnail-Threads hielten die PDF beim Verschieben offen).

Enthält #102 (#81, #99) und #103 (#92, #98, #100, #101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)