### PR TITLE
feat(detail): Einheitliche Vorschlagsliste mit gemerkter Rangfolge (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,21 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   danach in der Vorlagen-Liste und als eigene Muster-Zeile bei den
   Vorschlaegen im Detail-Panel; „Loeschen“ entfernt es wieder
   (Config-Schluessel `custom_patterns`).
+- **Text aus der Vorschau in die Metadaten** (#109): In der PDF-Vorschau
+  laesst sich Text mit der Maus markieren; Rechtsklick bietet „Als
+  Korrespondent / Kategorie / Zusammenfassung uebernehmen“ und „Kopieren“.
+  Ein so uebernommener Korrespondent wird in die Korrespondenten-Verwaltung
+  aufgenommen und bei spaeteren Dokumenten, in deren Text er vorkommt,
+  automatisch gesetzt - die eigene Schreibweise schlaegt den KI-Vorschlag.
+- **Kategorie als Auswahlfeld** (#110): Das Feld „Kategorie“ ist jetzt eine
+  editierbare Aufklappliste mit den 10 haeufigsten Kategorien der eigenen
+  Sammlung (aufgefuellt mit Standardwerten).
 
 ### Behoben
+- Bei eingeschaltetem „Ordnerstruktur im Namen“ (#42) landete der Name
+  samt Ordner-Praefix in der Historie und damit als Beispiel im KI-Prompt -
+  die KI haette Ordnernummern erfinden koennen. Gespeichert wird jetzt der
+  vom Nutzer gewaehlte Name ohne Praefix.
 - Einstellungen > Dateinamen: „Alle Platzhalter“ lag ueber dem letzten Chip
   „{betrag}“ und war unlesbar.
 - Verschieben schlug unter Windows mit „Die Datei wird von einem anderen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,21 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   Schalter „Ordnerstruktur im Namen“ (dieselbe Einstellung wie *Beim
   Verschieben* im Einstellungsdialog, wirkt sofort) und „Muster bearbeiten…“,
   das die Einstellungen direkt auf dem Tab *Dateinamen* oeffnet.
+- **Muster ohne Tastatur zusammenklicken** (Einstellungen > Dateinamen):
+  Unter den Platzhalter-Chips gibt es jetzt „Leerzeichen“, „_“ und „-“ sowie
+  „Zuruecknehmen“, das den letzten Baustein vor dem Cursor entfernt (ganzer
+  Platzhalter samt Trennzeichen, oder ein einzelnes Zeichen). Ein Chip-Klick
+  setzt automatisch „_“ zwischen zwei Platzhalter; wer vorher „-“ oder
+  Leerzeichen klickt, bekommt stattdessen dieses.
+- **Eigene Muster speichern** (Einstellungen > Dateinamen): „Muster
+  speichern…“ legt das Muster im Feld unter einem Namen ab. Es erscheint
+  danach in der Vorlagen-Liste und als eigene Muster-Zeile bei den
+  Vorschlaegen im Detail-Panel; „Loeschen“ entfernt es wieder
+  (Config-Schluessel `custom_patterns`).
 
 ### Behoben
+- Einstellungen > Dateinamen: „Alle Platzhalter“ lag ueber dem letzten Chip
+  „{betrag}“ und war unlesbar.
 - Verschieben schlug unter Windows mit „Die Datei wird von einem anderen
   Prozess verwendet“ fehl, wenn direkt nach dem Anklicken verschoben wurde
   (Vorschau-/Metadaten-Leser hatten die PDF noch offen). `move_file`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   (Config-Schluessel `suggestion_kind_order`). Muster-Zeilen erscheinen nur,
   wenn mindestens zwei Platzhalter einen Wert haben; „Nur Datum“ wird nicht
   mehr angeboten.
+- **„Gelernt“-Vorschlaege werden zu KI-Beispielen:** Die alten „Gelernt:
+  aehnlich zu …“-Zeilen (irgendein frueherer Dateiname mit einem gemeinsamen
+  Stichwort) sind aus dem Detail-Panel verschwunden. Stattdessen bekommt die
+  KI die Dateinamen, die man fuer wirklich aehnliche Dokumente gewaehlt hat
+  (Firma/Person aus dem Namen kommt im Text vor oder mindestens zwei
+  Stichwoerter stimmen ueberein), als Stil-Beispiele in den Prompt. Was man
+  waehlt oder korrigiert, praegt so den naechsten Vorschlag.
 
 ### Behoben
 - Verschieben schlug unter Windows mit „Die Datei wird von einem anderen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   editierbare Aufklappliste mit den 10 haeufigsten Kategorien der eigenen
   Sammlung (aufgefuellt mit Standardwerten).
 
+- **Metadaten: neu vs. aus dem PDF:** Hatte die PDF bereits Metadaten,
+  werden Felder, deren Wert nicht (so) im PDF steht, pastellgruen
+  hervorgehoben (wie Kacheln mit KI-Vorschlag) - bis zum Speichern. Der
+  Status lautet dann „Quelle: aus PDF gelesen - gruen = neue Vorschlaege“
+  statt des vagen „teils aus PDF, teils Vorschlag“.
+
 ### Behoben
 - Bei eingeschaltetem „Ordnerstruktur im Namen“ (#42) landete der Name
   samt Ordner-Praefix in der Historie und damit als Beispiel im KI-Prompt -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Geaendert
+- **Einheitliche Vorschlagsliste im Detail-Panel** (#106): Die Auswahl
+  „Muster“ unter der Liste ist weg. Stattdessen stehen alle Vorschlaege in
+  einer Liste: KI-Vorschlag, je Vorlage ein Muster-Vorschlag (Rechnungen &
+  Belege, Akten & Projekte, Buero-Kuerzel, eigenes Muster aus den
+  Einstellungen) sowie „Automatisch erkannt“, „Datum + Kategorie“ und
+  „Kategorie + Nummer“. Wer einen Vorschlag anklickt, macht dessen Art zum
+  Standard: Beim naechsten Dokument steht sie ganz oben und wird als
+  Dateiname uebernommen, die uebrigen ruecken eine Stufe nach unten
+  (Config-Schluessel `suggestion_kind_order`). Muster-Zeilen erscheinen nur,
+  wenn mindestens zwei Platzhalter einen Wert haben; „Nur Datum“ wird nicht
+  mehr angeboten.
+
 ### Behoben
 - Verschieben schlug unter Windows mit „Die Datei wird von einem anderen
   Prozess verwendet“ fehl, wenn direkt nach dem Anklicken verschoben wurde

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,10 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   Vorschlaegen im Detail-Panel; „Loeschen“ entfernt es wieder
   (Config-Schluessel `custom_patterns`).
 - **Text aus der Vorschau in die Metadaten** (#109): In der PDF-Vorschau
-  laesst sich Text mit der Maus markieren; Rechtsklick bietet „Als
-  Korrespondent / Kategorie / Zusammenfassung uebernehmen“ und „Kopieren“.
+  laesst sich Text mit der Maus markieren; Rechtsklick bietet „Als … uebernehmen“
+  fuer jedes Metadaten-Feld (Korrespondent, Kategorie, Zusammenfassung,
+  Betrag Netto/Brutto, Waehrung, MwSt-Satz, IBAN, Steuerjahr) sowie
+  „Kopieren“; IBAN, Betraege, MwSt und Steuerjahr werden dabei bereinigt.
   Ein so uebernommener Korrespondent wird in die Korrespondenten-Verwaltung
   aufgenommen und bei spaeteren Dokumenten, in deren Text er vorkommt,
   automatisch gesetzt - die eigene Schreibweise schlaegt den KI-Vorschlag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   fuer jedes Metadaten-Feld (Korrespondent, Kategorie, Zusammenfassung,
   Betrag Netto/Brutto, Waehrung, MwSt-Satz, IBAN, Steuerjahr) sowie
   „Kopieren“; IBAN, Betraege, MwSt und Steuerjahr werden dabei bereinigt.
+  Funktioniert auch im grossen Vorschau-Fenster („Gross“).
   Ein so uebernommener Korrespondent wird in die Korrespondenten-Verwaltung
   aufgenommen und bei spaeteren Dokumenten, in deren Text er vorkommt,
   automatisch gesetzt - die eigene Schreibweise schlaegt den KI-Vorschlag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   Schalter „Ordnerstruktur im Namen“ (dieselbe Einstellung wie *Beim
   Verschieben* im Einstellungsdialog, wirkt sofort) und „Muster bearbeiten…“,
   das die Einstellungen direkt auf dem Tab *Dateinamen* oeffnet.
+- **Neues Muster wirkt sofort:** Wird in *Einstellungen > Dateinamen* ein
+  anderes Muster gespeichert, steht es im Detail-Panel sofort ganz oben in
+  den Vorschlaegen und wird als neuer Dateiname uebernommen.
 - **Muster ohne Tastatur zusammenklicken** (Einstellungen > Dateinamen):
   Unter den Platzhalter-Chips gibt es jetzt „Leerzeichen“, „_“ und „-“ sowie
   „Zuruecknehmen“, das den letzten Baustein vor dem Cursor entfernt (ganzer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   (Firma/Person aus dem Namen kommt im Text vor oder mindestens zwei
   Stichwoerter stimmen ueberein), als Stil-Beispiele in den Prompt. Was man
   waehlt oder korrigiert, praegt so den naechsten Vorschlag.
+- **Kopfzeile ueber den Vorschlaegen:** Rechts neben dem Titel gibt es den
+  Schalter „Ordnerstruktur im Namen“ (dieselbe Einstellung wie *Beim
+  Verschieben* im Einstellungsdialog, wirkt sofort) und „Muster bearbeiten…“,
+  das die Einstellungen direkt auf dem Tab *Dateinamen* oeffnet.
 
 ### Behoben
 - Verschieben schlug unter Windows mit „Die Datei wird von einem anderen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,9 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   aufgenommen und bei spaeteren Dokumenten, in deren Text er vorkommt,
   automatisch gesetzt - die eigene Schreibweise schlaegt den KI-Vorschlag.
 - **Kategorie als Auswahlfeld** (#110): Das Feld „Kategorie“ ist jetzt eine
-  editierbare Aufklappliste mit den 10 haeufigsten Kategorien der eigenen
-  Sammlung (aufgefuellt mit Standardwerten).
+  editierbare Aufklappliste: zuerst die zuletzt selbst verwendeten
+  Kategorien (gemerkt bei jedem Speichern/Verschieben), dann haeufige aus
+  der Sammlung (ohne Bandwurm-Eintraege), aufgefuellt mit Standardwerten.
 
 - **Metadaten: neu vs. aus dem PDF:** Hatte die PDF bereits Metadaten,
   werden Felder, deren Wert nicht (so) im PDF steht, pastellgruen

--- a/src/core/filename_placeholders.py
+++ b/src/core/filename_placeholders.py
@@ -172,7 +172,9 @@ def _with_derived_dates(values: dict[str, str]) -> dict[str, str]:
     return merged
 
 
-def render_with_values(pattern: str, values: dict[str, str] | None) -> str:
+def render_with_values(
+    pattern: str, values: dict[str, str] | None, min_values: int = 1
+) -> str:
     """Rendert das Muster nur mit *echten* Werten - fuer Vorschlaege zu einem
     konkreten Dokument (Issue #99).
 
@@ -180,7 +182,8 @@ def render_with_values(pattern: str, values: dict[str, str] | None) -> str:
     Platzhalter ohne Wert fallen samt dem angrenzenden Trennzeichen weg
     (``{datum}_{kontakt}_{betreff}`` ohne Betreff -> ``2024-03-12_Firma``),
     genau wie es der KI-Prompt verlangt. Ergibt sich kein einziger echter
-    Wert, kommt ``""`` zurueck (= kein Vorschlag).
+    Wert (bzw. weniger als ``min_values``), kommt ``""`` zurueck
+    (= kein Vorschlag).
     """
     from src.utils.filename_sanitizer import sanitize_filename
 
@@ -216,7 +219,7 @@ def render_with_values(pattern: str, values: dict[str, str] | None) -> str:
         if part:
             out.append(part)
 
-    if not filled:
+    if not filled or filled < min_values:
         return ""
     return sanitize_filename("".join(out))
 

--- a/src/core/filename_placeholders.py
+++ b/src/core/filename_placeholders.py
@@ -80,6 +80,36 @@ PRESETS: list[tuple[str, str | None]] = [
 
 _PLACEHOLDER_RE = re.compile(r"\{([^{}]+)\}")
 
+# Vom Nutzer gespeicherte Muster (Einstellungen > Dateinamen > "Muster
+# speichern"): Config-Liste von {"name": ..., "pattern": ...}
+CUSTOM_PATTERNS_KEY = "custom_patterns"
+
+
+def load_custom_patterns(raw) -> list[tuple[str, str]]:
+    """Gespeicherte Muster aus der Config als ``(Name, Muster)``, bereinigt."""
+    result: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for item in raw or []:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        pattern = str(item.get("pattern") or "").strip()
+        if not name or not pattern or name.lower() in seen:
+            continue
+        seen.add(name.lower())
+        result.append((name, pattern))
+    return result
+
+
+def builtin_pattern_names() -> set[str]:
+    return {name for name, _p in PRESETS}
+
+
+def all_presets(custom_patterns=None) -> list[tuple[str, str | None]]:
+    """Vorlagen fuer die Combo: eingebaute, dann gespeicherte, zuletzt "Eigenes"."""
+    builtin = [(n, p) for n, p in PRESETS if p is not None]
+    return builtin + list(custom_patterns or []) + [(PRESET_CUSTOM, None)]
+
 # Alte Presets (bis 0.21) und Grosswort-Schreibweise -> neue Syntax
 _LEGACY_PRESETS = {
     "YYYY-MM-DD_Rechnung_Kontakt_Betreff": "{datum}_{kategorie}_{kontakt}_{betreff}",
@@ -274,13 +304,13 @@ def placeholder_values_from_metadata(
 PATTERN_CHOICE_SETTINGS = "Eigenes Muster (aus Einstellungen)"
 
 
-def pattern_choices(config_pattern: str) -> list[tuple[str, str]]:
-    """Auswahlliste fuer die Muster-Umschaltung im Detail-Panel (Issue #99).
+def pattern_choices(config_pattern: str, custom_patterns=None) -> list[tuple[str, str]]:
+    """Muster-Vorschlaege im Detail-Panel (Issues #99/#106).
 
     Liefert ``(Bezeichnung, Muster)``: zuerst „Standard“ (Muster ``""`` =
-    kein Muster-Vorschlag), dann die Vorlagen; ein eigenes Muster aus den
-    Einstellungen, das keiner Vorlage entspricht, steht als eigener Eintrag
-    direkt hinter „Standard“.
+    kein Muster-Vorschlag), dann die eingebauten Vorlagen, dann die vom
+    Nutzer gespeicherten Muster; ein Muster aus den Einstellungen, das keinem
+    davon entspricht, steht als eigener Eintrag direkt hinter „Standard“.
     """
     config_pattern = migrate_legacy_pattern(config_pattern or "")
     choices: list[tuple[str, str]] = []
@@ -288,6 +318,9 @@ def pattern_choices(config_pattern: str) -> list[tuple[str, str]]:
         if pattern is None:
             continue
         choices.append((name, pattern))
+    for name, pattern in custom_patterns or []:
+        if pattern and all(p != pattern for _n, p in choices):
+            choices.append((name, pattern))
     if config_pattern and all(p != config_pattern for _n, p in choices):
         choices.insert(1, (PATTERN_CHOICE_SETTINGS, config_pattern))
     return choices

--- a/src/core/korrespondent_match.py
+++ b/src/core/korrespondent_match.py
@@ -1,0 +1,53 @@
+"""Bekannte Korrespondenten im Dokumenttext wiederfinden (Issue #109).
+
+Uebernimmt der Nutzer einen Namen aus der Vorschau als Korrespondent, wird
+er in der Korrespondenten-Verwaltung angelegt. Bei spaeteren Dokumenten, in
+deren Text dieser Name (oder ein Alias) vorkommt, wird er automatisch
+vorgeschlagen - die eigene Schreibweise des Nutzers schlaegt dabei den
+KI-Vorschlag.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable, Mapping
+
+MIN_NAME_LENGTH = 3
+
+
+def _candidates(entry: Mapping) -> list[str]:
+    names = [str(entry.get("name") or "")]
+    aliases = entry.get("aliases") or []
+    if isinstance(aliases, str):
+        aliases = [aliases]
+    names.extend(str(a) for a in aliases)
+    return [n.strip() for n in names if n and len(n.strip()) >= MIN_NAME_LENGTH]
+
+
+def _occurs(name: str, text_lower: str) -> bool:
+    """Name als ganzes Wort/Phrase im Text (Gross-/Kleinschreibung egal)."""
+    pattern = r"(?<![\w-])" + re.escape(name.lower()) + r"(?![\w-])"
+    return re.search(pattern, text_lower) is not None
+
+
+def find_known_korrespondent(text: str, entries: Iterable[Mapping]) -> str | None:
+    """Anzeigename des bekannten Korrespondenten, der im Text vorkommt.
+
+    Bei mehreren Treffern gewinnt der laengste passende Name/Alias (der
+    spezifischere), bei Gleichstand der zuerst gelistete Eintrag (die Liste
+    kommt nach Haeufigkeit sortiert aus der Datenbank).
+    """
+    text_lower = (text or "").lower()
+    if not text_lower.strip():
+        return None
+    best: tuple[int, int, str] | None = None
+    for idx, entry in enumerate(entries):
+        display = str(entry.get("name") or "").strip()
+        if not display:
+            continue
+        for candidate in _candidates(entry):
+            if _occurs(candidate, text_lower):
+                key = (-len(candidate), idx, display)
+                if best is None or key < best:
+                    best = key
+                break
+    return best[2] if best else None

--- a/src/core/metadata_choices.py
+++ b/src/core/metadata_choices.py
@@ -1,6 +1,7 @@
 """Auswahllisten fuer Metadaten-Felder im Detail-Panel (Issue #110)."""
 from __future__ import annotations
 
+import re
 from typing import Iterable
 
 # Kategorien aus dem KI-Antwortschema - Rueckfall, solange die eigene
@@ -28,3 +29,30 @@ def category_choices(top_from_db: Iterable[str], limit: int = 10) -> list[str]:
         if len(result) >= limit:
             break
     return result
+
+
+_YEAR_RE = re.compile(r"(?<!\d)(19|20)\d{2}(?!\d)")
+_CURRENCY_RE = re.compile(r"(?i)\s*(€|eur|euro|\$|usd|chf)\s*")
+
+
+def normalize_for_field(field_key: str, text: str) -> str:
+    """Markierten Text fuer ein Metadaten-Feld aufbereiten (Issue #109).
+
+    Leerraum wird immer zusammengefasst; je nach Feld faellt Beiwerk weg:
+    IBAN ohne Leerzeichen, Betraege ohne Waehrungszeichen, MwSt ohne "%",
+    Steuerjahr als vierstellige Jahreszahl.
+    """
+    text = " ".join((text or "").split())
+    if field_key == "iban":
+        return text.replace(" ", "").upper()
+    if field_key in ("betrag_netto", "betrag_brutto"):
+        return _CURRENCY_RE.sub(" ", text).strip(" :")
+    if field_key == "mwst_satz":
+        return text.replace("%", "").strip(" :")
+    if field_key == "steuerjahr":
+        match = _YEAR_RE.search(text)
+        return match.group(0) if match else text
+    if field_key == "waehrung":
+        return text.upper().replace("€", "EUR")
+    return text
+

--- a/src/core/metadata_choices.py
+++ b/src/core/metadata_choices.py
@@ -1,0 +1,30 @@
+"""Auswahllisten fuer Metadaten-Felder im Detail-Panel (Issue #110)."""
+from __future__ import annotations
+
+from typing import Iterable
+
+# Kategorien aus dem KI-Antwortschema - Rueckfall, solange die eigene
+# Sammlung noch keine 10 verschiedenen Kategorien hergibt
+DEFAULT_CATEGORIES: tuple[str, ...] = (
+    "Rechnung", "Vertrag", "Steuer", "Versicherung", "Bank",
+    "Gehalt", "Arzt", "Energie", "Sonstiges",
+)
+
+
+def category_choices(top_from_db: Iterable[str], limit: int = 10) -> list[str]:
+    """Die haeufigsten Kategorien der Sammlung, mit Standardwerten aufgefuellt.
+
+    Reihenfolge: erst die eigenen (nach Haeufigkeit), dann Standardwerte;
+    Doppelte (Gross-/Kleinschreibung egal) erscheinen einmal.
+    """
+    result: list[str] = []
+    seen: set[str] = set()
+    for name in list(top_from_db) + list(DEFAULT_CATEGORIES):
+        name = (name or "").strip()
+        if not name or name.lower() in seen:
+            continue
+        seen.add(name.lower())
+        result.append(name)
+        if len(result) >= limit:
+            break
+    return result

--- a/src/core/metadata_choices.py
+++ b/src/core/metadata_choices.py
@@ -12,15 +12,46 @@ DEFAULT_CATEGORIES: tuple[str, ...] = (
 )
 
 
-def category_choices(top_from_db: Iterable[str], limit: int = 10) -> list[str]:
-    """Die haeufigsten Kategorien der Sammlung, mit Standardwerten aufgefuellt.
+RECENT_CATEGORIES_KEY = "recent_categories"
+RECENT_CATEGORIES_MAX = 15
+# Aus dem Suchindex nur "echte" Kategorien: alte KI-Ausrutscher wie
+# "Nebenkosten Schmutzwassergebuehr" sind lang und mehrwortig
+MAX_INDEX_CATEGORY_LEN = 20
+MAX_INDEX_CATEGORY_WORDS = 2
 
-    Reihenfolge: erst die eigenen (nach Haeufigkeit), dann Standardwerte;
-    Doppelte (Gross-/Kleinschreibung egal) erscheinen einmal.
+
+def remember_category(recent: Iterable[str] | None, category: str) -> list[str]:
+    """Kategorie nach vorn in die Zuletzt-verwendet-Liste (max. RECENT_CATEGORIES_MAX)."""
+    category = (category or "").strip()
+    result = [c for c in (recent or []) if isinstance(c, str) and c.strip()]
+    if not category:
+        return result
+    result = [c for c in result if c.strip().lower() != category.lower()]
+    return ([category] + result)[:RECENT_CATEGORIES_MAX]
+
+
+def _looks_like_category(name: str) -> bool:
+    return len(name) <= MAX_INDEX_CATEGORY_LEN and len(name.split()) <= MAX_INDEX_CATEGORY_WORDS
+
+
+def category_choices(
+    recent: Iterable[str] | None,
+    top_from_db: Iterable[str] | None = None,
+    limit: int = 10,
+) -> list[str]:
+    """Aufklappliste der Kategorie (Issue #110).
+
+    Reihenfolge: zuletzt vom Nutzer verwendete Kategorien (neueste zuerst),
+    dann die haeufigsten aus dem Suchindex (nur kurze, kategorie-artige
+    Namen), dann Standardwerte. Doppelte (Gross-/Kleinschreibung egal)
+    erscheinen einmal.
     """
+    candidates = list(recent or [])
+    candidates += [n for n in (top_from_db or []) if n and _looks_like_category(n.strip())]
+    candidates += list(DEFAULT_CATEGORIES)
     result: list[str] = []
     seen: set[str] = set()
-    for name in list(top_from_db) + list(DEFAULT_CATEGORIES):
+    for name in candidates:
         name = (name or "").strip()
         if not name or name.lower() in seen:
             continue

--- a/src/core/rename_examples.py
+++ b/src/core/rename_examples.py
@@ -1,0 +1,110 @@
+"""Beispiele aus der Umbenennungs-Historie fuer den KI-Prompt.
+
+Frueher wurden alte Dateinamen als eigene „Gelernt“-Vorschlaege gezeigt -
+ein fremder Dateiname ist fuer das aktuelle Dokument aber nie der richtige.
+Stattdessen bekommt die KI die Namen, die der Nutzer fuer *wirklich
+aehnliche* Dokumente gewaehlt hat, als Stil-Beispiele in den Prompt. Was der
+Nutzer waehlt oder korrigiert, landet wieder in der Historie und praegt den
+naechsten Vorschlag - das Lernen wird so iterativ.
+
+Aehnlich heisst hier: Namensbestandteile des alten Dateinamens (Firma,
+Person, Betreff) kommen im Text des neuen Dokuments vor, oder mindestens
+zwei Stichwoerter stimmen ueberein. Ein einzelnes gemeinsames Wort wie
+„rechnung“ reicht nicht.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable, Protocol, Sequence, TypeVar
+
+_TOKEN_RE = re.compile(r"[A-Za-zÄÖÜäöüß]{4,}")
+
+# Woerter, die in fast jedem Dateinamen stehen und nichts ueber Aehnlichkeit sagen
+_GENERIC_TOKENS = frozenset({
+    "rechnung", "rechnungen", "beleg", "belege", "vertrag", "brief", "schreiben",
+    "dokument", "scan", "sonstiges", "mail", "email", "korrespondenz", "unbekannt",
+    "datum", "info", "information", "kopie", "seite", "seiten", "sehr", "geehrte",
+    "ueber", "uebermittlung", "zur", "und", "der", "die", "das", "fuer", "vom",
+    # Kategorien aus dem KI-Schema - stehen in vielen Namen, identifizieren nichts
+    "bank", "steuer", "versicherung", "gehalt", "arzt", "energie", "vertraege",
+})
+
+# Punkte je Treffer: Namensbestandteil im Text wiegt doppelt so viel wie ein
+# gemeinsames Stichwort; ab MIN_SCORE gilt ein Eintrag als aehnlich
+NAME_HIT_WEIGHT = 2
+KEYWORD_HIT_WEIGHT = 1
+MIN_SCORE = 2
+MAX_TEXT_CHARS = 20000
+
+
+class HistoryEntry(Protocol):
+    new_filename: str
+    keywords: str | list[str] | None
+
+
+T = TypeVar("T", bound=HistoryEntry)
+
+
+def name_tokens(filename: str) -> set[str]:
+    """Aussagekraeftige Woerter eines Dateinamens (ohne Datum, Kuerzel, Fuellwoerter)."""
+    stem = re.sub(r"\.pdf$", "", filename or "", flags=re.IGNORECASE)
+    tokens = {t.lower() for t in _TOKEN_RE.findall(stem)}
+    return {t for t in tokens if t not in _GENERIC_TOKENS}
+
+
+def _keyword_set(keywords: str | Iterable[str] | None) -> set[str]:
+    if not keywords:
+        return set()
+    if isinstance(keywords, str):
+        keywords = keywords.split(",")
+    return {k.strip().lower() for k in keywords if k and k.strip()}
+
+
+def score_example(entry_filename: str, entry_keywords, text: str, keywords) -> int:
+    """Wie gut passt ein Historien-Eintrag zum aktuellen Dokument? (0 = gar nicht)"""
+    # Ganze Woerter vergleichen: "bank" darf nicht in "Commerzbank" treffen
+    text_words = {w.lower() for w in _TOKEN_RE.findall((text or "")[:MAX_TEXT_CHARS])}
+    name_hits = len(name_tokens(entry_filename) & text_words)
+    keyword_hits = len(_keyword_set(entry_keywords) & _keyword_set(keywords))
+    return NAME_HIT_WEIGHT * name_hits + KEYWORD_HIT_WEIGHT * keyword_hits
+
+
+def rank_examples(entries: Sequence[T], text: str, keywords, limit: int = 5) -> list[T]:
+    """Die passendsten Eintraege, beste zuerst; bei Gleichstand bleibt die
+    Eingabe-Reihenfolge (= neueste zuerst) erhalten. Doppelte Dateinamen
+    erscheinen einmal."""
+    scored: list[tuple[int, int, T]] = []
+    for idx, entry in enumerate(entries):
+        score = score_example(entry.new_filename, entry.keywords, text, keywords)
+        if score >= MIN_SCORE:
+            scored.append((score, idx, entry))
+    scored.sort(key=lambda t: (-t[0], t[1]))
+
+    seen: set[str] = set()
+    result: list[T] = []
+    for _score, _idx, entry in scored:
+        key = (entry.new_filename or "").lower()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        result.append(entry)
+        if len(result) >= limit:
+            break
+    return result
+
+
+def describe_examples_for_prompt(filenames: Sequence[str]) -> str:
+    """Prompt-Abschnitt mit den Beispiel-Dateinamen; leer ohne Beispiele."""
+    names = [n for n in filenames if n]
+    if not names:
+        return ""
+    lines = [
+        "",
+        "SO HAT DER NUTZER ÄHNLICHE DOKUMENTE ZULETZT BENANNT:",
+    ]
+    lines.extend(f"- {n}" for n in names)
+    lines.append(
+        "Richte Aufbau, Reihenfolge, Abkürzungen und Schreibweisen von Namen daran aus. "
+        "Datum, Betreff und Inhalt kommen aber aus DIESEM Dokument - nicht abschreiben."
+    )
+    return "\n".join(lines)

--- a/src/core/suggestion_order.py
+++ b/src/core/suggestion_order.py
@@ -55,16 +55,17 @@ def kind_from_reason(reason: str) -> str:
     return KIND_OTHER
 
 
-def default_order(config_pattern: str = "") -> list[str]:
+def default_order(config_pattern: str = "", custom_patterns=None) -> list[str]:
     """Standard-Rangfolge, solange der Nutzer noch nichts gewaehlt hat.
 
-    KI zuerst, dann das Muster aus den Einstellungen, die uebrigen Vorlagen,
-    danach die einfachen Vorschlaege aus der Textanalyse.
+    KI zuerst, dann das Muster aus den Einstellungen, die uebrigen Vorlagen
+    (eingebaute, dann gespeicherte), danach die einfachen Vorschlaege aus
+    der Textanalyse.
     """
     order = [KIND_KI]
     # pattern_choices liefert das Einstellungs-Muster an zweiter Stelle,
     # wenn es keiner Vorlage entspricht - sonst steht es unter den Vorlagen
-    choices = [p for _label, p in pattern_choices(config_pattern) if p]
+    choices = [p for _label, p in pattern_choices(config_pattern, custom_patterns) if p]
     if config_pattern and config_pattern in choices:
         choices.remove(config_pattern)
         choices.insert(0, config_pattern)
@@ -74,10 +75,12 @@ def default_order(config_pattern: str = "") -> list[str]:
     return order
 
 
-def effective_order(saved: Iterable[str] | None, config_pattern: str = "") -> list[str]:
+def effective_order(
+    saved: Iterable[str] | None, config_pattern: str = "", custom_patterns=None
+) -> list[str]:
     """Gespeicherte Rangfolge, ergaenzt um alle Arten, die darin noch fehlen."""
     order: list[str] = []
-    for kind in list(saved or []) + default_order(config_pattern):
+    for kind in list(saved or []) + default_order(config_pattern, custom_patterns):
         if isinstance(kind, str) and kind and kind not in order:
             order.append(kind)
     return order

--- a/src/core/suggestion_order.py
+++ b/src/core/suggestion_order.py
@@ -1,0 +1,98 @@
+"""Rangfolge der Dateinamen-Vorschlaege im Detail-Panel (Issue #106).
+
+Jeder Vorschlag hat eine *Art* (``kind``): KI-Vorschlag, ein bestimmtes
+Dateinamen-Muster, „Automatisch erkannt“ usw. Die Liste im Detail-Panel ist
+nach Art sortiert; die zuletzt vom Nutzer angeklickte Art steht beim naechsten
+Dokument ganz oben und ist damit der Vorschlag, der ins Feld
+„Neuer Dateiname“ uebernommen wird. Die Rangfolge liegt in der Config unter
+``suggestion_kind_order`` (Liste von Art-Schluesseln, vorne = oben).
+"""
+from __future__ import annotations
+
+from typing import Iterable, Sequence, TypeVar
+
+from src.core.filename_placeholders import pattern_choices
+
+CONFIG_KEY = "suggestion_kind_order"
+
+KIND_KI = "ki"
+KIND_LEARNED = "learned"
+KIND_AUTO = "auto"
+KIND_DATE_CATEGORY = "date_category"
+KIND_CATEGORY_NUMBER = "category_number"
+KIND_DATE = "date"
+KIND_OTHER = "other"
+PATTERN_PREFIX = "pattern:"
+
+T = TypeVar("T")
+
+
+def pattern_kind(pattern: str) -> str:
+    """Art-Schluessel fuer ein Dateinamen-Muster (stabil ueber Sitzungen)."""
+    return PATTERN_PREFIX + (pattern or "")
+
+
+def kind_from_reason(reason: str) -> str:
+    """Leitet die Art eines Vorschlags aus seiner Begruendung ab.
+
+    Die Begruendungen werden an mehreren Stellen erzeugt (``rename_dialog``,
+    ``main_window``, Detail-Panel); hier ist die einzige Stelle, die sie
+    auf Arten abbildet.
+    """
+    reason = (reason or "").strip()
+    if reason.startswith("KI"):
+        return KIND_KI
+    if reason.startswith("Gelernt"):
+        return KIND_LEARNED
+    if reason == "Automatisch erkannt":
+        return KIND_AUTO
+    if reason.startswith("Datum + Kategorie"):
+        return KIND_DATE_CATEGORY
+    if reason == "Kategorie + Nummer":
+        return KIND_CATEGORY_NUMBER
+    if reason == "Nur Datum":
+        return KIND_DATE
+    return KIND_OTHER
+
+
+def default_order(config_pattern: str = "") -> list[str]:
+    """Standard-Rangfolge, solange der Nutzer noch nichts gewaehlt hat.
+
+    KI zuerst, dann das Muster aus den Einstellungen, die uebrigen Vorlagen,
+    danach die einfachen Vorschlaege aus der Textanalyse.
+    """
+    order = [KIND_KI]
+    # pattern_choices liefert das Einstellungs-Muster an zweiter Stelle,
+    # wenn es keiner Vorlage entspricht - sonst steht es unter den Vorlagen
+    choices = [p for _label, p in pattern_choices(config_pattern) if p]
+    if config_pattern and config_pattern in choices:
+        choices.remove(config_pattern)
+        choices.insert(0, config_pattern)
+    order.extend(pattern_kind(p) for p in choices)
+    order.extend([KIND_LEARNED, KIND_AUTO, KIND_DATE_CATEGORY,
+                  KIND_CATEGORY_NUMBER, KIND_DATE, KIND_OTHER])
+    return order
+
+
+def effective_order(saved: Iterable[str] | None, config_pattern: str = "") -> list[str]:
+    """Gespeicherte Rangfolge, ergaenzt um alle Arten, die darin noch fehlen."""
+    order: list[str] = []
+    for kind in list(saved or []) + default_order(config_pattern):
+        if isinstance(kind, str) and kind and kind not in order:
+            order.append(kind)
+    return order
+
+
+def promote(order: Sequence[str], kind: str) -> list[str]:
+    """Setzt ``kind`` an die Spitze; alle anderen ruecken eine Stufe nach unten."""
+    return [kind] + [k for k in order if k != kind]
+
+
+def sort_by_kind(items: Sequence[tuple[T, str]], order: Sequence[str]) -> list[tuple[T, str]]:
+    """Sortiert ``(objekt, art)``-Paare stabil nach der Rangfolge.
+
+    Unbekannte Arten landen hinten, in ihrer bisherigen Reihenfolge.
+    """
+    rank = {kind: idx for idx, kind in enumerate(order)}
+    unknown = len(rank)
+    return sorted(items, key=lambda pair: rank.get(pair[1], unknown))

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -178,6 +178,9 @@ class DetailPanel(QWidget):
         # _displayed_kinds haelt parallel dazu die Art jeder Zeile
         self._displayed_suggestions: list[RenameSuggestion] = []
         self._displayed_kinds: list[str] = []
+        # Zuletzt gesehenes Einstellungs-Muster: aendert es sich (Dialog
+        # gespeichert), wird das neue Muster sofort zum obersten Vorschlag
+        self._seen_config_pattern: Optional[str] = None
         self._detected_date: Optional[str] = None
         self._metadata: dict = {}
         self._has_learned_overrides: bool = False
@@ -1074,7 +1077,12 @@ class DetailPanel(QWidget):
     # -- Kopfzeile: Ordnerstruktur-Schalter --------------------------------- #
 
     def refresh_settings(self):
-        """Gleicht die Kopfzeile an die Config an (nach Einstellungs-Aenderung)."""
+        """Gleicht das Panel an die Config an (nach Einstellungs-Aenderung).
+
+        Kopfzeilen-Schalter nachziehen; wurde in den Einstellungen ein neues
+        Dateinamen-Muster gespeichert, rueckt es sofort an die Spitze der
+        Vorschlaege und wird als neuer Dateiname uebernommen.
+        """
         try:
             from src.utils.config import get_config
             enabled = bool(get_config().get("folder_naming_enabled", False))
@@ -1083,6 +1091,21 @@ class DetailPanel(QWidget):
         self.folder_naming_checkbox.blockSignals(True)
         self.folder_naming_checkbox.setChecked(enabled)
         self.folder_naming_checkbox.blockSignals(False)
+
+        pattern = self._config_pattern()
+        if self._seen_config_pattern is None:
+            self._seen_config_pattern = pattern  # erster Blick: nur merken
+            return
+        if pattern == self._seen_config_pattern:
+            return
+        self._seen_config_pattern = pattern
+        if not pattern:
+            return
+        from src.core.suggestion_order import pattern_kind
+        self._remember_kind(pattern_kind(pattern))
+        if self._current_pdf is not None:
+            self._populate_suggestions()
+            self._apply_top_suggestion()
 
     def _on_folder_naming_toggled(self, checked: bool):
         """Schalter in der Kopfzeile schreibt dieselbe Einstellung wie der Dialog."""

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -1011,6 +1011,10 @@ class DetailPanel(QWidget):
             return None
         return find_known_korrespondent(text, entries)
 
+    def apply_preview_text(self, field_key: str, text: str):
+        """Markierten Text (auch aus dem grossen Vorschau-Fenster) in ein Feld uebernehmen."""
+        self._on_preview_text_applied(field_key, text)
+
     def _on_preview_text_applied(self, field_key: str, text: str):
         """Markierter Text aus der Vorschau -> Metadaten-Feld; Korrespondent wird gelernt."""
         from src.core.metadata_choices import normalize_for_field

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -122,6 +122,8 @@ class DetailPanel(QWidget):
     open_pdf_requested = pyqtSignal(Path)            # Suchergebnis doppelgeklickt
     open_pdf_external_requested = pyqtSignal(Path)   # "Extern öffnen" in der Vorschau
     enlarge_preview_requested = pyqtSignal(Path)     # große Vorschau gewünscht
+    # "Muster bearbeiten" in der Vorschlags-Kopfzeile: Einstellungen > Dateinamen
+    edit_pattern_requested = pyqtSignal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -201,11 +203,40 @@ class DetailPanel(QWidget):
         self.header_label.setWordWrap(True)
         detail_layout.addWidget(self.header_label)
 
-        # Vorschläge
-        suggestions_group = QGroupBox("Vorschläge (zum Auswählen klicken)")
+        # Vorschläge - Kopfzeile mit Titel links, Schalter + Button rechts
+        suggestions_group = QGroupBox()
         suggestions_layout = QVBoxLayout(suggestions_group)
         suggestions_layout.setSpacing(2)
         suggestions_layout.setContentsMargins(6, 4, 6, 6)
+
+        head_row = QHBoxLayout()
+        head_row.setSpacing(6)
+        title = QLabel("<b>Vorschläge</b>")
+        title.setToolTip("Zum Auswählen anklicken - der Name wandert ins Feld „Neuer Dateiname“.")
+        head_row.addWidget(title)
+        head_row.addStretch(1)
+        # Schalter fuer "Dateiname aus Ordnerstruktur" (Issue #42) direkt am
+        # Ort des Geschehens - gleiche Einstellung wie im Einstellungsdialog
+        self.folder_naming_checkbox = QCheckBox("Ordnerstruktur im Namen")
+        self.folder_naming_checkbox.setStyleSheet("font-size: 10px;")
+        self.folder_naming_checkbox.setToolTip(
+            "Beim Verschieben die Nummern/Namen des Zielordners in den Dateinamen\n"
+            "aufnehmen (Vorlage unter Einstellungen > Dateinamen > Beim Verschieben).\n"
+            "Wirkt sofort, auch fuer den naechsten Verschiebe-Vorgang."
+        )
+        self.folder_naming_checkbox.toggled.connect(self._on_folder_naming_toggled)
+        head_row.addWidget(self.folder_naming_checkbox)
+        self.edit_pattern_btn = QPushButton("Muster bearbeiten…")
+        self.edit_pattern_btn.setFlat(True)
+        self.edit_pattern_btn.setStyleSheet(
+            "QPushButton { font-size: 10px; color: #1a5fb4; padding: 1px 4px; }"
+            "QPushButton:hover { text-decoration: underline; }"
+        )
+        self.edit_pattern_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.edit_pattern_btn.setToolTip("Öffnet Einstellungen > Dateinamen (Muster und Vorlagen)")
+        self.edit_pattern_btn.clicked.connect(self.edit_pattern_requested)
+        head_row.addWidget(self.edit_pattern_btn)
+        suggestions_layout.addLayout(head_row)
 
         self.suggestions_list = QListWidget()
         self.suggestions_list.setFixedHeight(28)  # wird an die Anzahl angepasst
@@ -501,6 +532,7 @@ class DetailPanel(QWidget):
 
         # Vorschläge befüllen (nach den Metadaten: die Muster-Vorschlaege
         # rendern aus den Feldern)
+        self.refresh_settings()
         self._populate_suggestions()
 
         # GroupBox-Titel
@@ -893,6 +925,27 @@ class DetailPanel(QWidget):
         name = self._displayed_suggestions[0].name.replace('.pdf', '')
         self.name_input.setText(name)
         self._auto_name = name
+
+    # -- Kopfzeile: Ordnerstruktur-Schalter --------------------------------- #
+
+    def refresh_settings(self):
+        """Gleicht die Kopfzeile an die Config an (nach Einstellungs-Aenderung)."""
+        try:
+            from src.utils.config import get_config
+            enabled = bool(get_config().get("folder_naming_enabled", False))
+        except Exception:
+            enabled = False
+        self.folder_naming_checkbox.blockSignals(True)
+        self.folder_naming_checkbox.setChecked(enabled)
+        self.folder_naming_checkbox.blockSignals(False)
+
+    def _on_folder_naming_toggled(self, checked: bool):
+        """Schalter in der Kopfzeile schreibt dieselbe Einstellung wie der Dialog."""
+        try:
+            from src.utils.config import get_config
+            get_config().set("folder_naming_enabled", bool(checked))
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Ordnerstruktur-Schalter nicht gespeichert: {e}")
 
     # -- Rangfolge der Vorschlaege (Issue #106) --------------------------- #
 

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -820,15 +820,20 @@ class DetailPanel(QWidget):
         Rangfolge aus der Config (``suggestion_kind_order``, Issue #106): die
         zuletzt angeklickte Art zuoberst.
         """
-        from src.core.suggestion_order import KIND_DATE, kind_from_reason, sort_by_kind
+        from src.core.suggestion_order import (
+            KIND_DATE, KIND_LEARNED, kind_from_reason, sort_by_kind,
+        )
 
         self.suggestions_list.clear()
 
         pairs: list[tuple[RenameSuggestion, str]] = []
         for s in self._suggestions:
             kind = kind_from_reason(s.reason)
-            if kind == KIND_DATE:
-                continue  # "Nur Datum" ist als Dateiname unbrauchbar (#106)
+            if kind in (KIND_DATE, KIND_LEARNED):
+                # "Nur Datum" ist als Dateiname unbrauchbar; "Gelernt" (fremder
+                # alter Dateiname) ebenso - die Historie fliesst stattdessen als
+                # Beispiel in den KI-Prompt (src.core.rename_examples)
+                continue
             pairs.append((s, kind))
         pattern_pairs = self._pattern_suggestions()
         pairs.extend(pattern_pairs)

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -959,6 +959,16 @@ class DetailPanel(QWidget):
         except Exception:
             return ""
 
+    def _custom_patterns(self) -> list[tuple[str, str]]:
+        """Vom Nutzer gespeicherte Muster (Einstellungen > Dateinamen)."""
+        from src.core.filename_placeholders import CUSTOM_PATTERNS_KEY, load_custom_patterns
+
+        try:
+            from src.utils.config import get_config
+            return load_custom_patterns(get_config().get(CUSTOM_PATTERNS_KEY, []))
+        except Exception:
+            return []
+
     def _kind_order(self) -> list[str]:
         """Gemerkte Rangfolge der Vorschlagsarten, um fehlende Arten ergaenzt."""
         from src.core.suggestion_order import CONFIG_KEY, effective_order
@@ -969,7 +979,7 @@ class DetailPanel(QWidget):
             saved = get_config().get(CONFIG_KEY, None)
         except Exception:
             pass
-        return effective_order(saved, self._config_pattern())
+        return effective_order(saved, self._config_pattern(), self._custom_patterns())
 
     def _remember_kind(self, kind: str):
         """Die angeklickte Art wird beim naechsten Dokument zuoberst gereiht."""
@@ -1023,7 +1033,7 @@ class DetailPanel(QWidget):
             return []
         values = self._pattern_values()
         result: list[tuple[RenameSuggestion, str]] = []
-        for label, pattern in pattern_choices(self._config_pattern()):
+        for label, pattern in pattern_choices(self._config_pattern(), self._custom_patterns()):
             if not pattern:
                 continue  # "Standard" = kein Muster
             name = render_with_values(pattern, values, min_values=2)

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -1013,7 +1013,9 @@ class DetailPanel(QWidget):
 
     def _on_preview_text_applied(self, field_key: str, text: str):
         """Markierter Text aus der Vorschau -> Metadaten-Feld; Korrespondent wird gelernt."""
-        text = " ".join((text or "").split())
+        from src.core.metadata_choices import normalize_for_field
+
+        text = normalize_for_field(field_key, text)
         widget = self._metadata_inputs.get(field_key)
         if widget is None or not text:
             return

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -12,7 +12,7 @@ from typing import Optional
 import logging
 import time
 
-from PyQt6.QtCore import Qt, QTimer, pyqtSignal, QThread
+from PyQt6.QtCore import Qt, QEvent, QTimer, pyqtSignal, QThread
 from PyQt6.QtGui import QColor, QFont
 from PyQt6.QtWidgets import (
     QWidget,
@@ -215,6 +215,7 @@ class DetailPanel(QWidget):
             "und wird automatisch als Dateiname vorgeschlagen."
         )
         self.suggestions_list.itemClicked.connect(self._on_suggestion_clicked)
+        self.suggestions_list.installEventFilter(self)
         suggestions_layout.addWidget(self.suggestions_list)
 
         detail_layout.addWidget(suggestions_group)
@@ -978,13 +979,31 @@ class DetailPanel(QWidget):
         return result
 
     def _fit_suggestions_height(self):
-        """Liste nur so hoch wie noetig (max. ~8 Zeilen) - spart Platz fuer die Vorschau."""
-        count = max(1, self.suggestions_list.count())
-        row_h = self.suggestions_list.sizeHintForRow(0)
+        """Liste nur so hoch wie noetig (max. ~8 Zeilen) - spart Platz fuer die Vorschau.
+
+        Ragen Zeilen ueber die Breite hinaus (lange Muster-Namen), blendet Qt
+        einen horizontalen Scrollbalken ein - der wird mitgerechnet, sonst
+        verdeckt er die letzte Zeile.
+        """
+        lst = self.suggestions_list
+        count = max(1, lst.count())
+        row_h = lst.sizeHintForRow(0)
         if row_h <= 0:
             row_h = 22
-        frame = 2 * self.suggestions_list.frameWidth() + 4
-        self.suggestions_list.setFixedHeight(min(8 * row_h + frame, count * row_h + frame))
+        frame = 2 * lst.frameWidth() + 4
+        extra = 0
+        if lst.count() and lst.viewport().width() > 0:
+            fm = lst.fontMetrics()
+            widest = max(fm.horizontalAdvance(lst.item(i).text()) for i in range(lst.count()))
+            if widest + 8 > lst.viewport().width():
+                extra = lst.horizontalScrollBar().sizeHint().height()
+        lst.setFixedHeight(min(8, count) * row_h + frame + extra)
+
+    def eventFilter(self, obj, event):
+        # Breite der Liste aendert sich (Fenster/Splitter): Scrollbalken-Bedarf neu pruefen
+        if obj is self.suggestions_list and event.type() == QEvent.Type.Resize:
+            QTimer.singleShot(0, self._fit_suggestions_height)
+        return super().eventFilter(obj, event)
 
     def _on_suggestion_clicked(self, item: QListWidgetItem):
         """Übernimmt Vorschlag in Eingabefeld + Metadaten und merkt sich die Art."""

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -341,6 +341,8 @@ class DetailPanel(QWidget):
         metadata_layout.addWidget(self.metadata_status_label)
 
         self._metadata_inputs = {}
+        # Grundstil je Feld - fuer die gruene Hervorhebung "neu gegenueber PDF"
+        self._field_base_styles: dict[str, str] = {}
         metadata_fields = [
             ("subject", "Kategorie"),
             ("korrespondent", "Korrespondent"),
@@ -405,6 +407,7 @@ class DetailPanel(QWidget):
                 input_field.setToolTip(tooltip)
             input_field.textChanged.connect(self._on_metadata_user_edit)
             self._metadata_inputs[field_key] = input_field
+            self._field_base_styles[field_key] = input_field.styleSheet()
 
         metadata_layout.addLayout(grid)
 
@@ -874,7 +877,7 @@ class DetailPanel(QWidget):
             self.metadata_status_label.show()
         elif source == "pdf_partial":
             self.metadata_status_label.setText(
-                "Quelle: teils aus PDF gelesen, teils Vorschlag (noch nicht gespeichert)"
+                "Quelle: aus PDF gelesen - grün = neue Vorschläge (noch nicht gespeichert)"
             )
             self.metadata_status_label.setStyleSheet(
                 "font-size: 10px; padding: 2px 6px; border-radius: 3px; "
@@ -897,6 +900,31 @@ class DetailPanel(QWidget):
             self.metadata_status_label.show()
         else:
             self.metadata_status_label.hide()
+        self._highlight_new_fields()
+
+    # Pastellgruen wie die Kacheln mit KI-Vorschlag (PDFThumbnailWidget.AI_BACKGROUND)
+    _NEW_FIELD_STYLE = " background-color: #e6f4e6; border: 1px solid #7cc47f; border-radius: 3px;"
+
+    def _highlight_new_fields(self):
+        """Felder gruen, deren Wert nicht (so) im PDF steht - erst nach dem Speichern weiss.
+
+        Nur sinnvoll, wenn das PDF ueberhaupt Metadaten hatte: dann sieht man
+        auf einen Blick, was die KI/Analyse ergaenzt hat und was schon drin war.
+        """
+        compare = bool(self._pdf_field_keys) and self._metadata_source != "pdf"
+        for key, widget in self._metadata_inputs.items():
+            if isinstance(widget, QPlainTextEdit):
+                value = widget.toPlainText().strip()
+            else:
+                value = widget.text().strip()
+            is_new = compare and bool(value) and value != self._saved_metadata_snapshot.get(key)
+            style = self._field_base_styles.get(key, "") + (self._NEW_FIELD_STYLE if is_new else "")
+            if widget.styleSheet() != style:
+                widget.setStyleSheet(style)
+            if isinstance(widget, _CategoryCombo):
+                edit_style = "background-color: #e6f4e6;" if is_new else ""
+                if widget.lineEdit().styleSheet() != edit_style:
+                    widget.lineEdit().setStyleSheet(edit_style)
 
     # === Interne Methoden ===
 

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -28,7 +28,9 @@ from PyQt6.QtWidgets import (
     QScrollArea,
     QApplication,
     QCheckBox,
+    QComboBox,
     QGridLayout,
+    QSizePolicy,
     QSplitter,
 )
 
@@ -108,6 +110,48 @@ class _LLMMetadataWorker(QThread):
         finally:
             activity.end(token, success=ok)
         self.result_ready.emit(self._pdf_path, list(suggestions or []), "")
+
+
+class _CategoryCombo(QComboBox):
+    """Kategorie-Feld als editierbare Auswahl (Issue #110).
+
+    Verhaelt sich nach aussen wie das QLineEdit, das hier vorher stand
+    (``text``/``setText``/``clear``/``textChanged``), zeigt aber im Aufklapp-
+    Menue die haeufigsten Kategorien der Sammlung.
+    """
+
+    textChanged = pyqtSignal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setEditable(True)
+        self.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
+        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon)
+        self.setMinimumContentsLength(6)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.lineEdit().textChanged.connect(self.textChanged)
+
+    def text(self) -> str:
+        return self.currentText()
+
+    def setText(self, text: str) -> None:
+        self.setEditText(text or "")
+
+    def clear(self) -> None:  # nur den Text, nicht die Auswahlliste
+        self.clearEditText()
+
+    def setPlaceholderText(self, text: str) -> None:
+        self.lineEdit().setPlaceholderText(text)
+
+    def set_choices(self, choices: list[str]) -> None:
+        current = self.currentText()
+        self.blockSignals(True)
+        self.lineEdit().blockSignals(True)
+        super().clear()
+        self.addItems(list(choices))
+        self.setEditText(current)
+        self.lineEdit().blockSignals(False)
+        self.blockSignals(False)
 
 
 class DetailPanel(QWidget):
@@ -346,7 +390,10 @@ class DetailPanel(QWidget):
                 grid.addWidget(label, row_idx, 0)
                 grid.addWidget(input_field, row_idx, 1, 1, 3)
             else:
-                input_field = QLineEdit()
+                if field_key == "subject":
+                    input_field = _CategoryCombo()  # Aufklappliste (Issue #110)
+                else:
+                    input_field = QLineEdit()
                 input_field.setPlaceholderText(f"{field_label}...")
                 input_field.setStyleSheet("font-size: 10px; padding: 2px;")
                 row_idx, col = divmod(idx, 2)
@@ -446,6 +493,8 @@ class DetailPanel(QWidget):
         )
         self.preview.enlarge_requested.connect(self.enlarge_preview_requested)
         self.preview.open_external_requested.connect(self.open_pdf_external_requested)
+        # Markierten Text aus der Vorschau in ein Metadaten-Feld (Issue #109)
+        self.preview.apply_text_requested.connect(self._on_preview_text_applied)
 
         self.splitter = QSplitter(Qt.Orientation.Vertical, self)
         self.splitter.addWidget(scroll)
@@ -509,6 +558,12 @@ class DetailPanel(QWidget):
                     self._metadata.update(s.metadata)
                     break
 
+            # Bekannter Korrespondent im Text (Issue #109): die vom Nutzer
+            # gelernte Schreibweise schlaegt den KI-Vorschlag
+            known = self._known_korrespondent(extracted_text)
+            if known:
+                self._metadata["korrespondent"] = known
+
             # Gelernte Korrespondent-Zuordnungen
             korrespondent = self._metadata.get("korrespondent")
             if korrespondent:
@@ -532,6 +587,7 @@ class DetailPanel(QWidget):
 
         # Vorschläge befüllen (nach den Metadaten: die Muster-Vorschlaege
         # rendern aus den Feldern)
+        self._load_category_choices()
         self.refresh_settings()
         self._populate_suggestions()
 
@@ -925,6 +981,61 @@ class DetailPanel(QWidget):
         name = self._displayed_suggestions[0].name.replace('.pdf', '')
         self.name_input.setText(name)
         self._auto_name = name
+
+    # -- Metadaten-Hilfen (Issues #109/#110) ------------------------------- #
+
+    def _load_category_choices(self):
+        """Aufklappliste der Kategorie: haeufigste 10 der Sammlung + Standard."""
+        from src.core.metadata_choices import category_choices
+
+        top: list[str] = []
+        try:
+            from src.utils.database import get_database
+            top = get_database().get_top_kategorien(10)
+        except Exception:
+            pass
+        widget = self._metadata_inputs.get("subject")
+        if isinstance(widget, _CategoryCombo):
+            widget.set_choices(category_choices(top))
+
+    def _known_korrespondent(self, text: str) -> Optional[str]:
+        """Bekannter Korrespondent (Verwaltung), der im Dokumenttext vorkommt."""
+        if not text:
+            return None
+        from src.core.korrespondent_match import find_known_korrespondent
+
+        try:
+            from src.utils.database import get_database
+            entries = get_database().list_korrespondenten()
+        except Exception:
+            return None
+        return find_known_korrespondent(text, entries)
+
+    def _on_preview_text_applied(self, field_key: str, text: str):
+        """Markierter Text aus der Vorschau -> Metadaten-Feld; Korrespondent wird gelernt."""
+        text = " ".join((text or "").split())
+        widget = self._metadata_inputs.get(field_key)
+        if widget is None or not text:
+            return
+        if isinstance(widget, QPlainTextEdit):
+            widget.setPlainText(text)
+        else:
+            widget.setText(text)
+        widget.setFocus()
+        if field_key == "korrespondent":
+            self._learn_korrespondent(text)
+
+    def _learn_korrespondent(self, name: str):
+        """Nimmt den Namen in die Korrespondenten-Verwaltung auf (Issue #109).
+
+        Bei spaeteren Dokumenten, in deren Text der Name vorkommt, wird er
+        automatisch als Korrespondent gesetzt (siehe _known_korrespondent).
+        """
+        try:
+            from src.utils.database import get_database
+            get_database().add_or_update_korrespondent(name)
+        except Exception as e:  # noqa: BLE001 - Lernen ist Komfort, kein Muss
+            logger.debug(f"Korrespondent nicht gelernt: {e}")
 
     # -- Kopfzeile: Ordnerstruktur-Schalter --------------------------------- #
 

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -833,6 +833,7 @@ class DetailPanel(QWidget):
         self._metadata_source = "pdf"
         self._saved_metadata_snapshot = self.get_metadata()
         self._pdf_field_keys = set(self._saved_metadata_snapshot.keys())
+        self._remember_category()
         self._refresh_save_btn()
 
     def _on_metadata_user_edit(self, *args):
@@ -1016,9 +1017,15 @@ class DetailPanel(QWidget):
     # -- Metadaten-Hilfen (Issues #109/#110) ------------------------------- #
 
     def _load_category_choices(self):
-        """Aufklappliste der Kategorie: haeufigste 10 der Sammlung + Standard."""
-        from src.core.metadata_choices import category_choices
+        """Aufklappliste der Kategorie: zuletzt verwendet, dann haeufig, dann Standard."""
+        from src.core.metadata_choices import RECENT_CATEGORIES_KEY, category_choices
 
+        recent: list[str] = []
+        try:
+            from src.utils.config import get_config
+            recent = list(get_config().get(RECENT_CATEGORIES_KEY, []) or [])
+        except Exception:
+            pass
         top: list[str] = []
         try:
             from src.utils.database import get_database
@@ -1027,7 +1034,23 @@ class DetailPanel(QWidget):
             pass
         widget = self._metadata_inputs.get("subject")
         if isinstance(widget, _CategoryCombo):
-            widget.set_choices(category_choices(top))
+            widget.set_choices(category_choices(recent, top))
+
+    def _remember_category(self):
+        """Die gerade gespeicherte Kategorie nach vorn in die Aufklappliste."""
+        from src.core.metadata_choices import RECENT_CATEGORIES_KEY, remember_category
+
+        category = self.get_metadata().get("subject", "")
+        if not category:
+            return
+        try:
+            from src.utils.config import get_config
+            config = get_config()
+            config.set(RECENT_CATEGORIES_KEY,
+                       remember_category(config.get(RECENT_CATEGORIES_KEY, []), category))
+        except Exception as e:  # noqa: BLE001 - Komfort, kein Muss
+            logger.debug(f"Kategorie nicht gemerkt: {e}")
+        self._load_category_choices()
 
     def _known_korrespondent(self, text: str) -> Optional[str]:
         """Bekannter Korrespondent (Verwaltung), der im Dokumenttext vorkommt."""

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -9,6 +9,7 @@ und klickt rechts auf einen Zielordner zum Verschieben+Umbenennen.
 from pathlib import Path
 from typing import Optional
 
+import logging
 import time
 
 from PyQt6.QtCore import Qt, QTimer, pyqtSignal, QThread
@@ -27,10 +28,11 @@ from PyQt6.QtWidgets import (
     QScrollArea,
     QApplication,
     QCheckBox,
-    QComboBox,
     QGridLayout,
     QSplitter,
 )
+
+logger = logging.getLogger(__name__)
 
 from src.core.llm_activity import (
     KIND_SUGGEST,
@@ -125,13 +127,12 @@ class DetailPanel(QWidget):
         super().__init__(parent)
         self._current_pdf: Optional[Path] = None
         self._suggestions: list[RenameSuggestion] = []
-        # Tatsaechlich angezeigte Liste: _suggestions + Muster-Vorschlag (#99)
+        # Tatsaechlich angezeigte Liste (#99/#106): _suggestions + ein
+        # Muster-Vorschlag je Vorlage, sortiert nach der gemerkten Rangfolge;
+        # _displayed_kinds haelt parallel dazu die Art jeder Zeile
         self._displayed_suggestions: list[RenameSuggestion] = []
+        self._displayed_kinds: list[str] = []
         self._detected_date: Optional[str] = None
-        # Muster-Umschaltung (Issue #99): (Bezeichnung, Muster) je Combo-Eintrag;
-        # _pattern_config merkt sich das zuletzt gelesene Einstellungs-Muster
-        self._pattern_choices: list[tuple[str, str]] = []
-        self._pattern_config: Optional[str] = None
         self._metadata: dict = {}
         self._has_learned_overrides: bool = False
         # Quelle der aktuell angezeigten Metadaten: "pdf", "llm", "user", None
@@ -209,33 +210,12 @@ class DetailPanel(QWidget):
         self.suggestions_list = QListWidget()
         self.suggestions_list.setFixedHeight(28)  # wird an die Anzahl angepasst
         self.suggestions_list.setToolTip(
-            "Vorschlag anklicken, um Namen und Metadaten in die Felder unten zu übernehmen."
+            "Vorschlag anklicken, um Namen und Metadaten in die Felder unten zu übernehmen.\n"
+            "Die zuletzt gewählte Art von Vorschlag steht beim nächsten Dokument ganz oben\n"
+            "und wird automatisch als Dateiname vorgeschlagen."
         )
         self.suggestions_list.itemClicked.connect(self._on_suggestion_clicked)
         suggestions_layout.addWidget(self.suggestions_list)
-
-        # Muster-Umschaltung (Issue #99): Dateiname nach dem Muster aus
-        # Einstellungen > Dateinamen (oder einer anderen Vorlage), gerendert
-        # aus den Metadaten dieses Dokuments
-        pattern_row = QHBoxLayout()
-        pattern_row.setSpacing(4)
-        pattern_label = QLabel("Muster:")
-        pattern_label.setStyleSheet("color: #555; font-size: 10px;")
-        pattern_row.addWidget(pattern_label)
-        self.pattern_combo = QComboBox()
-        self.pattern_combo.setStyleSheet("font-size: 10px;")
-        self.pattern_combo.setSizeAdjustPolicy(
-            QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
-        )
-        self.pattern_combo.setMinimumContentsLength(18)
-        self.pattern_combo.setToolTip(
-            "Dateinamen-Muster aus Einstellungen > Dateinamen.\n"
-            "Umschalten zeigt den Namen nach dem gewählten Muster als Vorschlag\n"
-            "und übernimmt ihn ins Feld „Neuer Dateiname“."
-        )
-        self.pattern_combo.activated.connect(self._on_pattern_combo_activated)
-        pattern_row.addWidget(self.pattern_combo, 1)
-        suggestions_layout.addLayout(pattern_row)
 
         detail_layout.addWidget(suggestions_group)
 
@@ -469,9 +449,6 @@ class DetailPanel(QWidget):
         # Vorschau unten nachladen (Issue #74) - liest im Hintergrund
         self.preview.load_pdf(pdf_path)
 
-        # Muster-Auswahl an die Einstellungen angleichen (falls dort geaendert)
-        self._load_pattern_choices()
-
         # Metadaten vorbefüllen
         self._metadata = {}
 
@@ -521,8 +498,8 @@ class DetailPanel(QWidget):
             else:
                 self._metadata_source = None
 
-        # Vorschläge befüllen (nach den Metadaten: der Muster-Vorschlag
-        # rendert aus den Feldern)
+        # Vorschläge befüllen (nach den Metadaten: die Muster-Vorschlaege
+        # rendern aus den Feldern)
         self._populate_suggestions()
 
         # GroupBox-Titel
@@ -533,12 +510,10 @@ class DetailPanel(QWidget):
 
         self._refresh_save_btn()
 
-        # Ersten Vorschlag als Name setzen
+        # Obersten Vorschlag (= zuletzt gewaehlte Art, Issue #106) als Name setzen
         self._auto_name = ""
-        if self._suggestions:
-            name = self._suggestions[0].name.replace('.pdf', '')
-            self.name_input.setText(name)
-            self._auto_name = name
+        self.name_input.setText("")
+        self._apply_top_suggestion()
 
         # UI umschalten
         self.placeholder.hide()
@@ -698,7 +673,9 @@ class DetailPanel(QWidget):
         self._apply_pdf_metadata(pdf_meta)
         if self._saved_metadata_snapshot:
             self.metadata_group.setTitle("Metadaten (aus PDF gelesen, werden in PDF gespeichert)")
-            self._populate_suggestions()  # Muster-Vorschlag mit den PDF-Werten
+            self._populate_suggestions()  # Muster-Vorschlaege mit den PDF-Werten
+            if not self.has_user_edits():
+                self._apply_top_suggestion()
 
     def load_metadata_from_pdf(self, pdf_path: Path):
         """Liest XMP-Metadaten synchron aus der PDF und befüllt die Felder (Tests/Sonderfaelle)."""
@@ -835,18 +812,38 @@ class DetailPanel(QWidget):
     # === Interne Methoden ===
 
     def _populate_suggestions(self):
-        """Füllt die Vorschlagsliste (KI-Vorschläge, Muster-Vorschlag, Rest)."""
+        """Fuellt die Vorschlagsliste: eine einheitliche, nach Art sortierte Liste.
+
+        KI-Vorschlaege, ein Muster-Vorschlag je Vorlage (aus den Metadaten
+        dieses Dokuments) und die einfachen Analyse-Vorschlaege stehen in der
+        Rangfolge aus der Config (``suggestion_kind_order``, Issue #106): die
+        zuletzt angeklickte Art zuoberst.
+        """
+        from src.core.suggestion_order import KIND_DATE, kind_from_reason, sort_by_kind
+
         self.suggestions_list.clear()
 
-        displayed = list(self._suggestions)
-        pattern_suggestion = self._pattern_suggestion()
-        if pattern_suggestion is not None:
-            # Direkt hinter den KI-Vorschlaegen, vor "Automatisch erkannt" & Co.
-            pos = 0
-            while pos < len(displayed) and displayed[pos].reason == "KI-Vorschlag":
-                pos += 1
-            displayed.insert(pos, pattern_suggestion)
-        self._displayed_suggestions = displayed
+        pairs: list[tuple[RenameSuggestion, str]] = []
+        for s in self._suggestions:
+            kind = kind_from_reason(s.reason)
+            if kind == KIND_DATE:
+                continue  # "Nur Datum" ist als Dateiname unbrauchbar (#106)
+            pairs.append((s, kind))
+        pattern_pairs = self._pattern_suggestions()
+        pairs.extend(pattern_pairs)
+        pairs = sort_by_kind(pairs, self._kind_order())
+
+        # Doppelte Namen (z.B. KI folgt exakt dem Muster): hoeher gereihte Zeile gewinnt
+        seen: set[str] = set()
+        displayed: list[tuple[RenameSuggestion, str]] = []
+        for s, kind in pairs:
+            key = s.name.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            displayed.append((s, kind))
+        self._displayed_suggestions = [s for s, _k in displayed]
+        self._displayed_kinds = [k for _s, k in displayed]
 
         if not displayed:
             item = QListWidgetItem("Keine Vorschläge verfügbar")
@@ -855,7 +852,8 @@ class DetailPanel(QWidget):
             self._fit_suggestions_height()
             return
 
-        for suggestion in displayed:
+        pattern_rows = {id(s) for s, _k in pattern_pairs}
+        for suggestion, _kind in displayed:
             confidence_pct = int(suggestion.confidence * 100)
             display_text = f"{suggestion.name}"
             if suggestion.reason:
@@ -864,9 +862,9 @@ class DetailPanel(QWidget):
             item = QListWidgetItem(display_text)
             item.setData(Qt.ItemDataRole.UserRole, suggestion.name)
 
-            if suggestion is pattern_suggestion:
+            if id(suggestion) in pattern_rows:
                 item.setToolTip(
-                    "Nach dem gewählten Dateinamen-Muster aus den Metadaten dieses "
+                    "Nach diesem Dateinamen-Muster aus den Metadaten dieses "
                     "Dokuments gebildet. Anklicken übernimmt den Namen."
                 )
                 item.setBackground(QColor(214, 234, 255))  # hellblau = Muster
@@ -882,40 +880,49 @@ class DetailPanel(QWidget):
             self.suggestions_list.addItem(item)
         self._fit_suggestions_height()
 
-    # -- Muster-Umschaltung (Issue #99) ---------------------------------- #
+    def _apply_top_suggestion(self):
+        """Uebernimmt die oberste Zeile als (automatischen) Dateinamen."""
+        if not self._displayed_suggestions:
+            return
+        name = self._displayed_suggestions[0].name.replace('.pdf', '')
+        self.name_input.setText(name)
+        self._auto_name = name
 
-    def _load_pattern_choices(self, force: bool = False):
-        """Befuellt die Muster-Combo aus den Einstellungen.
+    # -- Rangfolge der Vorschlaege (Issue #106) --------------------------- #
 
-        Wird bei jeder PDF-Auswahl aufgerufen; die Combo wird nur neu
-        aufgebaut, wenn sich das Muster in den Einstellungen geaendert hat -
-        eine Umschaltung des Nutzers bleibt sonst ueber PDFs hinweg erhalten.
-        """
-        from src.core.filename_placeholders import migrate_legacy_pattern, pattern_choices
+    def _config_pattern(self) -> str:
+        """Dateinamen-Muster aus Einstellungen > Dateinamen (migriert)."""
+        from src.core.filename_placeholders import migrate_legacy_pattern
 
         try:
             from src.utils.config import get_config
-            config_pattern = migrate_legacy_pattern(get_config().get("filename_pattern", "") or "")
+            return migrate_legacy_pattern(get_config().get("filename_pattern", "") or "")
         except Exception:
-            config_pattern = ""
-        if not force and config_pattern == self._pattern_config:
+            return ""
+
+    def _kind_order(self) -> list[str]:
+        """Gemerkte Rangfolge der Vorschlagsarten, um fehlende Arten ergaenzt."""
+        from src.core.suggestion_order import CONFIG_KEY, effective_order
+
+        saved = None
+        try:
+            from src.utils.config import get_config
+            saved = get_config().get(CONFIG_KEY, None)
+        except Exception:
+            pass
+        return effective_order(saved, self._config_pattern())
+
+    def _remember_kind(self, kind: str):
+        """Die angeklickte Art wird beim naechsten Dokument zuoberst gereiht."""
+        from src.core.suggestion_order import CONFIG_KEY, KIND_OTHER, promote
+
+        if not kind or kind == KIND_OTHER:
             return
-        self._pattern_config = config_pattern
-        self._pattern_choices = pattern_choices(config_pattern)
-
-        self.pattern_combo.blockSignals(True)
-        self.pattern_combo.clear()
-        selected = 0
-        for idx, (label, pattern) in enumerate(self._pattern_choices):
-            self.pattern_combo.addItem(label, pattern)
-            if pattern and pattern == config_pattern:
-                selected = idx
-        self.pattern_combo.setCurrentIndex(selected)
-        self.pattern_combo.blockSignals(False)
-
-    def current_pattern(self) -> str:
-        """Das in der Combo gewaehlte Muster ("" = Standard, kein Muster-Vorschlag)."""
-        return self.pattern_combo.currentData() or ""
+        try:
+            from src.utils.config import get_config
+            get_config().set(CONFIG_KEY, promote(self._kind_order(), kind))
+        except Exception as e:  # noqa: BLE001 - Rangfolge ist Komfort, kein Muss
+            logger.debug(f"Vorschlags-Rangfolge nicht gespeichert: {e}")
 
     def _pattern_values(self) -> dict:
         """Platzhalter-Werte aus den aktuellen Feldern + Dokumentdatum."""
@@ -943,43 +950,53 @@ class DetailPanel(QWidget):
                         break
         return placeholder_values_from_metadata(self.get_metadata(), doc_date, initials)
 
-    def _pattern_suggestion(self) -> Optional[RenameSuggestion]:
-        """Vorschlag nach dem gewaehlten Muster - None ohne Muster oder ohne Werte."""
-        from src.core.filename_placeholders import render_with_values
+    def _pattern_suggestions(self) -> list[tuple[RenameSuggestion, str]]:
+        """Ein Vorschlag je Vorlage (und eigenem Einstellungs-Muster), mit Art.
 
-        pattern = self.current_pattern()
-        if not pattern or not self._current_pdf:
-            return None
-        name = render_with_values(pattern, self._pattern_values())
-        if not name:
-            return None
-        label = self.pattern_combo.currentText().split(" (")[0]
-        return RenameSuggestion(name=name, reason=f"Muster: {label}", confidence=0.75)
+        Vorlagen, bei denen weniger als zwei Platzhalter einen Wert haben,
+        fallen weg - „Rechnung.pdf“ oder ein blosses Datum sind als
+        Dateiname unbrauchbar.
+        """
+        from src.core.filename_placeholders import pattern_choices, render_with_values
+        from src.core.suggestion_order import pattern_kind
 
-    def _on_pattern_combo_activated(self, _index: int):
-        """Nutzer hat ein anderes Muster gewaehlt: Liste neu, Name uebernehmen."""
-        self._populate_suggestions()
-        suggestion = self._pattern_suggestion()
-        if suggestion is not None:
-            self.name_input.setText(suggestion.name.replace('.pdf', ''))
+        if not self._current_pdf:
+            return []
+        values = self._pattern_values()
+        result: list[tuple[RenameSuggestion, str]] = []
+        for label, pattern in pattern_choices(self._config_pattern()):
+            if not pattern:
+                continue  # "Standard" = kein Muster
+            name = render_with_values(pattern, values, min_values=2)
+            if not name:
+                continue
+            short = label.split(" (")[0]
+            result.append((
+                RenameSuggestion(name=name, reason=f"Muster: {short}", confidence=0.75),
+                pattern_kind(pattern),
+            ))
+        return result
 
     def _fit_suggestions_height(self):
-        """Liste nur so hoch wie noetig (max. ~4 Zeilen) - spart Platz fuer die Vorschau."""
+        """Liste nur so hoch wie noetig (max. ~8 Zeilen) - spart Platz fuer die Vorschau."""
         count = max(1, self.suggestions_list.count())
         row_h = self.suggestions_list.sizeHintForRow(0)
         if row_h <= 0:
             row_h = 22
         frame = 2 * self.suggestions_list.frameWidth() + 4
-        self.suggestions_list.setFixedHeight(min(96, count * row_h + frame))
+        self.suggestions_list.setFixedHeight(min(8 * row_h + frame, count * row_h + frame))
 
     def _on_suggestion_clicked(self, item: QListWidgetItem):
-        """Übernimmt Vorschlag in Eingabefeld + Metadaten."""
+        """Übernimmt Vorschlag in Eingabefeld + Metadaten und merkt sich die Art."""
         name = item.data(Qt.ItemDataRole.UserRole)
         if name:
             self.name_input.setText(name.replace('.pdf', ''))
 
-            # Metadaten des Vorschlags übernehmen
             idx = self.suggestions_list.row(item)
+            if 0 <= idx < len(self._displayed_kinds):
+                self._remember_kind(self._displayed_kinds[idx])
+
+            # Metadaten des Vorschlags übernehmen
             shown = self._displayed_suggestions
             if idx < len(shown) and shown[idx].metadata:
                 self._loading_metadata = True

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1998,6 +1998,7 @@ class MainWindow(QMainWindow):
                     extracted_text=self.selected_pdf_text,
                     keywords=self.selected_pdf_keywords,
                     detected_date=detected_date,
+                    target_folder=str(folder_path),
                 )
 
             # Volltext-Suchindex befüllen (Phase 17)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1906,8 +1906,16 @@ class MainWindow(QMainWindow):
         new_name = self.detail_panel.get_new_name()
         metadata = self.detail_panel.get_metadata()
 
+        # Der vom Nutzer gewaehlte/korrigierte Name ist das, was die KI
+        # kuenftig liefern soll - nur er geht als Beispiel in die Historie.
+        # Das Ordner-Praefix (#42) kommt beim Verschieben dazu und wuerde
+        # die KI sonst dazu verleiten, selbst Ordnernummern zu erfinden.
+        learned_name = new_name
+        folder_naming_applied = False
+
         # Dateiname aus Ordnerstruktur aufbauen (Issue #42, Opt-in)
         if self.config.get("folder_naming_enabled", False):
+            folder_naming_applied = True
             fallback_date = (
                 coerce_date(self.selected_pdf_dates[0])
                 if self.selected_pdf_dates else None
@@ -1993,14 +2001,18 @@ class MainWindow(QMainWindow):
                         detected_date = d.strftime("%Y-%m-%d") if hasattr(d, 'strftime') else str(d)
                     except Exception:
                         pass
-                self.db.add_rename_entry(
-                    original_filename=pdf_path.name,
-                    new_filename=new_path.name,
-                    extracted_text=self.selected_pdf_text,
-                    keywords=self.selected_pdf_keywords,
-                    detected_date=detected_date,
-                    target_folder=str(folder_path),
+                history_name = (
+                    learned_name if folder_naming_applied and learned_name else new_path.name
                 )
+                if history_name != pdf_path.name:
+                    self.db.add_rename_entry(
+                        original_filename=pdf_path.name,
+                        new_filename=history_name,
+                        extracted_text=self.selected_pdf_text,
+                        keywords=self.selected_pdf_keywords,
+                        detected_date=detected_date,
+                        target_folder=str(folder_path),
+                    )
 
             # Volltext-Suchindex befüllen (Phase 17)
             self.db.update_pdf_path(

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -203,6 +203,7 @@ class MainWindow(QMainWindow):
         self.detail_panel.open_pdf_requested.connect(self.open_pdf)
         self.detail_panel.open_pdf_external_requested.connect(self.open_pdf_external)
         self.detail_panel.enlarge_preview_requested.connect(self.show_preview_window)
+        self.detail_panel.edit_pattern_requested.connect(self.open_filename_settings)
         # Aufteilung Details/Vorschau aus der letzten Sitzung wiederherstellen
         saved_sizes = self.config.get("detail_splitter_sizes") or []
         if (len(saved_sizes) == 2 and all(isinstance(v, int) and v > 0 for v in saved_sizes)):
@@ -4138,8 +4139,17 @@ class MainWindow(QMainWindow):
 
     def open_settings(self):
         """Öffnet den Einstellungsdialog."""
+        self._open_settings_dialog()
+
+    def open_filename_settings(self):
+        """Einstellungen direkt auf dem Tab "Dateinamen" (Muster bearbeiten)."""
+        self._open_settings_dialog(tab="Dateinamen")
+
+    def _open_settings_dialog(self, tab: str | None = None):
         dialog = SettingsDialog(self, example_values_provider=self._settings_example_values)
         dialog.settings_changed.connect(self._on_settings_changed)
+        if tab:
+            dialog.show_tab(tab)
         dialog.exec()
 
     def _settings_example_values(self):
@@ -4160,6 +4170,8 @@ class MainWindow(QMainWindow):
         # Hybrid-Klassifikator neu initialisieren
         self.hybrid_classifier._init_llm_provider()
         self._update_llm_status()
+        # Kopfzeile der Vorschlaege (Ordnerstruktur-Schalter) nachziehen
+        self.detail_panel.refresh_settings()
         self.statusbar.showMessage("Einstellungen gespeichert", 3000)
         # KI-Vorabfrage neu anstossen: PDFs, die ohne verfuegbares LLM
         # uebersprungen wurden, werden jetzt eingereiht.

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -287,7 +287,23 @@ class MainWindow(QMainWindow):
             )
             self._preview_window.open_external_requested.connect(self.open_pdf_external)
             self._preview_window.geometry_changed.connect(self._on_preview_geometry_changed)
+            self._preview_window.apply_text_requested.connect(self._on_preview_window_text_applied)
         self._preview_window.show_pdf(Path(pdf_path))
+
+    def _on_preview_window_text_applied(self, field_key: str, text: str) -> None:
+        """Markierter Text aus dem grossen Vorschau-Fenster -> Metadaten-Feld (Issue #109).
+
+        Nur, wenn das Fenster dieselbe PDF zeigt wie das Detail-Panel - sonst
+        landete der Text bei einem anderen Dokument.
+        """
+        shown = self._preview_window.current_path() if self._preview_window else None
+        selected = self.detail_panel.get_current_pdf()
+        if shown is None or selected is None or Path(shown) != Path(selected):
+            self.statusbar.showMessage(
+                "Die Vorschau zeigt nicht die ausgewählte PDF - Text nicht übernommen.", 5000
+            )
+            return
+        self.detail_panel.apply_preview_text(field_key, text)
 
     def _on_preview_geometry_changed(self, geometry: list) -> None:
         self.config.set("preview_window_geometry", list(geometry))

--- a/src/gui/pdf_preview_widget.py
+++ b/src/gui/pdf_preview_widget.py
@@ -49,6 +49,12 @@ SELECTION_TARGETS: tuple[tuple[str, str], ...] = (
     ("korrespondent", "Als Korrespondent übernehmen"),
     ("subject", "Als Kategorie übernehmen"),
     ("description", "Als Zusammenfassung übernehmen"),
+    ("betrag_netto", "Als Betrag Netto übernehmen"),
+    ("betrag_brutto", "Als Betrag Brutto übernehmen"),
+    ("waehrung", "Als Währung übernehmen"),
+    ("mwst_satz", "Als MwSt-Satz übernehmen"),
+    ("iban", "Als IBAN übernehmen"),
+    ("steuerjahr", "Als Steuerjahr übernehmen"),
 )
 
 
@@ -231,7 +237,7 @@ class PdfPreviewWidget(QWidget):
         self._view.viewport().installEventFilter(self)
         self._view.setToolTip(
             "Text mit der Maus markieren, dann Rechtsklick: "
-            "als Korrespondent, Kategorie oder Zusammenfassung übernehmen."
+            "in ein Metadaten-Feld übernehmen (Korrespondent, Betrag, IBAN, ...)."
         )
         self._stack.addWidget(self._view)
 
@@ -645,6 +651,8 @@ class PdfPreviewWidget(QWidget):
         """Kontextmenue fuer den markierten Text (ohne exec, fuer Tests)."""
         text = self.selected_text()
         menu = QMenu(self)
+        short = text if len(text) <= 40 else text[:37] + "…"
+        menu.addSection(f"„{short}“")
         for field_key, label in SELECTION_TARGETS:
             action = menu.addAction(label)
             action.setData(field_key)

--- a/src/gui/pdf_preview_widget.py
+++ b/src/gui/pdf_preview_widget.py
@@ -18,12 +18,17 @@ from __future__ import annotations
 from pathlib import Path
 
 from PyQt6 import sip
-from PyQt6.QtCore import QBuffer, QEvent, QIODevice, QPointF, Qt, QThread, pyqtSignal
-from PyQt6.QtPdf import QPdfDocument
+from PyQt6.QtCore import (
+    QBuffer, QEvent, QIODevice, QPoint, QPointF, QRect, QSize, QSizeF, Qt, QThread, pyqtSignal,
+)
+from PyQt6.QtGui import QColor, QGuiApplication, QPainter, QPolygonF
+from PyQt6.QtPdf import QPdfDocument, QPdfSelection
 from PyQt6.QtPdfWidgets import QPdfView
 from PyQt6.QtWidgets import (
+    QApplication,
     QHBoxLayout,
     QLabel,
+    QMenu,
     QSizePolicy,
     QStackedLayout,
     QStyle,
@@ -38,6 +43,38 @@ MAX_PREVIEW_BYTES = 300 * 1024 * 1024
 ZOOM_STEP = 1.25
 ZOOM_MIN = 0.2
 ZOOM_MAX = 8.0
+
+# Rechtsklick auf markierten Text: in welches Metadaten-Feld? (Issue #109)
+SELECTION_TARGETS: tuple[tuple[str, str], ...] = (
+    ("korrespondent", "Als Korrespondent übernehmen"),
+    ("subject", "Als Kategorie übernehmen"),
+    ("description", "Als Zusammenfassung übernehmen"),
+)
+
+
+class _SelectionOverlay(QWidget):
+    """Zeichnet die Textmarkierung ueber den Viewport der QPdfView."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+        self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground)
+        self._polygons: list[QPolygonF] = []
+
+    def set_polygons(self, polygons):
+        self._polygons = list(polygons)
+        self.update()
+
+    def paintEvent(self, _event):
+        if not self._polygons:
+            return
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(QColor(51, 120, 220, 80))
+        for poly in self._polygons:
+            painter.drawPolygon(poly)
+        painter.end()
 
 
 class _PdfBytesReader(QThread):
@@ -81,6 +118,9 @@ class PdfPreviewWidget(QWidget):
     load_failed = pyqtSignal(Path, str)
     enlarge_requested = pyqtSignal(Path)
     open_external_requested = pyqtSignal(Path)
+    # Textauswahl (Issue #109): markierter Text; "uebernehmen in Feld X"
+    text_selected = pyqtSignal(str)
+    apply_text_requested = pyqtSignal(str, str)  # (feld, text)
 
     def __init__(self, parent=None, compact: bool = False):
         super().__init__(parent)
@@ -89,6 +129,12 @@ class PdfPreviewWidget(QWidget):
         self._buffer: QBuffer | None = None
         self._generation = 0
         self._readers: list[_PdfBytesReader] = []
+        # Textauswahl mit der Maus
+        self._selection: QPdfSelection | None = None
+        self._sel_page: int = -1
+        self._sel_start: QPointF = QPointF()
+        self._selecting: bool = False
+        self._line_boxes: dict[int, list] = {}  # Seite -> Textzeilen-Rechtecke (pt)
 
         self._document = QPdfDocument(self)
         self._document.statusChanged.connect(self._on_status_changed)
@@ -183,7 +229,19 @@ class PdfPreviewWidget(QWidget):
         self._view.setPageSpacing(6)
         self._view.pageNavigator().currentPageChanged.connect(self._on_current_page_changed)
         self._view.viewport().installEventFilter(self)
+        self._view.setToolTip(
+            "Text mit der Maus markieren, dann Rechtsklick: "
+            "als Korrespondent, Kategorie oder Zusammenfassung übernehmen."
+        )
         self._stack.addWidget(self._view)
+
+        # Markierung ueber dem Viewport; folgt Scrollen und Zoom
+        self._overlay = _SelectionOverlay(self._view.viewport())
+        self._overlay.resize(self._view.viewport().size())
+        self._view.verticalScrollBar().valueChanged.connect(self._refresh_overlay)
+        self._view.horizontalScrollBar().valueChanged.connect(self._refresh_overlay)
+        self._view.zoomFactorChanged.connect(self._refresh_overlay)
+        self._view.zoomModeChanged.connect(self._refresh_overlay)
 
         self.message_label = QLabel("Keine PDF ausgewählt")
         self.message_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -260,6 +318,8 @@ class PdfPreviewWidget(QWidget):
 
         self._view.setZoomMode(QPdfView.ZoomMode.FitToWidth)
         self._view.pageNavigator().jump(0, QPointF(0, 0))
+        self._line_boxes = {}
+        self.clear_selection()
         self._stack.setCurrentWidget(self._view)
         self._set_controls_enabled(True)
         self._update_page_label()
@@ -270,6 +330,8 @@ class PdfPreviewWidget(QWidget):
         """Leert die Ansicht (keine PDF ausgewaehlt)."""
         self._generation += 1
         self._current_path = None
+        self._line_boxes = {}
+        self.clear_selection()
         self._release_document()
         self._show_message("Keine PDF ausgewählt")
         self._set_controls_enabled(False)
@@ -439,11 +501,12 @@ class PdfPreviewWidget(QWidget):
 
     def eventFilter(self, obj, event):
         if obj is self._view.viewport():
-            if (event.type() == QEvent.Type.MouseButtonDblClick
+            etype = event.type()
+            if (etype == QEvent.Type.MouseButtonDblClick
                     and self._compact and self._current_path is not None):
                 self.enlarge_requested.emit(self._current_path)
                 return True
-            if event.type() == QEvent.Type.Wheel and (
+            if etype == QEvent.Type.Wheel and (
                 event.modifiers() & Qt.KeyboardModifier.ControlModifier
             ):
                 if event.angleDelta().y() > 0:
@@ -451,7 +514,232 @@ class PdfPreviewWidget(QWidget):
                 elif event.angleDelta().y() < 0:
                     self.zoom_out()
                 return True
+            if etype == QEvent.Type.Resize:
+                self._overlay.resize(event.size())
+                self._refresh_overlay()
+            elif etype == QEvent.Type.MouseButtonPress:
+                if event.button() == Qt.MouseButton.LeftButton:
+                    self._begin_selection(event.position().toPoint())
+                elif event.button() == Qt.MouseButton.RightButton and self.selected_text():
+                    self._show_selection_menu(event.globalPosition().toPoint())
+                    return True
+            elif etype == QEvent.Type.MouseMove and self._selecting:
+                if event.buttons() & Qt.MouseButton.LeftButton:
+                    self._update_selection(event.position().toPoint())
+                    return True
+            elif etype == QEvent.Type.MouseButtonRelease and self._selecting:
+                if event.button() == Qt.MouseButton.LeftButton:
+                    self._selecting = False
+                    self._update_selection(event.position().toPoint())
+                    text = self.selected_text()
+                    if text:
+                        self.text_selected.emit(text)
         return super().eventFilter(obj, event)
+
+    # ------------------------------------------------------------------ #
+    # Textauswahl (Issue #109)
+    # ------------------------------------------------------------------ #
+
+    def selected_text(self) -> str:
+        """Markierter Text, Leerraum normalisiert; "" ohne Markierung."""
+        if self._selection is None:
+            return ""
+        return " ".join(self._selection.text().split())
+
+    def clear_selection(self) -> None:
+        self._selection = None
+        self._sel_page = -1
+        self._selecting = False
+        self._refresh_overlay()
+
+    def _text_line_boxes(self, page: int) -> list:
+        """Rechtecke der Textzeilen einer Seite (pt), einmal pro Dokument ermittelt."""
+        boxes = self._line_boxes.get(page)
+        if boxes is None:
+            boxes = []
+            try:
+                all_text = self._document.getAllText(page)
+                if all_text.isValid():
+                    boxes = [poly.boundingRect() for poly in all_text.bounds()]
+            except Exception:  # noqa: BLE001 - dann eben ohne Einrasten
+                boxes = []
+            self._line_boxes[page] = boxes
+        return boxes
+
+    def _snap_to_text(self, page: int, point: QPointF) -> QPointF:
+        """Punkt auf die naechste Textzeile ziehen.
+
+        PDFium liefert nur eine Auswahl, wenn Start- UND Endpunkt ein Zeichen
+        treffen. Wer im Weissraum zu ziehen beginnt oder ueber das Zeilenende
+        hinaus zieht, bekaeme sonst nichts markiert.
+        """
+        boxes = self._text_line_boxes(page)
+        if not boxes:
+            return point
+        best = None
+        for box in boxes:
+            dx = max(box.left() - point.x(), 0.0, point.x() - box.right())
+            dy = max(box.top() - point.y(), 0.0, point.y() - box.bottom())
+            key = (dy, dx)
+            if best is None or key < best[0]:
+                best = (key, box)
+        box = best[1]
+        inset = 1.0
+        x = min(max(point.x(), box.left() + inset), max(box.left() + inset, box.right() - inset))
+        y = min(max(point.y(), box.top() + inset), max(box.top() + inset, box.bottom() - inset))
+        return QPointF(x, y)
+
+    def _begin_selection(self, pos: QPoint) -> None:
+        self.clear_selection()
+        if not self.is_showing_document():
+            return
+        hit = self._page_at(pos)
+        if hit is None:
+            return
+        page, rect = hit
+        self._sel_page = page
+        self._sel_start = self._snap_to_text(page, self._to_page_point(rect, page, pos))
+        self._selecting = True
+
+    def _update_selection(self, pos: QPoint) -> None:
+        if self._sel_page < 0:
+            return
+        rect = self._page_rect_in_viewport(self._sel_page)
+        if rect is None:
+            return
+        end = self._snap_to_text(self._sel_page, self._to_page_point(rect, self._sel_page, pos))
+        selection = self._document.getSelection(self._sel_page, self._sel_start, end)
+        self._selection = selection if selection.isValid() and selection.text().strip() else None
+        self._refresh_overlay()
+
+    def select_page_region(self, page: int, start: QPointF, end: QPointF) -> str:
+        """Markiert den Text zwischen zwei Punkten (Seiten-Koordinaten in pt).
+
+        Fuer Tests und Skripte - die Maus macht dasselbe ueber den Viewport.
+        """
+        self.clear_selection()
+        if not self.is_showing_document() or not 0 <= page < self.page_count():
+            return ""
+        self._sel_page = page
+        self._sel_start = self._snap_to_text(page, start)
+        selection = self._document.getSelection(page, self._sel_start, self._snap_to_text(page, end))
+        self._selection = selection if selection.isValid() and selection.text().strip() else None
+        self._refresh_overlay()
+        return self.selected_text()
+
+    def _refresh_overlay(self, *_args) -> None:
+        overlay = getattr(self, "_overlay", None)
+        if overlay is None or sip.isdeleted(overlay):
+            return
+        polygons: list[QPolygonF] = []
+        if self._selection is not None and self._sel_page >= 0:
+            rect = self._page_rect_in_viewport(self._sel_page)
+            if rect is not None:
+                polygons = [
+                    self._polygon_to_viewport(rect, self._sel_page, poly)
+                    for poly in self._selection.bounds()
+                ]
+        overlay.set_polygons(polygons)
+
+    def _build_selection_menu(self) -> QMenu:
+        """Kontextmenue fuer den markierten Text (ohne exec, fuer Tests)."""
+        text = self.selected_text()
+        menu = QMenu(self)
+        for field_key, label in SELECTION_TARGETS:
+            action = menu.addAction(label)
+            action.setData(field_key)
+            action.triggered.connect(
+                lambda _checked=False, k=field_key, t=text: self.apply_text_requested.emit(k, t)
+            )
+        menu.addSeparator()
+        copy_action = menu.addAction("Kopieren")
+        copy_action.triggered.connect(lambda _checked=False, t=text: QApplication.clipboard().setText(t))
+        return menu
+
+    def _show_selection_menu(self, global_pos: QPoint) -> None:
+        self._build_selection_menu().exec(global_pos)
+
+    # -- Seitengeometrie (wie QPdfViewPrivate::calculateDocumentLayout) ---- #
+
+    @staticmethod
+    def _screen_resolution() -> float:
+        screen = QGuiApplication.primaryScreen()
+        return (screen.logicalDotsPerInch() / 72.0) if screen is not None else 1.0
+
+    def _page_geometries(self) -> dict[int, QRect]:
+        """Seiten-Rechtecke in Dokument-Koordinaten (Pixel, vor dem Scrollen)."""
+        count = self.page_count()
+        if count == 0:
+            return {}
+        view = self._view
+        viewport = view.viewport()
+        margins = view.documentMargins()
+        spacing = view.pageSpacing()
+        res = self._screen_resolution()
+        mode = view.zoomMode()
+
+        sizes: dict[int, QSize] = {}
+        total_width = 0
+        for page in range(count):
+            points = self._document.pagePointSize(page)
+            if mode == QPdfView.ZoomMode.Custom:
+                size = QSizeF(points * res * view.zoomFactor()).toSize()
+            elif mode == QPdfView.ZoomMode.FitToWidth:
+                size = QSizeF(points * res).toSize()
+                avail = viewport.width() - margins.left() - margins.right()
+                factor = avail / max(1, size.width())
+                size = QSize(round(size.width() * factor), round(size.height() * factor))
+            else:  # FitInView
+                avail = viewport.size() + QSize(-margins.left() - margins.right(), -spacing)
+                size = QSizeF(points * res).toSize().scaled(avail, Qt.AspectRatioMode.KeepAspectRatio)
+            sizes[page] = size
+            total_width = max(total_width, size.width())
+        total_width += margins.left() + margins.right()
+
+        geometries: dict[int, QRect] = {}
+        y = margins.top()
+        for page in range(count):
+            size = sizes[page]
+            x = (max(total_width, viewport.width()) - size.width()) // 2
+            geometries[page] = QRect(QPoint(x, y), size)
+            y += size.height() + spacing
+        return geometries
+
+    def _scroll_offset(self) -> QPoint:
+        return QPoint(self._view.horizontalScrollBar().value(), self._view.verticalScrollBar().value())
+
+    def _page_rect_in_viewport(self, page: int) -> QRect | None:
+        rect = self._page_geometries().get(page)
+        if rect is None:
+            return None
+        offset = self._scroll_offset()
+        return rect.translated(-offset.x(), -offset.y())
+
+    def _page_at(self, pos: QPoint) -> tuple[int, QRect] | None:
+        offset = self._scroll_offset()
+        for page, rect in self._page_geometries().items():
+            shifted = rect.translated(-offset.x(), -offset.y())
+            if shifted.contains(pos):
+                return page, shifted
+        return None
+
+    def _to_page_point(self, rect: QRect, page: int, pos: QPoint) -> QPointF:
+        """Viewport-Pixel -> Seiten-Koordinaten in pt (auf die Seite begrenzt)."""
+        points = self._document.pagePointSize(page)
+        sx = points.width() / max(1, rect.width())
+        sy = points.height() / max(1, rect.height())
+        x = min(max((pos.x() - rect.x()) * sx, 0.0), points.width())
+        y = min(max((pos.y() - rect.y()) * sy, 0.0), points.height())
+        return QPointF(x, y)
+
+    def _polygon_to_viewport(self, rect: QRect, page: int, polygon: QPolygonF) -> QPolygonF:
+        points = self._document.pagePointSize(page)
+        sx = rect.width() / max(1.0, points.width())
+        sy = rect.height() / max(1.0, points.height())
+        return QPolygonF([
+            QPointF(rect.x() + polygon[i].x() * sx, rect.y() + polygon[i].y() * sy)
+            for i in range(len(polygon))
+        ])
 
     def keyPressEvent(self, event):
         key = event.key()

--- a/src/gui/pdf_preview_window.py
+++ b/src/gui/pdf_preview_window.py
@@ -29,6 +29,8 @@ class PdfPreviewWindow(QMainWindow):
 
     open_external_requested = pyqtSignal(Path)
     geometry_changed = pyqtSignal(list)
+    # Markierter Text -> Metadaten-Feld (Issue #109), weitergereicht aus der Vorschau
+    apply_text_requested = pyqtSignal(str, str)
 
     def __init__(self, parent=None, geometry: list | None = None):
         super().__init__(parent)
@@ -39,6 +41,7 @@ class PdfPreviewWindow(QMainWindow):
 
         self.preview = PdfPreviewWidget(self, compact=False)
         self.preview.open_external_requested.connect(self.open_external_requested)
+        self.preview.apply_text_requested.connect(self.apply_text_requested)
         self.setCentralWidget(self.preview)
 
         QShortcut(QKeySequence(Qt.Key.Key_Escape), self, activated=self.close)

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -58,6 +58,14 @@ class SettingsDialog(QDialog):
         self._setup_ui()
         self._load_settings()
 
+    def show_tab(self, title: str) -> bool:
+        """Schaltet auf den Tab mit diesem Titel (z.B. "Dateinamen")."""
+        for idx in range(self.tab_widget.count()):
+            if self.tab_widget.tabText(idx) == title:
+                self.tab_widget.setCurrentIndex(idx)
+                return True
+        return False
+
     def _setup_ui(self):
         """Erstellt die Benutzeroberfläche."""
         self.setWindowTitle("Einstellungen")

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -261,7 +261,7 @@ class SettingsDialog(QDialog):
         src.core.filename_placeholders und landen genauso im KI-Prompt.
         """
         from PyQt6.QtWidgets import QComboBox, QGridLayout, QRadioButton, QSizePolicy, QToolButton
-        from src.core.filename_placeholders import PLACEHOLDERS, PRESETS, legend_html
+        from src.core.filename_placeholders import PLACEHOLDERS, legend_html
         from src.core.folder_naming import DEFAULT_TEMPLATE
 
         tab = QWidget()
@@ -276,10 +276,25 @@ class SettingsDialog(QDialog):
 
         # Vorlage (Combo) fuellt das Muster-Feld; Tippen schaltet auf "Eigenes"
         self.pattern_preset_combo = QComboBox()
-        for name, _pattern in PRESETS:
-            self.pattern_preset_combo.addItem(name)
+        self._pattern_presets: list[tuple[str, str | None]] = []
+        self._rebuild_pattern_presets()
         self.pattern_preset_combo.activated.connect(self._on_pattern_preset_activated)
-        form.addRow("Vorlage:", self.pattern_preset_combo)
+        preset_row = QHBoxLayout()
+        preset_row.setSpacing(6)
+        preset_row.addWidget(self.pattern_preset_combo, 1)
+        # Eigenes Muster unter einem Namen merken -> erscheint in der Vorlagen-
+        # Liste und als Muster-Vorschlag im Detail-Panel
+        self.pattern_save_btn = QPushButton("Muster speichern…")
+        self.pattern_save_btn.setToolTip(
+            "Das Muster im Feld unter einem Namen in die Vorlagen-Liste aufnehmen."
+        )
+        self.pattern_save_btn.clicked.connect(self._save_custom_pattern)
+        preset_row.addWidget(self.pattern_save_btn)
+        self.pattern_delete_btn = QPushButton("Löschen")
+        self.pattern_delete_btn.setToolTip("Das gewählte gespeicherte Muster aus der Liste entfernen.")
+        self.pattern_delete_btn.clicked.connect(self._delete_custom_pattern)
+        preset_row.addWidget(self.pattern_delete_btn)
+        form.addRow("Vorlage:", preset_row)
 
         self.pattern_input = QLineEdit()
         self.pattern_input.setPlaceholderText("leer = KI entscheidet selbst")
@@ -324,6 +339,35 @@ class SettingsDialog(QDialog):
         chips.addWidget(self.pattern_legend_toggle, last_row, per_row,
                         Qt.AlignmentFlag.AlignRight)
         chips.setColumnStretch(per_row, 1)
+
+        # Trennzeichen + Zuruecknehmen: Muster ganz ohne Tastatur zusammenklicken
+        sep_row = QHBoxLayout()
+        sep_row.setSpacing(4)
+        self.pattern_sep_buttons = []
+        for label, sep, tip in (
+            ("Leerzeichen", " ", "Leerzeichen einfuegen"),
+            ("_", "_", "Unterstrich einfuegen"),
+            ("-", "-", "Bindestrich einfuegen"),
+        ):
+            btn = QPushButton(label)
+            btn.setToolTip(tip)
+            btn.setStyleSheet(
+                "QPushButton { padding: 1px 8px; font-family: monospace; font-size: 11px; }"
+            )
+            btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+            btn.clicked.connect(lambda _checked=False, s=sep: self._insert_separator(s))
+            sep_row.addWidget(btn)
+            self.pattern_sep_buttons.append(btn)
+        sep_row.addStretch(1)
+        self.pattern_undo_btn = QPushButton("⌫ Zurücknehmen")
+        self.pattern_undo_btn.setToolTip(
+            "Letzten Baustein vor dem Cursor entfernen (ganzer Platzhalter oder ein Trennzeichen)"
+        )
+        self.pattern_undo_btn.setStyleSheet("QPushButton { padding: 1px 8px; font-size: 11px; }")
+        self.pattern_undo_btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.pattern_undo_btn.clicked.connect(self._remove_last_pattern_token)
+        sep_row.addWidget(self.pattern_undo_btn)
+        chips.addLayout(sep_row, last_row + 1, 0, 1, per_row + 1)
         form.addRow("", chips_widget)
 
         self.pattern_legend_label = QLabel(legend_html())
@@ -417,12 +461,84 @@ class SettingsDialog(QDialog):
 
     def _on_pattern_preset_activated(self, index: int):
         """Vorlage gewaehlt -> Muster-Feld befuellen ("Eigenes": Feld behalten)."""
-        from src.core.filename_placeholders import PRESETS
-        _name, pattern = PRESETS[index]
+        _name, pattern = self._pattern_presets[index]
         if pattern is None:
             self.pattern_input.setFocus()
             return
         self.pattern_input.setText(pattern)
+
+    # -- Gespeicherte Muster ------------------------------------------------ #
+
+    def _custom_patterns(self) -> list[tuple[str, str]]:
+        from src.core.filename_placeholders import CUSTOM_PATTERNS_KEY, load_custom_patterns
+        return load_custom_patterns(self.config.get(CUSTOM_PATTERNS_KEY, []))
+
+    def _store_custom_patterns(self, patterns: list[tuple[str, str]]):
+        from src.core.filename_placeholders import CUSTOM_PATTERNS_KEY
+        self.config.set(CUSTOM_PATTERNS_KEY, [{"name": n, "pattern": p} for n, p in patterns])
+
+    def _rebuild_pattern_presets(self):
+        """Combo neu befuellen: eingebaute Vorlagen, gespeicherte Muster, "Eigenes"."""
+        from src.core.filename_placeholders import all_presets
+        self._pattern_presets = all_presets(self._custom_patterns())
+        self.pattern_preset_combo.blockSignals(True)
+        self.pattern_preset_combo.clear()
+        for name, _pattern in self._pattern_presets:
+            self.pattern_preset_combo.addItem(name)
+        self.pattern_preset_combo.blockSignals(False)
+
+    def _selected_custom_pattern(self) -> tuple[str, str] | None:
+        """(Name, Muster), wenn die Combo gerade ein gespeichertes Muster zeigt."""
+        from src.core.filename_placeholders import builtin_pattern_names
+        idx = self.pattern_preset_combo.currentIndex()
+        if not 0 <= idx < len(self._pattern_presets):
+            return None
+        name, pattern = self._pattern_presets[idx]
+        if pattern is None or name in builtin_pattern_names():
+            return None
+        return name, pattern
+
+    def _update_custom_pattern_buttons(self):
+        from src.core.filename_placeholders import PRESETS
+        text = self.pattern_input.text().strip()
+        is_builtin = any(p == text for _n, p in PRESETS if p)
+        self.pattern_save_btn.setEnabled(bool(text) and not is_builtin)
+        self.pattern_delete_btn.setEnabled(self._selected_custom_pattern() is not None)
+
+    def _save_custom_pattern(self):
+        """"Muster speichern…": Namen erfragen, in die Config schreiben, Combo neu."""
+        from PyQt6.QtWidgets import QInputDialog
+        pattern = self.pattern_input.text().strip()
+        if not pattern:
+            return
+        existing = self._custom_patterns()
+        default_name = next((n for n, p in existing if p == pattern), "")
+        name, ok = QInputDialog.getText(
+            self, "Muster speichern", "Name für dieses Muster:", text=default_name
+        )
+        name = (name or "").strip()
+        if not ok or not name:
+            return
+        from src.core.filename_placeholders import builtin_pattern_names
+        if name in builtin_pattern_names():
+            QMessageBox.warning(self, "Muster speichern",
+                                f"„{name}“ ist eine eingebaute Vorlage - bitte einen anderen Namen wählen.")
+            return
+        # Gleicher Name oder gleiches Muster -> Eintrag ersetzen
+        patterns = [(n, p) for n, p in existing if n.lower() != name.lower() and p != pattern]
+        patterns.append((name, pattern))
+        self._store_custom_patterns(patterns)
+        self._rebuild_pattern_presets()
+        self._sync_pattern_combo(pattern)
+
+    def _delete_custom_pattern(self):
+        selected = self._selected_custom_pattern()
+        if selected is None:
+            return
+        name, _pattern = selected
+        self._store_custom_patterns([(n, p) for n, p in self._custom_patterns() if n != name])
+        self._rebuild_pattern_presets()
+        self._sync_pattern_combo(self.pattern_input.text())
 
     def _on_pattern_text_changed(self, text: str):
         self._sync_pattern_combo(text)
@@ -430,20 +546,56 @@ class SettingsDialog(QDialog):
 
     def _sync_pattern_combo(self, text: str):
         """Combo auf die passende Vorlage stellen, sonst auf "Eigenes"."""
-        from src.core.filename_placeholders import PRESETS
         text = text.strip()
-        index = len(PRESETS) - 1
-        for i, (_name, pattern) in enumerate(PRESETS):
+        index = len(self._pattern_presets) - 1
+        for i, (_name, pattern) in enumerate(self._pattern_presets):
             if pattern is not None and pattern == text:
                 index = i
                 break
         self.pattern_preset_combo.blockSignals(True)
         self.pattern_preset_combo.setCurrentIndex(index)
         self.pattern_preset_combo.blockSignals(False)
+        self._update_custom_pattern_buttons()
+
+    _PATTERN_SEPARATORS = " _-"
 
     def _insert_placeholder(self, key: str):
-        """Chip geklickt -> Platzhalter an der Cursorposition einfuegen."""
-        self.pattern_input.insert("{" + key + "}")
+        """Chip geklickt -> Platzhalter an der Cursorposition einfuegen.
+
+        Steht davor bereits etwas, aber kein Trennzeichen, kommt automatisch
+        ein "_" dazwischen - so laesst sich ein Muster nur mit Chips
+        zusammenklicken. Wer "-" oder Leerzeichen will, klickt das vorher.
+        """
+        before = self.pattern_input.text()[: self.pattern_input.cursorPosition()]
+        sep = "_" if before and before[-1] not in self._PATTERN_SEPARATORS else ""
+        self.pattern_input.insert(sep + "{" + key + "}")
+        self.pattern_input.setFocus()
+
+    def _insert_separator(self, sep: str):
+        """Trennzeichen-Knopf -> an der Cursorposition einfuegen."""
+        self.pattern_input.insert(sep)
+        self.pattern_input.setFocus()
+
+    def _remove_last_pattern_token(self):
+        """Baustein vor dem Cursor entfernen: ganzer {platzhalter} oder ein Zeichen.
+
+        Ein Chip-Klick = Trennzeichen + Platzhalter, ein Klick auf
+        "Zuruecknehmen" macht genau das wieder rueckgaengig.
+        """
+        text = self.pattern_input.text()
+        pos = self.pattern_input.cursorPosition()
+        before, after = text[:pos], text[pos:]
+        if not before:
+            return
+        if before.endswith("}") and "{" in before:
+            before = before[:before.rfind("{")]
+            # das automatisch eingefuegte Trennzeichen gehoert zum Baustein
+            if before and before[-1] in self._PATTERN_SEPARATORS:
+                before = before[:-1]
+        else:
+            before = before[:-1]
+        self.pattern_input.setText(before + after)
+        self.pattern_input.setCursorPosition(len(before))
         self.pattern_input.setFocus()
 
     def _toggle_pattern_legend(self, checked: bool):

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -318,10 +318,12 @@ class SettingsDialog(QDialog):
         )
         self.pattern_legend_toggle.setAutoRaise(True)
         self.pattern_legend_toggle.toggled.connect(self._toggle_pattern_legend)
+        # Eigene Spalte rechts neben den Chips - nie in der Zelle eines Chips
+        # (bei vollen Zeilen lag der Knopf sonst ueber dem letzten Chip)
         last_row = (len(PLACEHOLDERS) - 1) // per_row
-        chips.addWidget(self.pattern_legend_toggle, last_row, per_row - 1,
+        chips.addWidget(self.pattern_legend_toggle, last_row, per_row,
                         Qt.AlignmentFlag.AlignRight)
-        chips.setColumnStretch(per_row - 1, 1)
+        chips.setColumnStretch(per_row, 1)
         form.addRow("", chips_widget)
 
         self.pattern_legend_label = QLabel(legend_html())

--- a/src/ml/claude_provider.py
+++ b/src/ml/claude_provider.py
@@ -180,6 +180,7 @@ class ClaudeProvider(LLMProvider):
         detected_date: str = None,
         target_folder: str = None,
         file_date: str = None,
+        examples: list[str] | None = None,
     ) -> LLMResponse:
         """
         Schlägt einen Dateinamen mit Claude vor.
@@ -202,7 +203,8 @@ class ClaudeProvider(LLMProvider):
             )
 
         prompt = self._build_filename_prompt(
-            text, current_filename, keywords, detected_date, target_folder, file_date
+            text, current_filename, keywords, detected_date, target_folder, file_date,
+            examples=examples,
         )
 
         try:

--- a/src/ml/hybrid_classifier.py
+++ b/src/ml/hybrid_classifier.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Optional
 from dataclasses import dataclass
 
+import logging
+
 from src.ml.classifier import PDFClassifier, Suggestion, get_classifier
 from src.ml.llm_provider import LLMProvider, LLMConfig, LLMResponse, LLMProviderType
 from src.ml.claude_provider import ClaudeProvider
@@ -19,6 +21,9 @@ from src.ml.poe_provider import PoeProvider
 from src.ml.openrouter_provider import OpenRouterProvider
 from src.ml.ollama_provider import OllamaProvider, OllamaCloudProvider
 from src.utils.config import get_config
+from src.utils.database import get_database
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -454,6 +459,19 @@ class HybridClassifier:
 
         return suggestions
 
+    def _rename_examples(self, text: str, keywords: list[str] | None) -> list[str]:
+        """Dateinamen, die der Nutzer fuer aehnliche Dokumente gewaehlt hat.
+
+        Gehen als Stil-Beispiele in den KI-Prompt; was der Nutzer danach
+        waehlt oder korrigiert, wird beim naechsten Mal selbst zum Beispiel.
+        """
+        try:
+            entries = get_database().get_rename_examples(text, keywords, limit=5)
+        except Exception as e:  # noqa: BLE001 - Beispiele sind optional
+            logger.debug(f"Historien-Beispiele nicht verfuegbar: {e}")
+            return []
+        return [e.new_filename for e in entries if e.new_filename]
+
     def _get_llm_filename_suggestion(
         self,
         text: str,
@@ -475,6 +493,7 @@ class HybridClassifier:
             detected_date=detected_date,
             target_folder=target_folder,
             file_date=file_date,
+            examples=self._rename_examples(text, keywords),
         )
 
         self.total_tokens_used += response.tokens_used

--- a/src/ml/llm_provider.py
+++ b/src/ml/llm_provider.py
@@ -226,6 +226,7 @@ class LLMProvider(ABC):
         detected_date: str = None,
         target_folder: str = None,
         file_date: str = None,
+        examples: list[str] | None = None,
     ) -> LLMResponse:
         """
         Schlägt einen Dateinamen für das Dokument vor.
@@ -237,6 +238,7 @@ class LLMProvider(ABC):
             detected_date: Erkanntes Datum im Dokument
             target_folder: Zielordner (falls bekannt)
             file_date: Änderungsdatum der Datei (Fallback wenn kein Datum im Dokument)
+            examples: Dateinamen, die der Nutzer fuer aehnliche Dokumente gewaehlt hat
 
         Returns:
             LLMResponse mit Dateinamenvorschlag und Begründung
@@ -379,6 +381,7 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
         detected_date: str = None,
         target_folder: str = None,
         file_date: str = None,
+        examples: list[str] | None = None,
     ) -> str:
         """
         Erstellt den Prompt für Dateinamenvorschläge.
@@ -390,6 +393,7 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
             detected_date: Erkanntes Datum im Dokument
             target_folder: Zielordner (falls bekannt)
             file_date: Änderungsdatum der Datei (Fallback wenn kein Datum im Dokument)
+            examples: Dateinamen aehnlicher Dokumente aus der Historie (Stil-Beispiele)
 
         Returns:
             Formatierter Prompt (JSON Format gefordert)
@@ -412,6 +416,8 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
 
         owner_info = self._build_owner_info()
         pattern_info = self._build_filename_pattern_info()
+        from src.core.rename_examples import describe_examples_for_prompt
+        examples_info = describe_examples_for_prompt(examples or [])
 
         return f"""Du bist ein Assistent zum Benennen und Analysieren von Dokumenten. Schlage einen aussagekräftigen Dateinamen vor und extrahiere Metadaten.
 {owner_info}
@@ -420,7 +426,7 @@ AKTUELLER DATEINAME: {current_filename}
 DOKUMENTINHALT:
 {self._truncate_text(text)}
 {keyword_info}{date_info}{file_date_info}{folder_info}
-{pattern_info}
+{pattern_info}{examples_info}
 
 REGELN FÜR DEN DATEINAMEN:
 1. Format (falls nicht durch Muster vorgegeben): YYYY-MM-DD_Kategorie_Beschreibung.pdf

--- a/src/ml/ollama_provider.py
+++ b/src/ml/ollama_provider.py
@@ -298,11 +298,15 @@ class OllamaProvider(LLMProvider):
         detected_date: str = None,
         target_folder: str = None,
         file_date: str = None,
+        examples: list[str] | None = None,
     ) -> LLMResponse:
         if not self.is_available():
             return LLMResponse(success=False, error_message="Ollama-Provider nicht konfiguriert.")
 
-        prompt = self._build_filename_prompt(text, current_filename, keywords, detected_date, target_folder, file_date)
+        prompt = self._build_filename_prompt(
+            text, current_filename, keywords, detected_date, target_folder, file_date,
+            examples=examples,
+        )
         system_prompt = "Du bist ein Assistent zum Benennen von Dokumenten. Antworte AUSSCHLIESSLICH mit einem validem JSON-Objekt."
 
         response_text, error = self._chat(system_prompt, prompt, json_mode=True)

--- a/src/ml/openai_provider.py
+++ b/src/ml/openai_provider.py
@@ -191,6 +191,7 @@ class OpenAIProvider(LLMProvider):
         detected_date: str = None,
         target_folder: str = None,
         file_date: str = None,
+        examples: list[str] | None = None,
     ) -> LLMResponse:
         """
         Schlägt einen Dateinamen mit OpenAI vor.
@@ -213,7 +214,8 @@ class OpenAIProvider(LLMProvider):
             )
 
         prompt = self._build_filename_prompt(
-            text, current_filename, keywords, detected_date, target_folder, file_date
+            text, current_filename, keywords, detected_date, target_folder, file_date,
+            examples=examples,
         )
 
         try:

--- a/src/ml/poe_provider.py
+++ b/src/ml/poe_provider.py
@@ -225,6 +225,7 @@ class PoeProvider(LLMProvider):
         detected_date: str = None,
         target_folder: str = None,
         file_date: str = None,
+        examples: list[str] | None = None,
     ) -> LLMResponse:
         """
         Schlägt einen Dateinamen mit Poe vor.
@@ -247,7 +248,8 @@ class PoeProvider(LLMProvider):
             )
 
         prompt = self._build_filename_prompt(
-            text, current_filename, keywords, detected_date, target_folder, file_date
+            text, current_filename, keywords, detected_date, target_folder, file_date,
+            examples=examples,
         )
 
         try:

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -66,6 +66,9 @@ class Config:
         # Benutzerdefiniertes Dateinamen-Muster (leer = LLM-Default).
         # Wird als Few-Shot-Hinweis in den Filename-Prompt eingeflochten.
         "filename_pattern": "",
+        # Rangfolge der Vorschlagsarten im Detail-Panel (Issue #106): zuletzt
+        # angeklickte Art zuerst; leer = Standard-Reihenfolge (KI, Muster, ...)
+        "suggestion_kind_order": [],
         # Dateiname aus Ordnerstruktur beim Verschieben (Issue #42), Opt-in.
         "folder_naming_enabled": False,
         "folder_naming_template": "{initialen} {ordnernummern}-{datum}-{text}",

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -66,6 +66,8 @@ class Config:
         # Benutzerdefiniertes Dateinamen-Muster (leer = LLM-Default).
         # Wird als Few-Shot-Hinweis in den Filename-Prompt eingeflochten.
         "filename_pattern": "",
+        # Vom Nutzer gespeicherte Dateinamen-Muster: [{"name": ..., "pattern": ...}]
+        "custom_patterns": [],
         # Rangfolge der Vorschlagsarten im Detail-Panel (Issue #106): zuletzt
         # angeklickte Art zuerst; leer = Standard-Reihenfolge (KI, Muster, ...)
         "suggestion_kind_order": [],

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -71,6 +71,8 @@ class Config:
         # Rangfolge der Vorschlagsarten im Detail-Panel (Issue #106): zuletzt
         # angeklickte Art zuerst; leer = Standard-Reihenfolge (KI, Muster, ...)
         "suggestion_kind_order": [],
+        # Zuletzt verwendete Kategorien fuer die Aufklappliste (Issue #110)
+        "recent_categories": [],
         # Dateiname aus Ordnerstruktur beim Verschieben (Issue #42), Opt-in.
         "folder_naming_enabled": False,
         "folder_naming_template": "{initialen} {ordnernummern}-{datum}-{text}",

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -1149,6 +1149,23 @@ class Database:
         except Exception:
             return []
 
+    def get_top_kategorien(self, limit: int = 10) -> list[str]:
+        """Die haeufigsten Kategorien der Sammlung, haeufigste zuerst (Issue #110)."""
+        import sqlite3
+        try:
+            conn = sqlite3.connect(str(self.db_path))
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT kategorie, COUNT(*) AS n FROM document_search "
+                "WHERE kategorie != '' GROUP BY kategorie ORDER BY n DESC, kategorie LIMIT ?",
+                (int(limit),),
+            )
+            result = [row[0] for row in cursor.fetchall()]
+            conn.close()
+            return result
+        except Exception:
+            return []
+
     def get_distinct_korrespondenten(self) -> list[str]:
         """Gibt sortierte Liste eindeutiger Korrespondenten zurück."""
         import sqlite3

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -1640,6 +1640,28 @@ class Database:
         finally:
             session.close()
 
+    def get_rename_examples(
+        self, text: str, keywords: list[str] | None, limit: int = 5
+    ) -> list[RenameHistory]:
+        """Umbenennungen aehnlicher Dokumente als Stil-Beispiele fuer die KI.
+
+        Aehnlichkeit siehe :mod:`src.core.rename_examples` - ein einzelnes
+        gemeinsames Stichwort reicht nicht.
+        """
+        from src.core.rename_examples import rank_examples
+
+        session = self.get_session()
+        try:
+            rows = (
+                session.query(RenameHistory)
+                .order_by(RenameHistory.created_at.desc())
+                .limit(2000)
+                .all()
+            )
+            return rank_examples(rows, text or "", keywords or [], limit=limit)
+        finally:
+            session.close()
+
     def get_rename_suggestions_by_folder(
         self, target_folder: str, limit: int = 5
     ) -> list[RenameHistory]:

--- a/tests/test_detail_panel_llm_refresh_gui.py
+++ b/tests/test_detail_panel_llm_refresh_gui.py
@@ -75,3 +75,19 @@ def test_settings_change_refreshes_header_switch(main_window):
     main_window._on_settings_changed()
     assert main_window.detail_panel.folder_naming_checkbox.isChecked()
 
+
+def test_big_preview_window_applies_text_to_detail_panel(main_window, tmp_path):
+    """Markieren im Fenster "Gross" landet im Detail-Panel - aber nur fuer dieselbe PDF."""
+    pdf = _prepare(main_window, tmp_path)
+    main_window.show_preview_window(pdf)
+    win = main_window._preview_window
+    win.preview._current_path = pdf  # load_pdf ist im Test abgeschaltet
+
+    win.preview.apply_text_requested.emit("korrespondent", "Commerzbank AG")
+    assert main_window.detail_panel.get_metadata()["korrespondent"] == "Commerzbank AG"
+
+    # Fenster zeigt eine andere PDF: nichts uebernehmen
+    win.preview._current_path = tmp_path / "andere.pdf"
+    win.preview.apply_text_requested.emit("iban", "DE89 3704 0044 0532 0130 00")
+    assert "iban" not in main_window.detail_panel.get_metadata()
+

--- a/tests/test_detail_panel_llm_refresh_gui.py
+++ b/tests/test_detail_panel_llm_refresh_gui.py
@@ -53,3 +53,25 @@ def test_no_update_for_other_pdf(main_window, tmp_path):
     _llm_arrives(main_window, other)
     assert main_window.detail_panel.name_input.text() == ""
     assert main_window.detail_panel.get_current_pdf() == pdf
+
+
+def test_edit_pattern_button_opens_settings_on_dateinamen_tab(main_window, monkeypatch):
+    """"Muster bearbeiten" in der Vorschlags-Kopfzeile -> Einstellungen, Tab Dateinamen."""
+    from src.gui import main_window as mw_mod
+    seen = {}
+
+    def fake_exec(self):
+        seen["tab"] = self.tab_widget.tabText(self.tab_widget.currentIndex())
+        return 0
+
+    monkeypatch.setattr(mw_mod.SettingsDialog, "exec", fake_exec)
+    main_window.detail_panel.edit_pattern_btn.click()
+    assert seen["tab"] == "Dateinamen"
+
+
+def test_settings_change_refreshes_header_switch(main_window):
+    cfg = main_window.config
+    cfg.set("folder_naming_enabled", True, auto_save=False)
+    main_window._on_settings_changed()
+    assert main_window.detail_panel.folder_naming_checkbox.isChecked()
+

--- a/tests/test_detail_panel_pattern_suggestions_gui.py
+++ b/tests/test_detail_panel_pattern_suggestions_gui.py
@@ -327,3 +327,28 @@ def test_known_korrespondent_in_text_beats_ki_suggestion(qtbot, monkeypatch, tmp
                   detected_date="2024-01-31")
     assert panel.get_metadata()["korrespondent"] == "Testfirma GmbH"
 
+
+def test_new_settings_pattern_is_applied_immediately(qtbot, monkeypatch, tmp_path):
+    """Einstellungen > Dateinamen gespeichert -> neues Muster oben + im Namensfeld."""
+    panel, cfg = _panel(qtbot, monkeypatch, tmp_path, owner_initials="JW")
+    _select(panel, tmp_path, [_ki_suggestion()] + _analysis_suggestions())
+    assert _reasons(panel)[0] == "KI-Vorschlag"
+    panel.name_input.setText("Selbst getippt")  # wird bewusst ueberschrieben
+
+    cfg.set("filename_pattern", "{jahr}_{kontakt}_Miete", auto_save=False)
+    panel.refresh_settings()  # macht MainWindow._on_settings_changed
+
+    assert _reasons(panel)[0] == "Muster: Eigenes Muster"
+    assert panel.name_input.text() == "2024_Testfirma-GmbH_Miete"
+    assert not panel.has_user_edits()
+    assert cfg.get(CONFIG_KEY)[0] == pattern_kind("{jahr}_{kontakt}_Miete")
+
+    # Naechste PDF: bleibt oben
+    _select(panel, tmp_path, [_ki_suggestion("2024-02-01_Rechnung_Andere.pdf")])
+    assert _reasons(panel)[0] == "Muster: Eigenes Muster"
+
+    # Unveraenderte Einstellungen: nichts passiert, Nutzertext bleibt
+    panel.name_input.setText("Mein Name")
+    panel.refresh_settings()
+    assert panel.name_input.text() == "Mein Name"
+

--- a/tests/test_detail_panel_pattern_suggestions_gui.py
+++ b/tests/test_detail_panel_pattern_suggestions_gui.py
@@ -224,3 +224,26 @@ def test_pdf_metadata_arriving_later_updates_auto_name_only(qtbot, monkeypatch, 
     panel.name_input.setText("Mein Name")
     panel._on_pdf_metadata_read(pdf, PDFMetadata(korrespondent="Dritte KG"))
     assert panel.name_input.text() == "Mein Name"
+
+
+def test_header_folder_naming_switch_mirrors_config(qtbot, monkeypatch, tmp_path):
+    panel, cfg = _panel(qtbot, monkeypatch, tmp_path, folder_naming_enabled=True)
+    _select(panel, tmp_path, [_ki_suggestion()])
+    assert panel.folder_naming_checkbox.isChecked()
+
+    # Schalter schreibt die Config (dieselbe Einstellung wie im Dialog)
+    panel.folder_naming_checkbox.setChecked(False)
+    assert cfg.get("folder_naming_enabled") is False
+    assert (tmp_path / "config.json").exists()
+
+    # Dialog aendert die Config -> refresh_settings zieht den Schalter nach
+    cfg.set("folder_naming_enabled", True, auto_save=False)
+    panel.refresh_settings()
+    assert panel.folder_naming_checkbox.isChecked()
+
+
+def test_header_edit_pattern_button_emits_signal(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
+    with qtbot.waitSignal(panel.edit_pattern_requested, timeout=1000):
+        panel.edit_pattern_btn.click()
+

--- a/tests/test_detail_panel_pattern_suggestions_gui.py
+++ b/tests/test_detail_panel_pattern_suggestions_gui.py
@@ -247,3 +247,12 @@ def test_header_edit_pattern_button_emits_signal(qtbot, monkeypatch, tmp_path):
     with qtbot.waitSignal(panel.edit_pattern_requested, timeout=1000):
         panel.edit_pattern_btn.click()
 
+
+def test_saved_custom_pattern_becomes_a_row(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path,
+                      custom_patterns=[{"name": "Mieter", "pattern": "{jahr}_{kontakt}_Miete"}])
+    _select(panel, tmp_path, [_ki_suggestion()])
+    rows = _rows(panel)
+    assert "2024_Testfirma-GmbH_Miete.pdf  [Muster: Mieter]" in rows
+    assert _reasons(panel)[-1] == "Muster: Mieter"  # nach den eingebauten Vorlagen
+

--- a/tests/test_detail_panel_pattern_suggestions_gui.py
+++ b/tests/test_detail_panel_pattern_suggestions_gui.py
@@ -1,12 +1,16 @@
-"""Issue #99: Muster-Vorschlaege im Detail-Panel.
+"""Issues #99/#106: Einheitliche Vorschlagsliste im Detail-Panel.
 
-Die Vorschlagsliste zeigt zusaetzlich den Dateinamen nach dem Muster aus
-Einstellungen > Dateinamen (oder einer anderen Vorlage), gerendert aus den
-Metadaten der ausgewaehlten PDF; per Combo laesst sich das Muster umschalten.
+Die Liste zeigt KI-Vorschlaege, je Vorlage (und eigenem Einstellungs-Muster)
+einen Muster-Vorschlag aus den Metadaten der PDF sowie die einfachen
+Analyse-Vorschlaege - alles in einer Liste, sortiert nach der gemerkten
+Rangfolge: die zuletzt angeklickte Art steht beim naechsten Dokument oben
+und wird als Dateiname uebernommen.
 """
+from src.core.suggestion_order import CONFIG_KEY, KIND_AUTO, KIND_KI, pattern_kind
 from src.gui.rename_dialog import RenameSuggestion
 
 RECHNUNGEN = "{datum}_{kategorie}_{kontakt}_{betreff}"
+AKTEN = "{initialen}_{aktenzeichen}_{datum}_{betreff}_{kontakt}"
 BUERO = "{initialen} {datum}-{betreff}"
 
 
@@ -43,9 +47,22 @@ def _ki_suggestion(name="2024-01-31_Rechnung_Testfirma.pdf"):
     )
 
 
+def _analysis_suggestions():
+    return [
+        RenameSuggestion("Dokument.pdf", "Automatisch erkannt", 0.6),
+        RenameSuggestion("2024-01-31.pdf", "Nur Datum", 0.3),
+        RenameSuggestion("2024-01-31 Rechnung.pdf", "Datum + Kategorie (Rechnung)", 0.5),
+        RenameSuggestion("Rechnung Nr4711.pdf", "Kategorie + Nummer", 0.4),
+    ]
+
+
 def _rows(panel):
     lst = panel.suggestions_list
     return [lst.item(i).text() for i in range(lst.count())]
+
+
+def _reasons(panel):
+    return [row.split("  [")[1].rstrip("]") for row in _rows(panel)]
 
 
 def _select(panel, tmp_path, suggestions, detected_date="2024-01-31"):
@@ -56,98 +73,149 @@ def _select(panel, tmp_path, suggestions, detected_date="2024-01-31"):
     return pdf
 
 
-def test_settings_pattern_becomes_a_suggestion(qtbot, monkeypatch, tmp_path):
-    panel, _ = _panel(qtbot, monkeypatch, tmp_path, filename_pattern=RECHNUNGEN)
-    _select(panel, tmp_path, [_ki_suggestion(),
-                              RenameSuggestion("Dokument.pdf", "Automatisch erkannt", 0.5)])
+def test_unified_list_ki_then_all_patterns_then_analysis(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path, owner_initials="JW")
+    _select(panel, tmp_path, [_ki_suggestion()] + _analysis_suggestions())
 
+    assert _reasons(panel) == [
+        "KI-Vorschlag",
+        "Muster: Rechnungen & Belege",
+        "Muster: Akten & Projekte",
+        "Muster: Büro-Kürzel voran",
+        "Automatisch erkannt",
+        "Datum + Kategorie (Rechnung)",
+        "Kategorie + Nummer",
+    ]
     rows = _rows(panel)
-    assert rows[0].startswith("2024-01-31_Rechnung_Testfirma.pdf")
-    assert rows[1] == (
-        "2024-01-31_Rechnung_Testfirma-GmbH_Beratung-im-Maerz-2024.pdf  [Muster: Rechnungen & Belege]"
-    )
-    assert rows[2].startswith("Dokument.pdf")
-    # Combo steht auf dem Einstellungs-Muster
-    assert panel.pattern_combo.currentData() == RECHNUNGEN
-    # Name bleibt der KI-Vorschlag (Muster-Vorschlag draengt sich nicht vor)
+    assert rows[1].startswith("2024-01-31_Rechnung_Testfirma-GmbH_Beratung-im-Maerz-2024.pdf")
+    assert rows[2].startswith("JW_2024-01-31_Beratung-im-Maerz-2024_Testfirma-GmbH.pdf")
+    assert rows[3].startswith("JW 2024-01-31-Beratung-im-Maerz-2024.pdf")
+    # Keine Muster-Combo mehr (#106)
+    assert not hasattr(panel, "pattern_combo")
+    # Oberste Zeile = Dateiname, gilt nicht als Nutzer-Aenderung
     assert panel.name_input.text() == "2024-01-31_Rechnung_Testfirma"
     assert not panel.has_user_edits()
 
 
-def test_standard_pattern_adds_no_row(qtbot, monkeypatch, tmp_path):
-    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
+def test_settings_pattern_ranks_first_among_patterns(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path, filename_pattern=BUERO, owner_initials="JW")
     _select(panel, tmp_path, [_ki_suggestion()])
-    assert panel.pattern_combo.currentIndex() == 0
-    assert panel.pattern_combo.currentData() == ""
-    assert len(_rows(panel)) == 1
+    assert _reasons(panel) == [
+        "KI-Vorschlag", "Muster: Büro-Kürzel voran",
+        "Muster: Rechnungen & Belege", "Muster: Akten & Projekte",
+    ]
 
 
-def test_no_row_without_any_metadata(qtbot, monkeypatch, tmp_path):
+def test_custom_settings_pattern_gets_own_row(qtbot, monkeypatch, tmp_path):
     panel, _ = _panel(qtbot, monkeypatch, tmp_path, filename_pattern="{kontakt}_{betreff}")
+    _select(panel, tmp_path, [_ki_suggestion()])
+    assert _rows(panel)[1] == "Testfirma-GmbH_Beratung-im-Maerz-2024.pdf  [Muster: Eigenes Muster]"
+
+
+def test_no_rows_without_any_metadata(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
     _select(panel, tmp_path, [], detected_date=None)
     assert _rows(panel) == ["Keine Vorschläge verfügbar"]
+    assert panel.name_input.text() == ""
 
 
-def test_switching_pattern_updates_row_and_name(qtbot, monkeypatch, tmp_path):
-    panel, _ = _panel(qtbot, monkeypatch, tmp_path, filename_pattern=RECHNUNGEN,
-                      owner_initials="JW")
-    _select(panel, tmp_path, [_ki_suggestion()])
+def test_patterns_with_fewer_than_two_values_are_skipped(qtbot, monkeypatch, tmp_path):
+    # Nur Datum + Kategorie (aus Stichwort), keine Initialen: Rechnungen rendert
+    # zwei Werte, Akten und Buero haetten nur das Datum -> weg
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
+    _select(panel, tmp_path, [RenameSuggestion("Dokument.pdf", "Automatisch erkannt", 0.6)])
+    assert _reasons(panel) == ["Muster: Rechnungen & Belege", "Automatisch erkannt"]
+    assert _rows(panel)[0].startswith("2024-01-31_Rechnung.pdf")
 
-    idx = panel.pattern_combo.findData(BUERO)
-    assert idx > 0
-    panel.pattern_combo.setCurrentIndex(idx)
-    panel.pattern_combo.activated.emit(idx)
 
-    assert _rows(panel)[1] == "JW 2024-01-31-Beratung-im-Maerz-2024.pdf  [Muster: Büro-Kürzel voran]"
+def test_clicking_a_pattern_makes_it_default_for_next_pdf(qtbot, monkeypatch, tmp_path):
+    panel, cfg = _panel(qtbot, monkeypatch, tmp_path, owner_initials="JW")
+    _select(panel, tmp_path, [_ki_suggestion()] + _analysis_suggestions())
+
+    # Buero-Muster anklicken: Name uebernommen, Liste bleibt fuer DIESES Dokument stehen
+    idx = _reasons(panel).index("Muster: Büro-Kürzel voran")
+    panel._on_suggestion_clicked(panel.suggestions_list.item(idx))
     assert panel.name_input.text() == "JW 2024-01-31-Beratung-im-Maerz-2024"
+    assert _reasons(panel)[0] == "KI-Vorschlag"
+    assert cfg.get(CONFIG_KEY)[:2] == [pattern_kind(BUERO), KIND_KI]
+    assert (tmp_path / "config.json").exists()  # persistiert
 
-    # Zurueck auf Standard: Zeile weg, Name bleibt wie zuletzt gewaehlt
-    panel.pattern_combo.setCurrentIndex(0)
-    panel.pattern_combo.activated.emit(0)
-    assert len(_rows(panel)) == 1
+    # Naechstes Dokument: Buero-Muster ganz oben, Rest eine Stufe tiefer, Name = Buero
+    _select(panel, tmp_path, [_ki_suggestion("2024-02-01_Rechnung_Andere.pdf")] + _analysis_suggestions())
+    assert _reasons(panel)[:3] == [
+        "Muster: Büro-Kürzel voran", "KI-Vorschlag", "Muster: Rechnungen & Belege",
+    ]
     assert panel.name_input.text() == "JW 2024-01-31-Beratung-im-Maerz-2024"
+    assert not panel.has_user_edits()
+
+    # Jetzt "Automatisch erkannt": wird neuer Default, Buero rueckt auf 2
+    idx = _reasons(panel).index("Automatisch erkannt")
+    panel._on_suggestion_clicked(panel.suggestions_list.item(idx))
+    _select(panel, tmp_path, [_ki_suggestion()] + _analysis_suggestions())
+    assert _reasons(panel)[:3] == [
+        "Automatisch erkannt", "Muster: Büro-Kürzel voran", "KI-Vorschlag",
+    ]
+    assert panel.name_input.text() == "Dokument"
+    assert cfg.get(CONFIG_KEY)[:2] == [KIND_AUTO, pattern_kind(BUERO)]
 
 
-def test_custom_settings_pattern_gets_own_entry(qtbot, monkeypatch, tmp_path):
-    from src.core.filename_placeholders import PATTERN_CHOICE_SETTINGS
-    panel, _ = _panel(qtbot, monkeypatch, tmp_path, filename_pattern="{kontakt}_{lieferant}")
-    _select(panel, tmp_path, [_ki_suggestion()])
-    assert panel.pattern_combo.currentText() == PATTERN_CHOICE_SETTINGS
-    assert _rows(panel)[1] == "Testfirma-GmbH.pdf  [Muster: Eigenes Muster]"
+def test_saved_order_is_respected_on_start(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path,
+                      **{CONFIG_KEY: [pattern_kind(RECHNUNGEN), KIND_AUTO]})
+    _select(panel, tmp_path, [_ki_suggestion()] + _analysis_suggestions())
+    assert _reasons(panel)[:3] == ["Muster: Rechnungen & Belege", "Automatisch erkannt", "KI-Vorschlag"]
+    assert panel.name_input.text() == "2024-01-31_Rechnung_Testfirma-GmbH_Beratung-im-Maerz-2024"
 
 
-def test_choice_survives_next_pdf_but_follows_settings_change(qtbot, monkeypatch, tmp_path):
-    panel, cfg = _panel(qtbot, monkeypatch, tmp_path, filename_pattern=RECHNUNGEN,
-                        owner_initials="JW")
-    _select(panel, tmp_path, [_ki_suggestion()])
-    idx = panel.pattern_combo.findData(BUERO)
-    panel.pattern_combo.setCurrentIndex(idx)
-    panel.pattern_combo.activated.emit(idx)
-
-    # Naechste PDF: Umschaltung des Nutzers bleibt
-    _select(panel, tmp_path, [_ki_suggestion("2024-02-01_Rechnung_Andere.pdf")])
-    assert panel.pattern_combo.currentData() == BUERO
-
-    # Einstellungen geaendert: Combo folgt dem neuen Muster
-    cfg.set("filename_pattern", "{jahr}_{kontakt}", auto_save=False)
-    _select(panel, tmp_path, [_ki_suggestion()])
-    assert panel.pattern_combo.currentData() == "{jahr}_{kontakt}"
-    assert _rows(panel)[1].startswith("2024_Testfirma-GmbH.pdf")
+def test_duplicate_names_shown_once_higher_rank_wins(qtbot, monkeypatch, tmp_path):
+    # KI folgt exakt dem Rechnungen-Muster -> nur die KI-Zeile bleibt
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
+    ki = _ki_suggestion("2024-01-31_Rechnung_Testfirma-GmbH_Beratung-im-Maerz-2024.pdf")
+    _select(panel, tmp_path, [ki])
+    reasons = _reasons(panel)
+    assert reasons[0] == "KI-Vorschlag"
+    assert "Muster: Rechnungen & Belege" not in reasons
 
 
-def test_clicking_pattern_row_takes_name_without_touching_metadata(qtbot, monkeypatch, tmp_path):
-    panel, _ = _panel(qtbot, monkeypatch, tmp_path, filename_pattern=RECHNUNGEN)
-    _select(panel, tmp_path, [_ki_suggestion(),
-                              RenameSuggestion("Dokument.pdf", "Automatisch erkannt", 0.5)])
-    panel._on_suggestion_clicked(panel.suggestions_list.item(1))
+def test_nur_datum_is_not_listed(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
+    _select(panel, tmp_path, _analysis_suggestions())
+    assert "Nur Datum" not in _reasons(panel)
+
+
+def test_clicking_ki_row_takes_metadata_pattern_row_does_not(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
+    _select(panel, tmp_path, [_ki_suggestion()] + _analysis_suggestions())
+    idx = _reasons(panel).index("Muster: Rechnungen & Belege")
+    panel._on_suggestion_clicked(panel.suggestions_list.item(idx))
     assert panel.name_input.text() == "2024-01-31_Rechnung_Testfirma-GmbH_Beratung-im-Maerz-2024"
     assert panel.get_metadata()["korrespondent"] == "Testfirma GmbH"
-    # Dritte Zeile (Index-Verschiebung durch die Muster-Zeile) trifft weiter den richtigen Vorschlag
-    panel._on_suggestion_clicked(panel.suggestions_list.item(2))
+    idx = _reasons(panel).index("Automatisch erkannt")
+    panel._on_suggestion_clicked(panel.suggestions_list.item(idx))
     assert panel.name_input.text() == "Dokument"
 
 
 def test_date_falls_back_to_ki_filename(qtbot, monkeypatch, tmp_path):
-    panel, _ = _panel(qtbot, monkeypatch, tmp_path, filename_pattern="{datum}_{kontakt}")
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
     _select(panel, tmp_path, [_ki_suggestion("2023-12-24_Rechnung_Testfirma.pdf")], detected_date=None)
-    assert _rows(panel)[1].startswith("2023-12-24_Testfirma-GmbH.pdf")
+    assert _rows(panel)[1].startswith("2023-12-24_Rechnung_Testfirma-GmbH_Beratung-im-Maerz-2024.pdf")
+
+
+def test_pdf_metadata_arriving_later_updates_auto_name_only(qtbot, monkeypatch, tmp_path):
+    """XMP-Werte kommen nach: oberste Muster-Zeile aendert sich -> Name folgt,
+    ausser der Nutzer hat schon selbst getippt."""
+    from src.core.pdf_metadata import PDFMetadata
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path,
+                      **{CONFIG_KEY: [pattern_kind(RECHNUNGEN)]})
+    pdf = _select(panel, tmp_path, [_ki_suggestion()])
+    assert panel.name_input.text() == "2024-01-31_Rechnung_Testfirma-GmbH_Beratung-im-Maerz-2024"
+
+    meta = PDFMetadata(korrespondent="Andere AG", subject="Rechnung", description="Wartung")
+    panel._on_pdf_metadata_read(pdf, meta)
+    assert panel.name_input.text() == "2024-01-31_Rechnung_Andere-AG_Wartung"
+    assert not panel.has_user_edits()
+
+    # Nutzer tippt -> spaetere Metadaten aendern den Namen nicht mehr
+    panel.name_input.setText("Mein Name")
+    panel._on_pdf_metadata_read(pdf, PDFMetadata(korrespondent="Dritte KG"))
+    assert panel.name_input.text() == "Mein Name"

--- a/tests/test_detail_panel_pattern_suggestions_gui.py
+++ b/tests/test_detail_panel_pattern_suggestions_gui.py
@@ -283,6 +283,14 @@ def test_category_field_is_editable_combo_with_choices(qtbot, monkeypatch, tmp_p
     combo.clear()
     assert combo.text() == "" and combo.count() == len(items)
 
+    # Neue Kategorie verwenden + speichern -> steht beim naechsten Mal ganz oben
+    combo.setText("Liste")
+    panel.mark_metadata_saved()
+    assert cfg.get("recent_categories") == ["Liste"]
+    assert combo.itemText(0) == "Liste"
+    _select(panel, tmp_path, [_ki_suggestion()])
+    assert combo.itemText(0) == "Liste" and combo.itemText(1) == "Rechnung"
+
 
 def test_preview_text_goes_into_field_and_korrespondent_is_learned(qtbot, monkeypatch, tmp_path):
     panel, cfg = _panel(qtbot, monkeypatch, tmp_path)

--- a/tests/test_detail_panel_pattern_suggestions_gui.py
+++ b/tests/test_detail_panel_pattern_suggestions_gui.py
@@ -298,6 +298,16 @@ def test_preview_text_goes_into_field_and_korrespondent_is_learned(qtbot, monkey
     assert panel.get_metadata()["description"] == "Depotauszug 2024"
     panel.preview.apply_text_requested.emit("subject", "Bank")
     assert panel.get_metadata()["subject"] == "Bank"
+    # Alle Felder erreichbar, mit Aufbereitung
+    panel.preview.apply_text_requested.emit("iban", "DE89 3704 0044 0532 0130 00")
+    panel.preview.apply_text_requested.emit("betrag_brutto", "1.234,56 €")
+    panel.preview.apply_text_requested.emit("mwst_satz", "19 %")
+    panel.preview.apply_text_requested.emit("steuerjahr", "Steuerjahr 2024")
+    md = panel.get_metadata()
+    assert md["iban"] == "DE89370400440532013000"
+    assert md["betrag_brutto"] == "1.234,56"
+    assert md["mwst_satz"] == "19"
+    assert md["steuerjahr"] == "2024"
 
 
 def test_known_korrespondent_in_text_beats_ki_suggestion(qtbot, monkeypatch, tmp_path):

--- a/tests/test_detail_panel_pattern_suggestions_gui.py
+++ b/tests/test_detail_panel_pattern_suggestions_gui.py
@@ -177,10 +177,15 @@ def test_duplicate_names_shown_once_higher_rank_wins(qtbot, monkeypatch, tmp_pat
     assert "Muster: Rechnungen & Belege" not in reasons
 
 
-def test_nur_datum_is_not_listed(qtbot, monkeypatch, tmp_path):
+def test_nur_datum_and_learned_are_not_listed(qtbot, monkeypatch, tmp_path):
     panel, _ = _panel(qtbot, monkeypatch, tmp_path)
-    _select(panel, tmp_path, _analysis_suggestions())
-    assert "Nur Datum" not in _reasons(panel)
+    _select(panel, tmp_path, _analysis_suggestions() + [
+        RenameSuggestion("2022-04-03_Commerzbank_Depotauszug.pdf",
+                         "Gelernt: ähnlich zu Depotauszug.pdf", 0.7),
+    ])
+    reasons = _reasons(panel)
+    assert "Nur Datum" not in reasons
+    assert not any(r.startswith("Gelernt") for r in reasons)
 
 
 def test_clicking_ki_row_takes_metadata_pattern_row_does_not(qtbot, monkeypatch, tmp_path):

--- a/tests/test_detail_panel_pattern_suggestions_gui.py
+++ b/tests/test_detail_panel_pattern_suggestions_gui.py
@@ -24,6 +24,11 @@ def _panel(qtbot, monkeypatch, tmp_path, **config_values):
     for key, value in config_values.items():
         cfg.set(key, value, auto_save=False)
     monkeypatch.setattr(cfg_mod, "get_config", lambda: cfg)
+    # Eigene Datenbank pro Test: Korrespondenten-Lernen, Kategorie-Liste (#109/#110)
+    from src.utils.database import Database
+    db = Database(db_path=tmp_path / "panel.db")
+    monkeypatch.setattr("src.utils.database.get_database", lambda: db)
+    cfg._db = db
 
     from src.gui import detail_panel as dp
     # Keine Hintergrund-Threads im Unit-Test (Teardown-Crash): XMP-Lesen
@@ -255,4 +260,60 @@ def test_saved_custom_pattern_becomes_a_row(qtbot, monkeypatch, tmp_path):
     rows = _rows(panel)
     assert "2024_Testfirma-GmbH_Miete.pdf  [Muster: Mieter]" in rows
     assert _reasons(panel)[-1] == "Muster: Mieter"  # nach den eingebauten Vorlagen
+
+
+# --- Issues #109/#110: Kategorie-Auswahl, Text aus der Vorschau, Lernen ---
+
+
+def test_category_field_is_editable_combo_with_choices(qtbot, monkeypatch, tmp_path):
+    from src.core.metadata_choices import DEFAULT_CATEGORIES
+    panel, cfg = _panel(qtbot, monkeypatch, tmp_path)
+    _select(panel, tmp_path, [_ki_suggestion()])
+    combo = panel._metadata_inputs["subject"]
+    items = [combo.itemText(i) for i in range(combo.count())]
+    assert items[: len(DEFAULT_CATEGORIES)] == list(DEFAULT_CATEGORIES)
+    # Verhaelt sich wie das Textfeld: Wert aus dem KI-Vorschlag, get_metadata liest ihn
+    assert combo.text() == "Rechnung"
+    assert panel.get_metadata()["subject"] == "Rechnung"
+    # Auswahl aus der Liste = Nutzer-Eingabe
+    combo.setCurrentIndex(items.index("Vertrag"))
+    assert panel.get_metadata()["subject"] == "Vertrag"
+    assert panel.has_user_edits()
+    # clear() leert nur den Text, die Liste bleibt
+    combo.clear()
+    assert combo.text() == "" and combo.count() == len(items)
+
+
+def test_preview_text_goes_into_field_and_korrespondent_is_learned(qtbot, monkeypatch, tmp_path):
+    panel, cfg = _panel(qtbot, monkeypatch, tmp_path)
+    _select(panel, tmp_path, [_ki_suggestion()])
+    assert panel.get_metadata()["korrespondent"] == "Testfirma GmbH"
+
+    panel.preview.apply_text_requested.emit("korrespondent", "  Commerzbank   AG ")
+    assert panel.get_metadata()["korrespondent"] == "Commerzbank AG"
+    assert panel.has_user_edits()
+    assert [k["name"] for k in cfg._db.list_korrespondenten()] == ["Commerzbank AG"]
+
+    panel.preview.apply_text_requested.emit("description", "Depotauszug 2024")
+    assert panel.get_metadata()["description"] == "Depotauszug 2024"
+    panel.preview.apply_text_requested.emit("subject", "Bank")
+    assert panel.get_metadata()["subject"] == "Bank"
+
+
+def test_known_korrespondent_in_text_beats_ki_suggestion(qtbot, monkeypatch, tmp_path):
+    panel, cfg = _panel(qtbot, monkeypatch, tmp_path)
+    cfg._db.add_or_update_korrespondent("Commerzbank AG", aliases=["Coba"])
+
+    pdf = tmp_path / "scan.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    panel.set_pdf(pdf_path=pdf, suggestions=[_ki_suggestion()],
+                  extracted_text="Depotauszug der Coba fuer Kunde 4711",
+                  keywords=["bank"], detected_date="2024-01-31")
+    assert panel.get_metadata()["korrespondent"] == "Commerzbank AG"
+
+    # Ohne Treffer im Text bleibt der KI-Vorschlag
+    panel.set_pdf(pdf_path=pdf, suggestions=[_ki_suggestion()],
+                  extracted_text="Rechnung der Testfirma", keywords=["rechnung"],
+                  detected_date="2024-01-31")
+    assert panel.get_metadata()["korrespondent"] == "Testfirma GmbH"
 

--- a/tests/test_detail_panel_pdf_source.py
+++ b/tests/test_detail_panel_pdf_source.py
@@ -20,7 +20,15 @@ def test_partial_pdf_metadata_is_not_marked_saved(qtbot, tmp_path, monkeypatch):
     assert panel._saved_metadata_snapshot == {"description": "Leistungsabrechnung der HUK."}
     assert panel.save_metadata_btn.isEnabled()
     assert panel.save_metadata_btn.text() == "Metadaten speichern"
-    assert "teils" in panel.metadata_status_label.text()
+    assert "neue Vorschläge" in panel.metadata_status_label.text()
+    # Neu gegenueber dem PDF -> gruen; aus dem PDF -> normal
+    assert "#e6f4e6" in panel._metadata_inputs["subject"].styleSheet()
+    assert "#e6f4e6" in panel._metadata_inputs["steuerjahr"].styleSheet()
+    assert "#e6f4e6" not in panel._metadata_inputs["description"].styleSheet()
+    assert "#e6f4e6" not in panel._metadata_inputs["iban"].styleSheet()  # leer
+    # Nach dem Speichern ist nichts mehr "neu"
+    panel.mark_metadata_saved()
+    assert all("#e6f4e6" not in w.styleSheet() for w in panel._metadata_inputs.values())
 
 
 def test_full_pdf_metadata_is_marked_saved(qtbot, tmp_path, monkeypatch):
@@ -39,3 +47,8 @@ def test_full_pdf_metadata_is_marked_saved(qtbot, tmp_path, monkeypatch):
     assert not panel.save_metadata_btn.isEnabled()
     assert panel.save_metadata_btn.text() == "Metadaten gespeichert"
     assert panel.metadata_status_label.text() == "Quelle: aus PDF gelesen"
+    assert all("#e6f4e6" not in w.styleSheet() for w in panel._metadata_inputs.values())
+    # Nutzer aendert ein PDF-Feld -> genau dieses wird gruen
+    panel._metadata_inputs["steuerjahr"].setText("2025")
+    assert "#e6f4e6" in panel._metadata_inputs["steuerjahr"].styleSheet()
+    assert "#e6f4e6" not in panel._metadata_inputs["subject"].styleSheet()

--- a/tests/test_filename_placeholders.py
+++ b/tests/test_filename_placeholders.py
@@ -205,3 +205,31 @@ def test_pattern_choices_presets_and_custom_settings_pattern():
     assert pattern_choices("{datum}_{kategorie}_{kontakt}_{betreff}") == choices
     # Altes Grosswort-Muster wird zuerst migriert
     assert pattern_choices("YYYY-MM-DD_Rechnung_Kontakt_Betreff") == choices
+
+
+def test_custom_patterns_load_and_join_choices():
+    from src.core.filename_placeholders import PRESET_CUSTOM, all_presets, load_custom_patterns
+
+    raw = [
+        {"name": "Mieter", "pattern": "{jahr}_{kontakt}_Miete"},
+        {"name": "mieter", "pattern": "doppelt"},          # Name doppelt -> weg
+        {"name": "", "pattern": "{datum}"},                 # ohne Name -> weg
+        {"name": "Leer", "pattern": ""},                    # ohne Muster -> weg
+        "kaputt",
+    ]
+    custom = load_custom_patterns(raw)
+    assert custom == [("Mieter", "{jahr}_{kontakt}_Miete")]
+
+    presets = all_presets(custom)
+    assert presets[0] == PRESETS[0]
+    assert ("Mieter", "{jahr}_{kontakt}_Miete") in presets
+    assert presets[-1] == (PRESET_CUSTOM, None)
+
+    choices = pattern_choices("", custom)
+    assert choices[-1] == ("Mieter", "{jahr}_{kontakt}_Miete")
+    # Gespeichertes Muster = Einstellungs-Muster: kein Extra-Eintrag "Eigenes Muster"
+    assert PATTERN_CHOICE_SETTINGS not in [n for n, _p in pattern_choices("{jahr}_{kontakt}_Miete", custom)]
+    # Gespeichertes Muster gleich einer eingebauten Vorlage: nur einmal
+    dup = [("Kopie", PRESETS[1][1])]
+    assert [p for _n, p in pattern_choices("", dup)].count(PRESETS[1][1]) == 1
+

--- a/tests/test_history_learned_name_gui.py
+++ b/tests/test_history_learned_name_gui.py
@@ -1,0 +1,60 @@
+"""Ordnerstruktur-Namen (#42): In die Historie (= KI-Beispiele) geht der vom
+Nutzer gewaehlte Name, nicht der Name mit Ordner-Praefix."""
+from pathlib import Path
+
+from tests.test_auto_next_after_move_gui import (  # noqa: F401 - Fixtures
+    _make_scan_folder,
+    _prime_cache,
+    fresh_singletons,
+    main_window,
+)
+
+
+def _history_names(main_window) -> list[str]:
+    from src.utils.database import RenameHistory
+    session = main_window.db.get_session()
+    try:
+        return [e.new_filename for e in session.query(RenameHistory).all()]
+    finally:
+        session.close()
+
+
+def test_history_keeps_user_name_without_folder_prefix(main_window, fresh_singletons):
+    tmp: Path = fresh_singletons["tmp_path"]
+    scan = _make_scan_folder(tmp, ["scan_001.pdf"])
+    ziel = tmp / "JK 069-03 Rohbau"
+    ziel.mkdir()
+    main_window.config.set("folder_naming_enabled", True, auto_save=False)
+    main_window.config.set("owner_initials", "JK", auto_save=False)
+
+    main_window._navigate_to_folder(scan)
+    _prime_cache(main_window, [w.pdf_path for w in main_window.pdf_widgets])
+    pdf = main_window.pdf_widgets[0].pdf_path
+    main_window.on_pdf_clicked(pdf)
+    main_window.selected_pdf_keywords = ["rechnung"]
+    main_window.detail_panel.name_input.setText("2026-05-12_Rechnung_Elektro-Mueller")
+
+    main_window._move_rename_and_learn(pdf, ziel)
+
+    moved = list(ziel.glob("*.pdf"))
+    assert len(moved) == 1
+    assert moved[0].name.startswith("JK 069-03-")          # Praefix auf der Datei ...
+    assert _history_names(main_window) == ["2026-05-12_Rechnung_Elektro-Mueller.pdf"]  # ... nicht im Beispiel
+
+
+def test_history_without_folder_naming_stores_final_name(main_window, fresh_singletons):
+    tmp: Path = fresh_singletons["tmp_path"]
+    scan = _make_scan_folder(tmp, ["scan_002.pdf"])
+    ziel = tmp / "Ziel"
+    ziel.mkdir()
+    main_window._navigate_to_folder(scan)
+    _prime_cache(main_window, [w.pdf_path for w in main_window.pdf_widgets])
+    pdf = main_window.pdf_widgets[0].pdf_path
+    main_window.on_pdf_clicked(pdf)
+    main_window.selected_pdf_keywords = ["rechnung"]
+    main_window.detail_panel.name_input.setText("2026-05-12_Rechnung_Elektro-Mueller")
+
+    main_window._move_rename_and_learn(pdf, ziel)
+
+    assert (ziel / "2026-05-12_Rechnung_Elektro-Mueller.pdf").exists()
+    assert _history_names(main_window) == ["2026-05-12_Rechnung_Elektro-Mueller.pdf"]

--- a/tests/test_korrespondent_match.py
+++ b/tests/test_korrespondent_match.py
@@ -1,6 +1,6 @@
 """Issues #109/#110: Korrespondenten im Text wiederfinden, Kategorie-Auswahl."""
 from src.core.korrespondent_match import find_known_korrespondent
-from src.core.metadata_choices import DEFAULT_CATEGORIES, category_choices, normalize_for_field
+from src.core.metadata_choices import DEFAULT_CATEGORIES, category_choices, normalize_for_field, remember_category
 
 TEXT = (
     "Commerzbank AG - Depotauszug per 31.12.2024\n"
@@ -33,13 +33,30 @@ def test_no_text_or_short_names_give_none():
     assert find_known_korrespondent(TEXT, []) is None
 
 
-def test_category_choices_merge_db_and_defaults():
-    assert category_choices([]) == list(DEFAULT_CATEGORIES)[:10]
-    choices = category_choices(["Rechnung", "Mietvertrag", "rechnung", "", "Notar"])
-    assert choices[:3] == ["Rechnung", "Mietvertrag", "Notar"]
+def test_category_choices_recent_first_then_db_then_defaults():
+    assert category_choices([], []) == list(DEFAULT_CATEGORIES)[:10]
+    choices = category_choices(["Liste", "Rechnung"], ["Rechnung", "Mietvertrag", "rechnung", "", "Notar"])
+    assert choices[:4] == ["Liste", "Rechnung", "Mietvertrag", "Notar"]
     assert "Vertrag" in choices and len(choices) == 10
     assert choices.count("Rechnung") == 1
-    assert category_choices(["A", "B"], limit=3) == ["A", "B", "Rechnung"]
+    assert category_choices(["A"], ["B"], limit=3) == ["A", "B", "Rechnung"]
+
+
+def test_category_choices_drop_long_index_junk_but_keep_recent():
+    junk = "Nebenkosten Schmutzwassergebühr"
+    assert junk not in category_choices([], [junk, "Steuer"])
+    assert "Drei Wort Kategorie" not in category_choices([], ["Drei Wort Kategorie"])
+    # Was der Nutzer selbst verwendet hat, bleibt - egal wie lang
+    assert category_choices([junk], [])[0] == junk
+
+
+def test_remember_category_is_mru_and_capped():
+    recent = remember_category(["Rechnung", "Vertrag"], "Liste")
+    assert recent == ["Liste", "Rechnung", "Vertrag"]
+    assert remember_category(recent, "vertrag") == ["vertrag", "Liste", "Rechnung"]
+    assert remember_category(recent, "  ") == recent
+    many = remember_category([f"K{i}" for i in range(20)], "Neu")
+    assert len(many) == 15 and many[0] == "Neu"
 
 
 def test_normalize_for_field_cleans_amounts_iban_year():

--- a/tests/test_korrespondent_match.py
+++ b/tests/test_korrespondent_match.py
@@ -1,0 +1,42 @@
+"""Issues #109/#110: Korrespondenten im Text wiederfinden, Kategorie-Auswahl."""
+from src.core.korrespondent_match import find_known_korrespondent
+from src.core.metadata_choices import DEFAULT_CATEGORIES, category_choices
+
+TEXT = (
+    "Commerzbank AG - Depotauszug per 31.12.2024\n"
+    "Kunde: Johannes Wack\nIhre Ansprechpartnerin: Frau Müller, Stadtwerke-Kundencenter"
+)
+
+
+def test_known_name_is_found_case_insensitive_as_whole_phrase():
+    entries = [{"name": "Stadtwerke München", "aliases": ["SWM"]},
+               {"name": "commerzbank", "aliases": []}]
+    assert find_known_korrespondent(TEXT, entries) == "commerzbank"
+    # "Stadtwerke" allein ist kein Alias, "Stadtwerke-Kundencenter" kein Wortgrenzen-Treffer
+    assert find_known_korrespondent("Stadtwerke-Kundencenter", entries) is None
+    assert find_known_korrespondent("SWM Rechnung", entries) == "Stadtwerke München"
+
+
+def test_longest_match_wins_then_list_order():
+    entries = [{"name": "Bank", "aliases": []},                      # zu kurz/generisch, aber 4 Zeichen
+               {"name": "Commerzbank AG", "aliases": []},
+               {"name": "Commerzbank", "aliases": []}]
+    assert find_known_korrespondent(TEXT, entries) == "Commerzbank AG"
+    # Gleich lange Treffer: der zuerst gelistete (nach Haeufigkeit) gewinnt
+    entries = [{"name": "Wack", "aliases": []}, {"name": "Frau", "aliases": []}]
+    assert find_known_korrespondent(TEXT, entries) == "Wack"
+
+
+def test_no_text_or_short_names_give_none():
+    assert find_known_korrespondent("", [{"name": "Commerzbank"}]) is None
+    assert find_known_korrespondent(TEXT, [{"name": "AG"}, {"name": ""}]) is None
+    assert find_known_korrespondent(TEXT, []) is None
+
+
+def test_category_choices_merge_db_and_defaults():
+    assert category_choices([]) == list(DEFAULT_CATEGORIES)[:10]
+    choices = category_choices(["Rechnung", "Mietvertrag", "rechnung", "", "Notar"])
+    assert choices[:3] == ["Rechnung", "Mietvertrag", "Notar"]
+    assert "Vertrag" in choices and len(choices) == 10
+    assert choices.count("Rechnung") == 1
+    assert category_choices(["A", "B"], limit=3) == ["A", "B", "Rechnung"]

--- a/tests/test_korrespondent_match.py
+++ b/tests/test_korrespondent_match.py
@@ -1,6 +1,6 @@
 """Issues #109/#110: Korrespondenten im Text wiederfinden, Kategorie-Auswahl."""
 from src.core.korrespondent_match import find_known_korrespondent
-from src.core.metadata_choices import DEFAULT_CATEGORIES, category_choices
+from src.core.metadata_choices import DEFAULT_CATEGORIES, category_choices, normalize_for_field
 
 TEXT = (
     "Commerzbank AG - Depotauszug per 31.12.2024\n"
@@ -40,3 +40,15 @@ def test_category_choices_merge_db_and_defaults():
     assert "Vertrag" in choices and len(choices) == 10
     assert choices.count("Rechnung") == 1
     assert category_choices(["A", "B"], limit=3) == ["A", "B", "Rechnung"]
+
+
+def test_normalize_for_field_cleans_amounts_iban_year():
+    assert normalize_for_field("iban", "DE89 3704 0044 0532 0130 00") == "DE89370400440532013000"
+    assert normalize_for_field("betrag_brutto", "Gesamt: 1.234,56 €") == "Gesamt: 1.234,56"
+    assert normalize_for_field("betrag_netto", "EUR 99,00") == "99,00"
+    assert normalize_for_field("mwst_satz", "19 %") == "19"
+    assert normalize_for_field("steuerjahr", "Abrechnung 2024/2025") == "2024"
+    assert normalize_for_field("steuerjahr", "kein Jahr") == "kein Jahr"
+    assert normalize_for_field("waehrung", "€") == "EUR"
+    assert normalize_for_field("korrespondent", "  Commerzbank 	 AG ") == "Commerzbank AG"
+

--- a/tests/test_preview_text_selection_gui.py
+++ b/tests/test_preview_text_selection_gui.py
@@ -1,0 +1,78 @@
+"""Issue #109: Text in der Vorschau markieren und in Metadaten-Felder uebernehmen."""
+from pathlib import Path
+
+import fitz
+import pytest
+from PyQt6.QtCore import QPoint, QPointF, Qt
+from PyQt6.QtTest import QTest
+
+from src.gui.pdf_preview_widget import SELECTION_TARGETS, PdfPreviewWidget
+
+
+def _make_pdf(path: Path) -> Path:
+    doc = fitz.open()
+    try:
+        page = doc.new_page()  # A4: 595 x 842 pt
+        page.insert_text((72, 72), "Commerzbank AG", fontsize=14)
+        page.insert_text((72, 120), "Depotauszug 2024", fontsize=14)
+        doc.save(str(path))
+    finally:
+        doc.close()
+    return path
+
+
+@pytest.fixture
+def widget(qtbot, tmp_path):
+    w = PdfPreviewWidget(compact=True)
+    qtbot.addWidget(w)
+    w.resize(500, 700)
+    w.show()
+    qtbot.waitExposed(w)
+    pdf = _make_pdf(tmp_path / "text.pdf")
+    assert w.load_bytes(pdf, pdf.read_bytes())
+    qtbot.waitUntil(lambda: w.page_count() == 1, timeout=5000)
+    yield w
+    w.shutdown()
+
+
+def test_select_page_region_returns_text(widget):
+    # Textzeile bei y=72 (Grundlinie), Schrift 14 pt -> Kasten etwa y 58..76
+    text = widget.select_page_region(0, QPointF(60, 55), QPointF(220, 80))
+    assert text == "Commerzbank AG"
+    assert widget.selected_text() == "Commerzbank AG"
+    widget.clear_selection()
+    assert widget.selected_text() == ""
+
+
+def test_mouse_drag_selects_text_and_emits_signal(qtbot, widget):
+    rect = widget._page_rect_in_viewport(0)
+    assert rect is not None and rect.width() > 100
+    scale = rect.width() / 595.0
+
+    def vp(x_pt, y_pt) -> QPoint:
+        return QPoint(int(rect.x() + x_pt * scale), int(rect.y() + y_pt * scale))
+
+    viewport = widget._view.viewport()
+    with qtbot.waitSignal(widget.text_selected, timeout=2000) as blocker:
+        QTest.mousePress(viewport, Qt.MouseButton.LeftButton, pos=vp(60, 55))
+        QTest.mouseMove(viewport, vp(150, 70))
+        QTest.mouseMove(viewport, vp(220, 80))
+        QTest.mouseRelease(viewport, Qt.MouseButton.LeftButton, pos=vp(220, 80))
+    assert blocker.args == ["Commerzbank AG"]
+    # Markierung wird gezeichnet (mindestens ein Polygon)
+    assert widget._overlay._polygons
+
+    # Klick ohne Ziehen loescht die Markierung
+    QTest.mouseClick(viewport, Qt.MouseButton.LeftButton, pos=vp(300, 400))
+    assert widget.selected_text() == ""
+
+
+def test_context_menu_actions_emit_apply_text(qtbot, widget):
+    widget.select_page_region(0, QPointF(60, 105), QPointF(260, 128))
+    assert widget.selected_text() == "Depotauszug 2024"
+    menu = widget._build_selection_menu()
+    actions = [a for a in menu.actions() if a.data()]
+    assert [a.data() for a in actions] == [k for k, _l in SELECTION_TARGETS]
+    with qtbot.waitSignal(widget.apply_text_requested, timeout=1000) as blocker:
+        actions[1].trigger()  # "Als Kategorie uebernehmen"
+    assert blocker.args == ["subject", "Depotauszug 2024"]

--- a/tests/test_rename_examples.py
+++ b/tests/test_rename_examples.py
@@ -1,0 +1,120 @@
+"""Historie als Stil-Beispiele im KI-Prompt statt „Gelernt“-Vorschlaege."""
+from dataclasses import dataclass
+
+import pytest
+
+from src.core.rename_examples import (
+    describe_examples_for_prompt,
+    name_tokens,
+    rank_examples,
+    score_example,
+)
+from tests.test_llm_metadata_extraction import provider  # noqa: F401 - Fixture
+
+
+@dataclass
+class _Entry:
+    new_filename: str
+    keywords: str | None = None
+
+
+TEXT = (
+    "Commerzbank AG Depotauszug per 31.12.2024 fuer Johannes Wack. "
+    "Wertpapiere und Kurswerte. Rechnung fuer Depotgebuehren."
+)
+
+
+def test_name_tokens_drop_dates_initials_and_generic_words():
+    tokens = name_tokens("JW_2024-01-31_Rechnung_Commerzbank_Depotauszug-Wertpapiere.pdf")
+    assert tokens == {"commerzbank", "depotauszug", "wertpapiere"}
+
+
+def test_single_shared_keyword_is_not_similar():
+    # Das alte Verhalten: "rechnung" allein machte jeden Eintrag zum Treffer
+    assert score_example("2024-01-01_Rechnung_Telekom.pdf", "rechnung,telekom", TEXT, ["rechnung"]) == 1
+    assert rank_examples([_Entry("2024-01-01_Rechnung_Telekom.pdf", "rechnung,telekom")],
+                         TEXT, ["rechnung"]) == []
+
+
+def test_name_in_text_or_two_keywords_count_as_similar():
+    by_name = _Entry("2022-04-03_Commerzbank_Depotauszug.pdf", "bank")
+    by_keywords = _Entry("2023-02-01_Kostenrechnung_Notar.pdf", "rechnung,depot")
+    unrelated = _Entry("2024-02-04_Bank_Nachlassvollmacht.pdf", "vollmacht")
+    ranked = rank_examples([unrelated, by_keywords, by_name], TEXT, ["rechnung", "depot"])
+    assert ranked == [by_name, by_keywords]  # 4 Punkte vor 2 Punkten
+
+
+def test_ties_keep_newest_first_and_dedupe_names():
+    newest = _Entry("2025-01-01_Commerzbank_Auszug.pdf", "")
+    older = _Entry("2024-01-01_Commerzbank_Auszug.pdf", "")
+    same_name = _Entry("2025-01-01_Commerzbank_Auszug.pdf", "")
+    ranked = rank_examples([newest, same_name, older], TEXT, [], limit=5)
+    assert ranked == [newest, older]
+    assert rank_examples([newest, older], TEXT, [], limit=1) == [newest]
+
+
+def test_describe_examples_for_prompt():
+    assert describe_examples_for_prompt([]) == ""
+    block = describe_examples_for_prompt(["A_B.pdf", "", "C_D.pdf"])
+    assert "ÄHNLICHE DOKUMENTE ZULETZT BENANNT" in block
+    assert "- A_B.pdf\n- C_D.pdf" in block
+    assert "aus DIESEM Dokument" in block
+
+
+def test_prompt_contains_examples_only_when_given(provider):  # noqa: F811
+    prompt = provider._build_filename_prompt(
+        text=TEXT, current_filename="scan.pdf", keywords=["bank"],
+        examples=["2022-04-03_Commerzbank_Depotauszug.pdf"],
+    )
+    assert "- 2022-04-03_Commerzbank_Depotauszug.pdf" in prompt
+    assert "ZULETZT BENANNT" in prompt
+    plain = provider._build_filename_prompt(text=TEXT, current_filename="scan.pdf")
+    assert "ZULETZT BENANNT" not in plain
+
+
+def test_database_returns_similar_renames(tmp_path):
+    from src.utils.database import Database
+    db = Database(db_path=tmp_path / "hist.db")
+    db.add_rename_entry("scan1.pdf", "2024-02-04_Bank_Nachlassvollmacht.pdf",
+                        extracted_text="Vollmacht", keywords=["vollmacht", "bank"])
+    db.add_rename_entry("scan2.pdf", "2022-04-03_Commerzbank_Depotauszug.pdf",
+                        extracted_text="Depot", keywords=["bank"])
+    db.add_rename_entry("scan3.pdf", "2023-02-25_Kostenrechnung_Notar_Eisenburger.pdf",
+                        extracted_text="Notar", keywords=["rechnung", "notar"])
+
+    names = [e.new_filename for e in db.get_rename_examples(TEXT, ["rechnung", "bank"])]
+    assert names == ["2022-04-03_Commerzbank_Depotauszug.pdf"]
+    assert db.get_rename_examples("", []) == []
+
+
+def test_hybrid_passes_examples_to_provider(monkeypatch, tmp_path):
+    """Der KI-Aufruf bekommt die Historien-Beispiele; ohne DB laeuft er trotzdem."""
+    from src.ml import hybrid_classifier as hc
+    from src.ml.llm_provider import LLMResponse
+    from src.utils.database import Database
+
+    db = Database(db_path=tmp_path / "hist.db")
+    db.add_rename_entry("s.pdf", "2022-04-03_Commerzbank_Depotauszug.pdf", keywords=["bank"])
+    monkeypatch.setattr(hc, "get_database", lambda: db)
+
+    calls = {}
+
+    class _Provider:
+        def suggest_filename(self, **kwargs):
+            calls.update(kwargs)
+            return LLMResponse(success=True, filename_suggestion="2024-12-31_Bank_Commerzbank_Depotauszug.pdf",
+                               confidence=0.9, tokens_used=1)
+
+    classifier = hc.HybridClassifier.__new__(hc.HybridClassifier)
+    classifier.llm_provider = _Provider()
+    classifier.total_tokens_used = 0
+    classifier.last_llm_error = None
+
+    result = classifier._get_llm_filename_suggestion(TEXT, "scan.pdf", ["bank"], None, None)
+    assert result is not None and result.filename.startswith("2024-12-31_Bank_Commerzbank")
+    assert calls["examples"] == ["2022-04-03_Commerzbank_Depotauszug.pdf"]
+
+    def boom():
+        raise RuntimeError("keine DB")
+    monkeypatch.setattr(hc, "get_database", boom)
+    assert classifier._rename_examples(TEXT, ["bank"]) == []

--- a/tests/test_settings_filename_tab_gui.py
+++ b/tests/test_settings_filename_tab_gui.py
@@ -163,3 +163,121 @@ def test_legend_toggle_does_not_share_a_cell_with_a_chip(qtbot, monkeypatch, tmp
     assert toggle_cells and len(cells[toggle_cells[0]]) == 1
     assert all(len(ws) == 1 for ws in cells.values())
 
+
+def test_separator_buttons_insert_at_cursor(qtbot, monkeypatch, tmp_path):
+    dlg, _ = _dialog(qtbot, monkeypatch, tmp_path)
+    dlg.pattern_input.setText("{datum}")
+    dlg.pattern_input.setCursorPosition(len("{datum}"))
+    by_text = {b.text(): b for b in dlg.pattern_sep_buttons}
+    by_text["_"].click()
+    by_text["-"].click()
+    by_text["Leerzeichen"].click()
+    assert dlg.pattern_input.text() == "{datum}_- "
+
+
+def test_chip_click_auto_inserts_underscore_between_placeholders(qtbot, monkeypatch, tmp_path):
+    dlg, _ = _dialog(qtbot, monkeypatch, tmp_path)
+    chip = {b.text(): b for b in dlg.pattern_chip_buttons}
+    chip["{datum}"].click()
+    assert dlg.pattern_input.text() == "{datum}"          # am Anfang kein Trenner
+    chip["{kontakt}"].click()
+    assert dlg.pattern_input.text() == "{datum}_{kontakt}"  # automatisch "_"
+    sep = {b.text(): b for b in dlg.pattern_sep_buttons}
+    sep["-"].click()
+    chip["{betreff}"].click()
+    assert dlg.pattern_input.text() == "{datum}_{kontakt}-{betreff}"  # eigener Trenner bleibt
+
+
+def test_undo_button_removes_placeholder_with_its_separator(qtbot, monkeypatch, tmp_path):
+    """Ein Klick zurueck je Chip-Klick - auch nach Doppelklick auf {jahr}."""
+    dlg, _ = _dialog(qtbot, monkeypatch, tmp_path)
+    chip = {b.text(): b for b in dlg.pattern_chip_buttons}
+    chip["{datum}"].click()
+    chip["{jahr}"].click()
+    chip["{jahr}"].click()
+    assert dlg.pattern_input.text() == "{datum}_{jahr}_{jahr}"
+    dlg.pattern_undo_btn.click()
+    assert dlg.pattern_input.text() == "{datum}_{jahr}"
+    dlg.pattern_undo_btn.click()
+    assert dlg.pattern_input.text() == "{datum}"
+    # Getippter Text ohne Trenner: nur der Platzhalter geht weg
+    dlg.pattern_input.setText("Akte{datum}")
+    dlg.pattern_input.setCursorPosition(len("Akte{datum}"))
+    dlg.pattern_undo_btn.click()
+    assert dlg.pattern_input.text() == "Akte"
+    dlg.pattern_undo_btn.click()  # einzelnes Zeichen
+    assert dlg.pattern_input.text() == "Akt"
+    # Leeres Feld: nichts passiert
+    dlg.pattern_input.setText("")
+    dlg.pattern_undo_btn.click()
+    assert dlg.pattern_input.text() == ""
+
+
+def test_undo_button_respects_cursor_position(qtbot, monkeypatch, tmp_path):
+    dlg, _ = _dialog(qtbot, monkeypatch, tmp_path)
+    dlg.pattern_input.setText("{datum}_{kontakt}_{betreff}")
+    dlg.pattern_input.setCursorPosition(len("{datum}_{kontakt}"))
+    dlg.pattern_undo_btn.click()
+    assert dlg.pattern_input.text() == "{datum}_{betreff}"
+    assert dlg.pattern_input.cursorPosition() == len("{datum}")
+
+
+def test_save_custom_pattern_adds_it_to_combo_and_config(qtbot, monkeypatch, tmp_path):
+    from PyQt6.QtWidgets import QInputDialog
+    dlg, cfg = _dialog(qtbot, monkeypatch, tmp_path)
+    # Eingebaute Vorlage: Speichern gesperrt
+    dlg.pattern_input.setText("{datum}_{kategorie}_{kontakt}_{betreff}")
+    assert not dlg.pattern_save_btn.isEnabled()
+    dlg.pattern_input.setText("{jahr}_{kontakt}_Miete")
+    assert dlg.pattern_save_btn.isEnabled()
+    assert not dlg.pattern_delete_btn.isEnabled()
+
+    monkeypatch.setattr(QInputDialog, "getText", staticmethod(lambda *a, **k: ("Mieter", True)))
+    dlg.pattern_save_btn.click()
+
+    names = [dlg.pattern_preset_combo.itemText(i) for i in range(dlg.pattern_preset_combo.count())]
+    assert "Mieter" in names
+    assert names[-1] == "Eigenes Muster"
+    assert dlg.pattern_preset_combo.currentText() == "Mieter"
+    assert cfg.get("custom_patterns") == [{"name": "Mieter", "pattern": "{jahr}_{kontakt}_Miete"}]
+    assert dlg.pattern_delete_btn.isEnabled()
+
+    # Vorlage aus der Combo waehlen fuellt das Feld
+    dlg.pattern_input.setText("")
+    idx = names.index("Mieter")
+    dlg.pattern_preset_combo.setCurrentIndex(idx)
+    dlg.pattern_preset_combo.activated.emit(idx)
+    assert dlg.pattern_input.text() == "{jahr}_{kontakt}_Miete"
+
+    # Loeschen entfernt es wieder, Feldinhalt bleibt
+    dlg.pattern_delete_btn.click()
+    names = [dlg.pattern_preset_combo.itemText(i) for i in range(dlg.pattern_preset_combo.count())]
+    assert "Mieter" not in names
+    assert cfg.get("custom_patterns") == []
+    assert dlg.pattern_input.text() == "{jahr}_{kontakt}_Miete"
+    assert dlg.pattern_preset_combo.currentText() == "Eigenes Muster"
+
+
+def test_save_custom_pattern_cancel_and_builtin_name(qtbot, monkeypatch, tmp_path):
+    from PyQt6.QtWidgets import QInputDialog, QMessageBox
+    dlg, cfg = _dialog(qtbot, monkeypatch, tmp_path)
+    dlg.pattern_input.setText("{jahr}_{kontakt}")
+    monkeypatch.setattr(QInputDialog, "getText", staticmethod(lambda *a, **k: ("", False)))
+    dlg.pattern_save_btn.click()
+    assert cfg.get("custom_patterns", []) == []
+
+    warned = []
+    monkeypatch.setattr(QMessageBox, "warning", staticmethod(lambda *a, **k: warned.append(a)))
+    monkeypatch.setattr(QInputDialog, "getText",
+                        staticmethod(lambda *a, **k: ("Rechnungen & Belege", True)))
+    dlg.pattern_save_btn.click()
+    assert warned and cfg.get("custom_patterns", []) == []
+
+
+def test_saved_pattern_is_preselected_when_config_matches(qtbot, monkeypatch, tmp_path):
+    dlg, _ = _dialog(qtbot, monkeypatch, tmp_path,
+                     filename_pattern="{jahr}_{kontakt}_Miete",
+                     custom_patterns=[{"name": "Mieter", "pattern": "{jahr}_{kontakt}_Miete"}])
+    assert dlg.pattern_preset_combo.currentText() == "Mieter"
+    assert dlg.pattern_delete_btn.isEnabled()
+

--- a/tests/test_settings_filename_tab_gui.py
+++ b/tests/test_settings_filename_tab_gui.py
@@ -149,3 +149,17 @@ def test_show_tab_selects_dateinamen(qtbot, monkeypatch, tmp_path):
     assert dialog.tab_widget.tabText(dialog.tab_widget.currentIndex()) == "Dateinamen"
     assert not dialog.show_tab("Gibt es nicht")
 
+
+def test_legend_toggle_does_not_share_a_cell_with_a_chip(qtbot, monkeypatch, tmp_path):
+    """Bei vollen Chip-Zeilen lag "Alle Platzhalter" ueber dem letzten Chip."""
+    dlg, _ = _dialog(qtbot, monkeypatch, tmp_path)
+    grid = dlg.pattern_legend_toggle.parentWidget().layout()
+    cells = {}
+    for i in range(grid.count()):
+        item = grid.itemAt(i)
+        row, col, _rs, _cs = grid.getItemPosition(i)
+        cells.setdefault((row, col), []).append(item.widget())
+    toggle_cells = [c for c, ws in cells.items() if dlg.pattern_legend_toggle in ws]
+    assert toggle_cells and len(cells[toggle_cells[0]]) == 1
+    assert all(len(ws) == 1 for ws in cells.values())
+

--- a/tests/test_settings_filename_tab_gui.py
+++ b/tests/test_settings_filename_tab_gui.py
@@ -141,3 +141,11 @@ def test_connection_test_button_only_on_llm_tab(qtbot, monkeypatch, tmp_path):
     assert not dlg.test_button.isVisibleTo(dlg)
     dlg.tab_widget.setCurrentIndex(0)
     assert dlg.test_button.isVisibleTo(dlg)
+
+
+def test_show_tab_selects_dateinamen(qtbot, monkeypatch, tmp_path):
+    dialog, _ = _dialog(qtbot, monkeypatch, tmp_path)
+    assert dialog.show_tab("Dateinamen")
+    assert dialog.tab_widget.tabText(dialog.tab_widget.currentIndex()) == "Dateinamen"
+    assert not dialog.show_tab("Gibt es nicht")
+

--- a/tests/test_suggestion_order.py
+++ b/tests/test_suggestion_order.py
@@ -78,3 +78,13 @@ def test_sort_by_kind_is_stable_and_puts_unknown_last():
     items = [("c", KIND_AUTO), ("a1", KIND_KI), ("x", "fremd"), ("a2", KIND_KI), ("b", KIND_LEARNED)]
     order = [KIND_AUTO, KIND_KI, KIND_LEARNED]
     assert [o for o, _k in sort_by_kind(items, order)] == ["c", "a1", "a2", "b", "x"]
+
+
+def test_default_order_includes_saved_custom_patterns_after_builtin():
+    custom = [("Mieter", "{jahr}_{kontakt}_Miete")]
+    order = default_order("", custom)
+    presets = [pattern_kind(p) for _n, p in PRESETS if p]
+    assert order[1:1 + len(presets)] == presets
+    assert order[1 + len(presets)] == pattern_kind("{jahr}_{kontakt}_Miete")
+    assert pattern_kind("{jahr}_{kontakt}_Miete") in effective_order(None, "", custom)
+

--- a/tests/test_suggestion_order.py
+++ b/tests/test_suggestion_order.py
@@ -1,0 +1,80 @@
+"""Issue #106: Rangfolge der Vorschlagsarten (reine Logik, ohne Qt)."""
+from src.core.filename_placeholders import PRESETS
+from src.core.suggestion_order import (
+    KIND_AUTO,
+    KIND_CATEGORY_NUMBER,
+    KIND_DATE,
+    KIND_DATE_CATEGORY,
+    KIND_KI,
+    KIND_LEARNED,
+    KIND_OTHER,
+    default_order,
+    effective_order,
+    kind_from_reason,
+    pattern_kind,
+    promote,
+    sort_by_kind,
+)
+
+RECHNUNGEN = "{datum}_{kategorie}_{kontakt}_{betreff}"
+AKTEN = "{initialen}_{aktenzeichen}_{datum}_{betreff}_{kontakt}"
+BUERO = "{initialen} {datum}-{betreff}"
+
+
+def test_kind_from_reason_covers_all_sources():
+    assert kind_from_reason("KI-Vorschlag") == KIND_KI
+    assert kind_from_reason("KI (gecacht): Vorschlag") == KIND_KI
+    assert kind_from_reason("KI: Rechnung erkannt") == KIND_KI
+    assert kind_from_reason("Gelernt: ähnlich zu alt.pdf") == KIND_LEARNED
+    assert kind_from_reason("Automatisch erkannt") == KIND_AUTO
+    assert kind_from_reason("Datum + Kategorie (Rechnung)") == KIND_DATE_CATEGORY
+    assert kind_from_reason("Kategorie + Nummer") == KIND_CATEGORY_NUMBER
+    assert kind_from_reason("Nur Datum") == KIND_DATE
+    assert kind_from_reason("") == KIND_OTHER
+    assert kind_from_reason("Irgendwas") == KIND_OTHER
+
+
+def test_default_order_ki_then_patterns_then_analysis():
+    order = default_order("")
+    presets = [pattern_kind(p) for _n, p in PRESETS if p]
+    assert order[0] == KIND_KI
+    assert order[1:1 + len(presets)] == presets
+    assert order[1 + len(presets):] == [
+        KIND_LEARNED, KIND_AUTO, KIND_DATE_CATEGORY, KIND_CATEGORY_NUMBER, KIND_DATE, KIND_OTHER,
+    ]
+
+
+def test_default_order_puts_settings_pattern_first_among_patterns():
+    # Vorlage aus den Einstellungen rueckt vor die anderen Vorlagen
+    order = default_order(BUERO)
+    assert order[:2] == [KIND_KI, pattern_kind(BUERO)]
+    assert order.count(pattern_kind(BUERO)) == 1
+    # Eigenes Muster, das keiner Vorlage entspricht, ebenso
+    order = default_order("{jahr}_{kontakt}")
+    assert order[:3] == [KIND_KI, pattern_kind("{jahr}_{kontakt}"), pattern_kind(RECHNUNGEN)]
+
+
+def test_effective_order_merges_saved_with_defaults():
+    saved = [pattern_kind(AKTEN), KIND_AUTO, "", 42, KIND_AUTO]
+    order = effective_order(saved, "")
+    assert order[:2] == [pattern_kind(AKTEN), KIND_AUTO]
+    assert order.count(KIND_AUTO) == 1
+    assert set(default_order("")) <= set(order)
+    assert effective_order(None, "") == default_order("")
+
+
+def test_promote_moves_kind_to_top_and_shifts_rest_down():
+    order = [KIND_KI, pattern_kind(RECHNUNGEN), pattern_kind(AKTEN), KIND_AUTO]
+    assert promote(order, pattern_kind(AKTEN)) == [
+        pattern_kind(AKTEN), KIND_KI, pattern_kind(RECHNUNGEN), KIND_AUTO,
+    ]
+    # Bereits oben: unveraendert
+    assert promote(order, KIND_KI) == order
+    # Unbekannte Art wird vorne angehaengt
+    assert promote(order, "neu")[0] == "neu"
+
+
+def test_sort_by_kind_is_stable_and_puts_unknown_last():
+    items = [("c", KIND_AUTO), ("a1", KIND_KI), ("x", "fremd"), ("a2", KIND_KI), ("b", KIND_LEARNED)]
+    order = [KIND_AUTO, KIND_KI, KIND_LEARNED]
+    assert [o for o, _k in sort_by_kind(items, order)] == ["c", "a1", "a2", "b", "x"]


### PR DESCRIPTION
Closes #106, closes #109, closes #110

## Was sich ändert
- Die Auswahl „Muster“ unter der Vorschlagsliste ist weg. Die Liste zeigt alles auf einmal, in fester Reihenfolge nach *Art*:
  KI-Vorschlag → Muster „Rechnungen & Belege“ → „Akten & Projekte“ → „Büro-Kürzel“ (→ eigenes Muster aus den Einstellungen) → Automatisch erkannt → Datum + Kategorie → Kategorie + Nummer.
- **Klick = neuer Standard:** Die Art des angeklickten Vorschlags steht beim nächsten Dokument ganz oben und wird automatisch als Dateiname übernommen; alle anderen rücken eine Stufe nach unten. Gespeichert in der Config (`suggestion_kind_order`).
- Muster-Zeilen nur, wenn mindestens zwei Platzhalter einen Wert haben („Rechnung.pdf“ allein ist kein Vorschlag); „Nur Datum“ wird nicht mehr angeboten.
- Doppelte Namen (KI folgt exakt dem Muster) erscheinen einmal – die höher gereihte Zeile gewinnt.
- Treffen XMP-Metadaten später ein, folgt der automatische Name der obersten Zeile, solange nichts selbst getippt wurde.
- Liste zeigt bis zu 8 Zeilen ohne Scrollen; ein horizontaler Scrollbalken (lange Namen) wird in die Höhe eingerechnet.

## „Gelernt“ → Beispiele für die KI (Folge-Feedback)
- Die Zeilen „Gelernt: ähnlich zu …“ sind aus dem Detail-Panel verschwunden – sie zeigten irgendeinen früheren Dateinamen mit *einem* gemeinsamen Stichwort.
- Stattdessen bekommt die KI die Dateinamen, die man für **wirklich ähnliche** Dokumente gewählt hat, als Stil-Beispiele in den Prompt: Firma/Person/Betreff aus dem alten Namen kommt als ganzes Wort im Text vor, oder mindestens zwei Stichwörter stimmen überein (Kategorie-Wörter wie „Bank“ zählen nicht).
- Was man wählt oder korrigiert, landet in der Historie und prägt den nächsten Vorschlag – iteratives Lernen ohne zweiten KI-Aufruf. Beim Verschieben wird jetzt auch der Zielordner mitgespeichert.

## Kopfzeile über den Vorschlägen (Folge-Feedback)
- Rechts neben dem Titel: Schalter **„Ordnerstruktur im Namen“** (dieselbe Einstellung wie *Beim Verschieben* im Dialog, wirkt sofort) und **„Muster bearbeiten…“**, das die Einstellungen direkt auf dem Tab *Dateinamen* öffnet.
- „(zum Auswählen klicken)“ ist in den Tooltip gewandert, damit die Zeile in die Spalte passt.

## Einstellungen > Dateinamen (Folge-Feedback)
- **Chip-Überlappung behoben:** „Alle Platzhalter“ lag über `{betrag}` – der Knopf hat jetzt eine eigene Spalte.
- **Muster ohne Tastatur:** Knöpfe „Leerzeichen“, „_“, „-“ und „⌫ Zurücknehmen“ (entfernt den letzten Baustein vor dem Cursor: Platzhalter samt Trennzeichen oder ein Zeichen). Ein Chip-Klick setzt automatisch „_“ zwischen zwei Platzhalter; wer vorher „-“/Leerzeichen klickt, bekommt das.
- **Neues Muster wirkt sofort:** Nach „Speichern“ im Dialog steht das Muster im Detail-Panel ganz oben und ist als neuer Dateiname vorausgewählt.
- **Muster speichern…** legt das Muster unter einem Namen ab (`custom_patterns`); es erscheint in der Vorlagen-Combo und als Muster-Zeile im Detail-Panel. „Löschen“ entfernt es wieder.

## #109 Text aus der Vorschau in die Metadaten
- In der PDF-Vorschau Text mit der Maus markieren → Rechtsklick: **Als … übernehmen** für jedes Metadaten-Feld (Korrespondent, Kategorie, Zusammenfassung, Betrag Netto/Brutto, Währung, MwSt-Satz, IBAN, Steuerjahr) sowie **Kopieren**. IBAN, Beträge, MwSt und Steuerjahr werden dabei bereinigt (Leerzeichen, „€“, „%“, vierstellige Jahreszahl). Die Markierung wird blau hinterlegt und folgt Scrollen/Zoom. Funktioniert auch im großen Vorschau-Fenster („Groß“), sofern es dieselbe PDF zeigt.
- **Lernfähig:** Ein so übernommener Korrespondent wird in die Korrespondenten-Verwaltung aufgenommen. Taucht sein Name (oder ein Alias) später im Text eines Dokuments auf, wird er automatisch als Korrespondent gesetzt – die eigene Schreibweise schlägt den KI-Vorschlag.
- Technik: PDFium liefert nur eine Auswahl, wenn Start- und Endpunkt ein Zeichen treffen; die Punkte rasten deshalb auf die nächste Textzeile ein.

## #110 Kategorie als Auswahlfeld
- „Kategorie“ ist eine editierbare Aufklappliste: zuerst die zuletzt selbst verwendeten Kategorien (gemerkt bei jedem Speichern/Verschieben), dann häufige aus der Sammlung (ohne Bandwurm-Einträge), aufgefüllt mit Standardwerten. Tippen geht weiterhin.

## Metadaten: neu vs. aus dem PDF
- Hatte die PDF schon Metadaten, werden Felder, deren Wert nicht (so) im PDF steht, **pastellgrün** hervorgehoben (wie Kacheln mit KI-Vorschlag) – bis zum Speichern. Status: „Quelle: aus PDF gelesen – grün = neue Vorschläge“ statt „teils … teils“.

## Historie ohne Ordner-Präfix
- Bei „Ordnerstruktur im Namen“ (#42) wird der vom Nutzer gewählte Name **ohne** Ordner-Präfix als KI-Beispiel gespeichert – sonst hätte die KI Ordnernummern nachgeahmt (und beim Verschieben käme das Präfix doppelt).

## Technik
- Neu: `src/core/suggestion_order.py` (Art-Erkennung, Rangfolge, `promote`), `src/core/rename_examples.py` (Ähnlichkeit + Prompt-Abschnitt) – beide ohne Qt/DB testbar.
- `render_with_values(..., min_values=2)`; `Database.get_rename_examples()`; `examples`-Parameter in `suggest_filename`/`_build_filename_prompt` aller Provider; Lookup in `HybridClassifier._rename_examples()`.

## Tests
- Neu: `test_suggestion_order.py`, `test_rename_examples.py`; `test_detail_panel_pattern_suggestions_gui.py` neu geschrieben.
- Volle Suite: 856 passed.

## Nach dem Merge bitte live prüfen
Ob die KI-Namen nach ein paar Dokumenten desselben Absenders dem eigenen Stil folgen – das ist mit Tests nicht abbildbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

