### PR TITLE
chore(release): v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-08-30
+
 ### Geaendert
 - **Einheitliche Vorschlagsliste im Detail-Panel** (#106): Die Auswahl
   „Muster“ unter der Liste ist weg. Stattdessen stehen alle Vorschlaege in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdf-sortier-meister"
-version = "0.22.0"
+version = "0.23.0"
 description = "Ein intelligentes Programm zum Sortieren und Umbenennen von gescannten PDF-Dokumenten"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,7 @@ from src.utils.single_instance import (
 from src.utils.explorer_integration import update_launcher_script
 
 # Versionsnummer zentral definiert
-__version__ = "0.22.0"
+__version__ = "0.23.0"
 
 
 def _apply_wizard_result(window, config):


### PR DESCRIPTION
Version 0.23.0: Einheitliche Vorschlagsliste (#106), Text aus der Vorschau in Metadaten (#109), Kategorie-Auswahl (#110), Muster-Werkzeuge und -Speichern, Historie als KI-Beispiele, gruene Metadaten-Hervorhebung. CHANGELOG umgehaengt, Version gebumpt.