### PR TITLE
fix(gui): Nebenbefunde rund ums Verschieben (Sprint D, Quick-Wins)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Behoben
+- **Fehlerdialog nach „Verschieben nach…“:** Das Verschieben ueber den
+  Ordnerauswahl-Dialog lief durch, meldete danach aber „Verschieben
+  fehlgeschlagen“ (undefinierte Variable beim Aktualisieren der
+  Ordneransicht).
+- **Drop auf gruene Vorschlagskacheln** verschiebt die PDF jetzt wirklich;
+  vorher passierte beim Loslassen nichts.
+- **Kontextmenue der Vorschlagskacheln:** Der wirkungslose Eintrag „Aus
+  Zielliste entfernen“ ist dort weg (Vorschlaege sind Unterordner, keine
+  Eintraege der Zielliste).
+- **Zielordner entfernen** scannt den Zielbaum nur noch einmal statt zweimal.
+- **Tooltip im Zielbaum** nennt jetzt die Tastatur-Navigation (Pfeil rechts
+  klappt auf, * alle Unterordner) und den Rechtsklick.
+
 ## [0.23.0] - 2026-08-30
 
 ### Geaendert

--- a/src/gui/folder_tree_widget.py
+++ b/src/gui/folder_tree_widget.py
@@ -80,7 +80,9 @@ class FolderTreeWidget(QWidget):
     # Kern-Workflow, der sonst fuer neue Nutzer unsichtbar ist (Issue #51).
     _CLICK_HINT = (
         "\n\nEinfachklick: ausgewaehlte PDF hierher verschieben.\n"
-        "Doppelklick: als Scan-Ordner links oeffnen (Navigation)."
+        "Doppelklick: als Scan-Ordner links oeffnen (Navigation).\n"
+        "Pfeil rechts klappt auf, * klappt alle Unterordner auf.\n"
+        "Rechtsklick: weitere Aktionen."
     )
 
     # Signale
@@ -146,6 +148,8 @@ class FolderTreeWidget(QWidget):
         self.tree.setToolTip(
             "Einfachklick auf einen Ordner: ausgewaehlte PDF hierher verschieben.\n"
             "Doppelklick: Ordner links als Scan-Ordner oeffnen (Navigation).\n"
+            "Pfeil rechts klappt einen Ordner auf, * alle Unterordner.\n"
+            "Rechtsklick: weitere Aktionen.\n"
             "PDFs koennen auch per Drag & Drop hierher gezogen werden."
         )
 

--- a/src/gui/folder_widget.py
+++ b/src/gui/folder_widget.py
@@ -150,6 +150,10 @@ class FolderWidget(QFrame):
 
     def contextMenuEvent(self, event):
         """Zeigt das Kontextmenü an."""
+        self._build_context_menu().exec(event.globalPos())
+
+    def _build_context_menu(self) -> QMenu:
+        """Baut das Kontextmenue (getrennt, damit es testbar ist)."""
         menu = QMenu(self)
 
         # Im Dateimanager öffnen
@@ -157,13 +161,16 @@ class FolderWidget(QFrame):
         open_action = menu.addAction(f"Im {file_manager_name()} öffnen")
         open_action.triggered.connect(lambda: self._open_in_explorer())
 
-        menu.addSeparator()
+        # Aus Liste entfernen - nur fuer echte Zielordner-Kacheln. Auf den
+        # gruenen Vorschlagskacheln war der Eintrag wirkungslos (Signal nie
+        # verbunden) und inhaltlich falsch: Vorschlaege sind meist Unterordner,
+        # keine Eintraege der Zielliste.
+        if not self._is_suggestion:
+            menu.addSeparator()
+            remove_action = menu.addAction("Aus Zielliste entfernen")
+            remove_action.triggered.connect(lambda: self.remove_requested.emit(self.folder_path))
 
-        # Aus Liste entfernen
-        remove_action = menu.addAction("Aus Zielliste entfernen")
-        remove_action.triggered.connect(lambda: self.remove_requested.emit(self.folder_path))
-
-        menu.exec(event.globalPos())
+        return menu
 
     def _open_in_explorer(self):
         """Öffnet den Ordner im Dateimanager des Systems."""

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1893,6 +1893,9 @@ class MainWindow(QMainWindow):
 
             widget.clicked.connect(self.on_suggestion_clicked)
             widget.double_clicked.connect(self.on_folder_double_clicked)
+            # Drop auf eine gruene Vorschlagskachel verschiebt wie ein Drop
+            # auf den Baum (vorher stilles No-op, weil nie verbunden)
+            widget.pdf_dropped.connect(self.on_pdf_dropped_on_folder)
 
             self.suggestions_layout.addWidget(widget)
             self.suggestion_widgets.append(widget)
@@ -2650,7 +2653,7 @@ class MainWindow(QMainWindow):
                 # Nur das verschobene PDF-Widget entfernen
                 self._remove_pdf_widget_and_select_next(pdf_path)
                 # Ordneransicht aktualisieren
-                self._refresh_after_move(folder_path, pdf_path.parent)
+                self._refresh_after_move(Path(folder), pdf_path.parent)
                 # Phase 21: Automation-Regeln (Vorschlag im Statusbar)
                 self._check_automation_rules(pdf_path)
                 # Phase 20: Korrespondenten aus Historie sammeln
@@ -3396,7 +3399,11 @@ class MainWindow(QMainWindow):
         """Wird aufgerufen wenn ein Ordner aus der Liste entfernt werden soll."""
         self.config.remove_target_folder(folder_path)
         self.folder_manager.remove_folder(folder_path)
-        self.load_folders()
+        # Der Baum hat sich beim Kontextmenue-Aufruf bereits selbst neu
+        # gescannt; ein zweiter Voll-Scan ueber load_folders() ist nur noetig,
+        # wenn der Aufruf von woanders kam (z.B. aus dem versteckten Raster).
+        if self.folder_tree.has_folder(Path(folder_path)):
+            self.load_folders()
 
         # Auch aus den Vorschlag-Widgets entfernen (grüne Buttons)
         for widget in self.suggestion_widgets[:]:  # Kopie der Liste für sichere Iteration

--- a/tests/test_nebenbefunde_verschieben_gui.py
+++ b/tests/test_nebenbefunde_verschieben_gui.py
@@ -1,0 +1,135 @@
+"""Nebenbefunde aus der Planungsrunde 09/2026 (Fahrplan v0.24).
+
+Vier kleine Fehler rund ums Verschieben, jeder mit eigenem Test:
+
+1. ``on_pdf_move`` benutzte ein undefiniertes ``folder_path`` und zeigte nach
+   erfolgreichem "Verschieben nach..." einen Fehlerdialog (NameError).
+2. Drop auf eine gruene Vorschlagskachel war ein stilles No-op, weil
+   ``pdf_dropped`` in ``display_suggestions`` nie verbunden wurde.
+3. "Aus Zielliste entfernen" auf Vorschlagskacheln war toter Code.
+4. Root-Ordner entfernen scannte den Zielbaum zweimal.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PyQt6 import sip
+
+from src.gui.folder_tree_widget import FolderTreeWidget
+from src.gui.folder_widget import FolderWidget
+from src.ml.classifier import Suggestion
+
+from tests.test_main_window_gui import fresh_singletons, main_window  # noqa: F401
+
+
+def _pdf(folder: Path, name: str = "scan.pdf") -> Path:
+    folder.mkdir(parents=True, exist_ok=True)
+    p = folder / name
+    p.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    return p
+
+
+# 1) "Verschieben nach..." ---------------------------------------------------
+
+
+def test_on_pdf_move_moves_without_error_dialog(main_window, fresh_singletons, monkeypatch):  # noqa: F811
+    from src.gui import main_window as mw_mod
+
+    tmp = fresh_singletons["tmp_path"]
+    pdf = _pdf(tmp / "Scan")
+    target = tmp / "Ziel" / "Ablage"
+    target.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        mw_mod.QFileDialog, "getExistingDirectory", staticmethod(lambda *a, **k: str(target))
+    )
+
+    def boom(*args, **kwargs):  # pragma: no cover - nur bei Regression
+        raise AssertionError(f"Fehlerdialog nach erfolgreichem Verschieben: {args[2:]}")
+
+    monkeypatch.setattr(mw_mod.QMessageBox, "critical", staticmethod(boom))
+
+    main_window.on_pdf_move(pdf)
+
+    assert not pdf.exists()
+    assert (target / "scan.pdf").exists()
+
+
+# 2) Drop auf Vorschlagskachel ----------------------------------------------
+
+
+def test_drop_on_suggestion_tile_is_wired(main_window, fresh_singletons, monkeypatch):  # noqa: F811
+    tmp = fresh_singletons["tmp_path"]
+    target = tmp / "Ziel" / "Rechnungen"
+    target.mkdir(parents=True)
+    pdf = _pdf(tmp / "Scan")
+
+    received = []
+    monkeypatch.setattr(
+        main_window, "on_pdf_dropped_on_folder", lambda p, f: received.append((p, f))
+    )
+
+    main_window.display_suggestions(
+        [Suggestion(folder_path=target, folder_name="Rechnungen", confidence=0.8, reason="Test")]
+    )
+    tile = main_window.suggestion_widgets[0]
+    assert tile.is_suggestion
+
+    tile.pdf_dropped.emit(pdf, target)
+
+    assert received == [(pdf, target)]
+
+
+# 3) Kontextmenue auf Kacheln ----------------------------------------------
+
+
+def test_suggestion_tile_has_no_remove_entry(qtbot, tmp_path):
+    w = FolderWidget(tmp_path, 0)
+    qtbot.addWidget(w)
+    w.is_suggestion = True
+
+    texts = [a.text() for a in w._build_context_menu().actions() if not a.isSeparator()]
+
+    assert texts and "Aus Zielliste entfernen" not in texts
+
+
+def test_target_tile_keeps_remove_entry(qtbot, tmp_path):
+    w = FolderWidget(tmp_path, 0)
+    qtbot.addWidget(w)
+
+    texts = [a.text() for a in w._build_context_menu().actions() if not a.isSeparator()]
+
+    assert "Aus Zielliste entfernen" in texts
+
+
+# 4) Root entfernen: ein Scan statt zwei ------------------------------------
+
+
+def test_remove_root_scans_tree_once(main_window, fresh_singletons, monkeypatch):  # noqa: F811
+    tmp = fresh_singletons["tmp_path"]
+    root_a = tmp / "Ziel A"
+    root_b = tmp / "Ziel B"
+    root_a.mkdir()
+    root_b.mkdir()
+    cfg = fresh_singletons["config"]
+    cfg.add_target_folder(root_a)
+    cfg.add_target_folder(root_b)
+    main_window.folder_manager.add_folder(root_a)
+    main_window.folder_manager.add_folder(root_b)
+
+    tree: FolderTreeWidget = main_window.folder_tree
+    tree.async_scan = False
+    main_window.load_folders()
+    assert tree.has_folder(root_a) and tree.has_folder(root_b)
+
+    scans = []
+    original = tree.refresh_tree
+    monkeypatch.setattr(tree, "refresh_tree", lambda: (scans.append(1), original())[1])
+
+    # Wie ueber das Kontextmenue "Aus Zielliste entfernen"
+    tree._remove_folder(root_a)
+
+    assert len(scans) == 1
+    assert not tree.has_folder(root_a) and tree.has_folder(root_b)
+    assert root_a not in main_window.folder_manager.target_folders


### PR DESCRIPTION
## Was

Vier kleine Fehler aus der Planungsrunde vom 05.09. (Fahrplan v0.24), alle rund ums Verschieben:

- **Fehlerdialog nach „Verschieben nach…“**: `on_pdf_move` benutzte ein undefiniertes `folder_path`; das Verschieben lief durch, danach kam „Verschieben fehlgeschlagen“.
- **Drop auf grüne Vorschlagskacheln** war ein stilles No-op (`pdf_dropped` nie verbunden). Jetzt verschiebt der Drop wie beim Baum.
- **„Aus Zielliste entfernen“ auf Vorschlagskacheln** war toter Code und inhaltlich falsch (Vorschläge sind Unterordner). Eintrag dort entfernt; Kontextmenü ist als `_build_context_menu()` testbar.
- **Zielordner entfernen** scannte den Baum zweimal (Tree refresht sich selbst, dann nochmal `load_folders()`).
- Bonus: **Baum-Tooltip** nennt Pfeil-rechts/`*`-Navigation und Rechtsklick.

## Tests

Neu: `tests/test_nebenbefunde_verschieben_gui.py` (5 Tests). Gesamt 861 grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
