### PR TITLE
fix(move): Wiederholung bei Windows-Dateisperre + deterministischer Auto-Next-Test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Behoben
+- Verschieben schlug unter Windows mit „Die Datei wird von einem anderen
+  Prozess verwendet“ fehl, wenn direkt nach dem Anklicken verschoben wurde
+  (Vorschau-/Metadaten-Leser hatten die PDF noch offen). `move_file`
+  wiederholt den Vorgang jetzt bei kurzzeitigen Sperren einige Male
+  (Virenscanner, OneDrive), bevor es einen Fehler meldet.
+
 ## [0.22.0] - 2026-08-29
 
 ### Neu

--- a/src/core/file_manager.py
+++ b/src/core/file_manager.py
@@ -9,6 +9,7 @@ Funktionen:
 
 import os
 import shutil
+import time
 from pathlib import Path
 from typing import Optional, Generator
 from datetime import datetime
@@ -122,9 +123,25 @@ class FileManager:
         target_path = self._get_unique_path(target_path)
 
         # Datei verschieben
-        shutil.move(str(source), str(target_path))
+        self._move_with_retry(source, target_path)
 
         return target_path
+
+    # Kurzzeitige Sperren (Vorschau-/Metadaten-Reader, Virenscanner, OneDrive)
+    # loesen sich meist binnen Millisekunden - deshalb mehrere Versuche, bevor
+    # "Verschieben fehlgeschlagen" gemeldet wird.
+    MOVE_RETRY_DELAYS = (0.1, 0.2, 0.3, 0.5, 0.8)
+
+    @classmethod
+    def _move_with_retry(cls, source: Path, target_path: Path) -> None:
+        """``shutil.move`` mit Wiederholung bei ``PermissionError`` (Windows-Dateisperre)."""
+        for delay in cls.MOVE_RETRY_DELAYS:
+            try:
+                shutil.move(str(source), str(target_path))
+                return
+            except PermissionError:
+                time.sleep(delay)
+        shutil.move(str(source), str(target_path))
 
     def copy_file(
         self,

--- a/tests/test_auto_next_after_move_gui.py
+++ b/tests/test_auto_next_after_move_gui.py
@@ -71,7 +71,11 @@ def main_window(qtbot, fresh_singletons, monkeypatch):
         mw_mod.QMessageBox, "question",
         lambda *a, **k: QMessageBox.StandardButton.Yes,
     )
-    monkeypatch.setattr(mw_mod.QMessageBox, "critical", lambda *a, **k: None)
+    # Fehlerdialoge sind Testfehler: Meldung sichtbar machen statt schlucken
+    # (sonst sieht man in CI nur "3 == 2" statt des eigentlichen Grunds).
+    def _critical(*a, **k):
+        raise AssertionError(f"QMessageBox.critical: {a[1]!s}: {a[2]!s}")
+    monkeypatch.setattr(mw_mod.QMessageBox, "critical", _critical)
     monkeypatch.setattr(mw_mod.QMessageBox, "warning", lambda *a, **k: None)
 
     win = mw_mod.MainWindow()

--- a/tests/test_auto_next_after_move_gui.py
+++ b/tests/test_auto_next_after_move_gui.py
@@ -59,11 +59,15 @@ def main_window(qtbot, fresh_singletons, monkeypatch):
     monkeypatch.setattr(mw_mod.QMainWindow, "showMaximized", lambda self: None)
     monkeypatch.setattr(mw_mod.QMainWindow, "show", lambda self: None)
 
-    # Keine Thumbnail-Threads: die halten die PDF unter Windows kurz offen,
-    # und ein Verschieben waehrenddessen scheitert (PermissionError) - auf
-    # langsamen CI-Runnern schlug so der erste Test der Sitzung fehl.
+    # Keine Hintergrund-Leser: Thumbnail-, Vorschau- und XMP-Reader-Threads
+    # halten die PDF unter Windows kurz offen, und ein Verschieben
+    # waehrenddessen scheitert mit WinError 32 - auf langsamen CI-Runnern
+    # schlug so der erste Test der Sitzung fehl.
     from src.gui import pdf_thumbnail as th_mod
+    from src.gui import detail_panel as dp_mod
     monkeypatch.setattr(th_mod.ThumbnailLoaderThread, "start", lambda self: None)
+    monkeypatch.setattr(dp_mod.PdfPreviewWidget, "load_pdf", lambda self, path: None)
+    monkeypatch.setattr(dp_mod._PdfMetadataReader, "start", lambda self: None)
 
     # Modale Dialoge duerfen den Test nie blockieren: Verschieben immer
     # bestaetigen, Fehler-/Warn-Dialoge nur protokollieren.

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -62,3 +62,54 @@ def test_split_pdf_invalid_page_raises(tmp_path: Path) -> None:
     manager = FileManager()
     with pytest.raises(ValueError, match="Ungültige Seitenzahlen"):
         manager.split_pdf(source, output_folder, pages=[1, 5])
+
+
+# --------------------------------------------------------------------- #
+# Windows-Dateisperre beim Verschieben: kurz warten und erneut versuchen
+# --------------------------------------------------------------------- #
+
+
+def test_move_file_retries_on_transient_permission_error(tmp_path, monkeypatch):
+    import shutil
+    from src.core import file_manager as fm_mod
+
+    src = tmp_path / "a.pdf"
+    src.write_bytes(b"%PDF-1.4")
+    target = tmp_path / "Ziel"
+    target.mkdir()
+
+    real_move = shutil.move
+    calls = []
+
+    def flaky_move(s, d):
+        calls.append(d)
+        if len(calls) < 3:
+            raise PermissionError(32, "being used by another process")
+        return real_move(s, d)
+
+    monkeypatch.setattr(fm_mod.shutil, "move", flaky_move)
+    monkeypatch.setattr(fm_mod.time, "sleep", lambda s: None)
+
+    result = FileManager._move_with_retry(src, target / "a.pdf")
+    assert result is None
+    assert len(calls) == 3
+    assert (target / "a.pdf").exists() and not src.exists()
+
+
+def test_move_file_gives_up_after_retries(tmp_path, monkeypatch):
+    from src.core import file_manager as fm_mod
+
+    src = tmp_path / "a.pdf"
+    src.write_bytes(b"%PDF-1.4")
+    calls = []
+
+    def locked_move(s, d):
+        calls.append(d)
+        raise PermissionError(32, "being used by another process")
+
+    monkeypatch.setattr(fm_mod.shutil, "move", locked_move)
+    monkeypatch.setattr(fm_mod.time, "sleep", lambda s: None)
+
+    with pytest.raises(PermissionError):
+        FileManager._move_with_retry(src, tmp_path / "b.pdf")
+    assert len(calls) == len(FileManager.MOVE_RETRY_DELAYS) + 1


### PR DESCRIPTION
Behebt den seit 2026-08-29 09:47 auf Windows-CI fehlschlagenden Test `test_move_selects_next_pdf_in_same_grid_slot` (lokal immer grün).

**Ursache** (per Diagnose-Lauf sichtbar gemacht): `[WinError 32] The process cannot access the file because it is being used by another process` – nach dem Klick lesen Vorschau- (`PdfPreviewWidget`) und XMP-Reader-Threads (`_PdfMetadataReader`) die PDF noch, das sofortige Verschieben scheitert auf langsamen Runnern.

**Fix**
- `FileManager._move_with_retry`: bei `PermissionError` bis zu 5 Wiederholungen (0.1–0.8 s) – hilft auch echten Nutzern bei Virenscanner/OneDrive-Sperren.
- Test-Fixture startet Thumbnail-/Vorschau-/XMP-Reader-Threads nicht; `QMessageBox.critical` wirft statt zu schlucken, damit künftige Fehler sichtbar sind.
- 2 neue Tests für den Retry; Suite: **805 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)