### PR TITLE
chore(lizenz): GPL-3.0-or-later konsistent, LICENSE im Paket, Erststart-Hinweise nach dem Assistenten

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Portables Zip erstellen
         run: |
           $version = (Select-String -Path src/main.py -Pattern '^__version__\s*=\s*"([^"]+)"').Matches[0].Groups[1].Value
+          Copy-Item LICENSE dist\PDF_Sortier_Meister\LICENSE.txt
           Compress-Archive -Path dist\PDF_Sortier_Meister -DestinationPath "dist\installer\PDF_Sortier_Meister-v$version-win64.zip"
 
       - uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Behoben
+- **Lizenz-Angaben konsistent:** Der Über-Dialog nannte „MIT License“, 16
+  Modul-Header ebenfalls; das Projekt steht seit Juli 2026 unter
+  GPL-3.0-or-later. Beides korrigiert, der Lizenztext liegt jetzt als
+  `LICENSE.txt` im Installer und im portablen ZIP (und in `_internal/`).
+- **Erststart:** Die Hinweise „Erste Schritte“ und „Backup empfohlen“
+  erschienen über dem noch offenen Einrichtungsassistenten. Sie kommen jetzt
+  erst, wenn der Assistent geschlossen ist.
+
 ## [0.23.0] - 2026-08-30
 
 ### Geaendert

--- a/installer.iss
+++ b/installer.iss
@@ -58,6 +58,8 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 [Files]
 ; Kompletten PyInstaller-onedir-Ordner mitnehmen
 Source: "dist\PDF_Sortier_Meister\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+; Lizenztext (GPL-3.0-or-later) gut sichtbar neben der EXE
+Source: "LICENSE"; DestDir: "{app}"; DestName: "LICENSE.txt"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"

--- a/pdf_sortier_meister.spec
+++ b/pdf_sortier_meister.spec
@@ -44,6 +44,9 @@ if SPLASH_IMG.exists():
 if (ROOT_DIR / "icon.png").exists():
     # Fenster-/Taskleisten-Icon zur Laufzeit (app.setWindowIcon)
     datas.append((str(ROOT_DIR / "icon.png"), "."))
+# Lizenztext (GPL-3.0-or-later) muss mit jedem Binary ausgeliefert werden
+if (ROOT_DIR / "LICENSE").exists():
+    datas.append((str(ROOT_DIR / "LICENSE"), "."))
 # Gebuendelte Tesseract-Laufzeit (vorher scripts/prepare_tesseract.py bzw.
 # scripts/prepare_tesseract_mac.py ausfuehren).
 # Landet in _internal/tesseract/ und wird von find_tesseract() zuerst gefunden.

--- a/src/gui/chat_view.py
+++ b/src/gui/chat_view.py
@@ -7,7 +7,7 @@ Status-/Banner-Bereich. Der eigentliche RAG-Aufruf laeuft asynchron
 ueber :class:`~src.gui.chat_worker.ChatWorker` in einem ``QThread``,
 damit die GUI nicht einfriert.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 from html import escape

--- a/src/gui/chat_worker.py
+++ b/src/gui/chat_worker.py
@@ -7,7 +7,7 @@ nicht einfriert. Der Worker ist ein ``QObject`` und wird per
 ``moveToThread`` in einen ``QThread`` verschoben (Architektur-Vorgabe
 R3: striktes QObject-move-to-thread-Pattern, kein QThread-Subclassing).
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import threading

--- a/src/gui/folder_tree_widget.py
+++ b/src/gui/folder_tree_widget.py
@@ -4,7 +4,7 @@ Ordner-Baum-Widget für PDF Sortier Meister
 Zeigt eine hierarchische Ordnerstruktur als Baumansicht an.
 Unterstützt Unterordner und zeigt PDF-Anzahlen an.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import os

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -4304,10 +4304,12 @@ class MainWindow(QMainWindow):
         # Lizenz
         license_label = QLabel(
             "<p style='color: #666; font-size: 11px;'>"
-            "<b>Lizenz:</b> MIT License<br>"
+            "<b>Lizenz:</b> GPL-3.0-or-later<br>"
             "Copyright (c) 2024-2026<br>"
-            "Freie Software - Open Source</p>"
+            "Freie Software - Open Source. Lizenztext: "
+            '<a href="https://www.gnu.org/licenses/gpl-3.0.html">gnu.org/licenses/gpl-3.0</a></p>'
         )
+        license_label.setOpenExternalLinks(True)
         license_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(license_label)
 

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -3,7 +3,7 @@ Einstellungsdialog für PDF Sortier Meister
 
 Ermöglicht die Konfiguration von LLM-Providern und anderen Einstellungen.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 from PyQt6.QtWidgets import (

--- a/src/main.py
+++ b/src/main.py
@@ -40,6 +40,22 @@ from src.utils.explorer_integration import update_launcher_script
 __version__ = "0.23.0"
 
 
+def _schedule_startup_hints(window, delay_ms: int = 300) -> None:
+    """Zeigt Erste-Schritte- und Backup-Hinweis kurz nach dem Start.
+
+    Reihenfolge: Erste Schritte (Issue #51) vor dem Backup-Hinweis, weil der
+    Workflow wichtiger ist als die Backup-Erinnerung. Beim Erststart wird die
+    Funktion erst NACH dem Einrichtungsassistenten aufgerufen, damit die
+    Dialoge nicht ueber dem offenen Assistenten erscheinen.
+    """
+
+    def show_startup_hints():
+        window.show_first_steps_hint()
+        window.show_backup_hint()
+
+    QTimer.singleShot(delay_ms, show_startup_hints)
+
+
 def _apply_wizard_result(window, config):
     """Aktualisiert das Hauptfenster nach dem Einrichtungs-Assistenten.
 
@@ -242,7 +258,7 @@ def main():
     # Scan-Ordner konfiguriert ist und thumbnails_loaded nicht feuert.
     _splash_closed = {"done": False}
 
-    def close_splash():
+    def close_splash(show_hints: bool = True):
         if _splash_closed["done"]:
             return
         _splash_closed["done"] = True
@@ -255,15 +271,11 @@ def main():
                 pass
         window.raise_()
         window.activateWindow()
-
-        def show_startup_hints():
-            # Erste-Schritte-Hinweis (Issue #51) vor dem Backup-Hinweis zeigen,
-            # weil der Workflow wichtiger ist als die Backup-Erinnerung.
-            window.show_first_steps_hint()
-            window.show_backup_hint()
-
-        # Hinweise erst zeigen, wenn der Splash weg ist
-        QTimer.singleShot(300, show_startup_hints)
+        # Hinweise erst zeigen, wenn der Splash weg ist. Beim Erststart
+        # uebernimmt das der Wizard-Zweig unten, sonst laegen die Dialoge
+        # ueber dem offenen Assistenten.
+        if show_hints:
+            _schedule_startup_hints(window)
 
     window.thumbnails_loaded.connect(close_splash)
     QTimer.singleShot(15000, close_splash)
@@ -272,12 +284,15 @@ def main():
     if not config.get_scan_folder():
         # Splash sofort schliessen: ohne Scan-Ordner feuert thumbnails_loaded
         # nie und der Splash laege 15s ueber dem Wizard (Issue #50)
-        close_splash()
+        close_splash(show_hints=False)
         wizard = SetupWizard(window)
         wizard.exec()
         # Nach dem Wizard: Hauptfenster mit neuem Scan-Ordner und LLM-Status
         # aktualisieren (Closes #65)
         _apply_wizard_result(window, config)
+        # Erst jetzt die Erste-Schritte-/Backup-Hinweise, nicht waehrend
+        # der Assistent offen ist
+        _schedule_startup_hints(window)
 
     # Update-Pruefung im Hintergrund, kurz nach dem Start (Issue #73).
     # Bewusst hier und nicht im MainWindow-Konstruktor, damit Tests und

--- a/src/ml/claude_provider.py
+++ b/src/ml/claude_provider.py
@@ -3,7 +3,7 @@ Claude API Provider für PDF Sortier Meister
 
 Implementiert die LLM-Schnittstelle für Anthropic's Claude API.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import json

--- a/src/ml/hybrid_classifier.py
+++ b/src/ml/hybrid_classifier.py
@@ -4,7 +4,7 @@ Hybrid-Klassifikator für PDF Sortier Meister
 Kombiniert lokale TF-IDF Klassifikation mit optionaler LLM-Unterstützung
 für bessere Sortier- und Benennungsvorschläge.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 from pathlib import Path

--- a/src/ml/llm_provider.py
+++ b/src/ml/llm_provider.py
@@ -4,7 +4,7 @@ LLM Provider-Abstraktion für PDF Sortier Meister
 Bietet eine einheitliche Schnittstelle für verschiedene LLM-Anbieter
 (Claude, OpenAI, etc.) zur Klassifikation und Benennung von PDFs.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import json

--- a/src/ml/ollama_provider.py
+++ b/src/ml/ollama_provider.py
@@ -18,7 +18,7 @@ Nachteile:
 Diese Implementierung spricht die native Ollama-API (/api/chat) ueber
 urllib (stdlib), um keine zusaetzliche Dependency einzufuehren.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import json

--- a/src/ml/openai_provider.py
+++ b/src/ml/openai_provider.py
@@ -3,7 +3,7 @@ OpenAI API Provider für PDF Sortier Meister
 
 Implementiert die LLM-Schnittstelle für OpenAI's GPT API.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import json

--- a/src/ml/poe_provider.py
+++ b/src/ml/poe_provider.py
@@ -5,7 +5,7 @@ Implementiert die LLM-Schnittstelle für Poe.com's API.
 Poe bietet Zugang zu verschiedenen Modellen (GPT, Claude, Gemini, etc.)
 über eine einheitliche OpenAI-kompatible API.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import json

--- a/src/rag/__init__.py
+++ b/src/rag/__init__.py
@@ -17,7 +17,7 @@ Stellt die Kernbausteine des RAG-Chat-Features bereit:
 Die GUI-Komponenten (``ChatView``, ``ChatWorker``) sind Bestandteil
 von M2 und werden hier nicht exportiert.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 from src.rag.chat_session import ChatSession, ChatTurn

--- a/src/rag/chat_session.py
+++ b/src/rag/chat_session.py
@@ -6,7 +6,7 @@ Token-Schaetzung und History-Slicing fuer den Prompt-Builder.
 
 Persistence (SQLite) ist explizit Q1-deferred und nicht Teil von M1.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 from dataclasses import dataclass, field

--- a/src/rag/citation.py
+++ b/src/rag/citation.py
@@ -13,7 +13,7 @@ Implementiert in M1, weil die ``RAGController.ask``-Pipeline den Parser
 bereits aufrufen soll (M3 wird das ganze noch verfeinern: Ranking,
 Footer-Rekonstruktion, Whitelist-Heuristiken).
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import re

--- a/src/rag/prompts.py
+++ b/src/rag/prompts.py
@@ -8,7 +8,7 @@ bereit:
 * :func:`build_context_block` erzeugt den ``=== DOKUMENTE ===``-Block.
 * :func:`build_user_prompt` baut die User-Message inkl. History.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 # System-Prompt - VERBATIM aus docs/ARCHITECTURE.md Section 4.

--- a/src/rag/rag_controller.py
+++ b/src/rag/rag_controller.py
@@ -9,7 +9,7 @@ Der Controller haelt zusaetzlich eine ``ChatSession`` (Konversationshistorie)
 und einen simplen LRU-Cache fuer Frage/Antwort-Paaren, damit
 wiederholt gestellte Fragen nicht erneut das LLM rufen.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 from __future__ import annotations

--- a/src/rag/retrieval.py
+++ b/src/rag/retrieval.py
@@ -9,7 +9,7 @@ und produziert ``RetrievedDoc``-Objekte mit trunc-Snippets
 Kein LLM noetig - alles in stdlib (re, str) plus der bestehende
 ``Database.search_documents``-Methode.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import re

--- a/tests/test_first_start_wizard.py
+++ b/tests/test_first_start_wizard.py
@@ -56,3 +56,21 @@ def test_apply_wizard_result_calls_settings_changed_after_initial_load(qtbot, fr
     _apply_wizard_result(window, fresh_config)
 
     assert calls == ["initial_load", "settings_changed"]
+
+
+def test_schedule_startup_hints_shows_first_steps_before_backup(qtbot):
+    """Erststart-Reihenfolge: Erste Schritte vor dem Backup-Hinweis, und beide
+    erst nach der Verzoegerung (also nach dem Einrichtungsassistenten, der
+    vorher synchron per exec() lief)."""
+    from src.main import _schedule_startup_hints
+
+    calls = []
+    window = MagicMock()
+    window.show_first_steps_hint.side_effect = lambda: calls.append("first_steps")
+    window.show_backup_hint.side_effect = lambda: calls.append("backup")
+
+    _schedule_startup_hints(window, delay_ms=0)
+    assert calls == []  # nichts synchron
+
+    qtbot.waitUntil(lambda: len(calls) == 2, timeout=2000)
+    assert calls == ["first_steps", "backup"]


### PR DESCRIPTION
## Was

Zwei Nebenbefunde aus der Planungsrunde vom 05.09. (Fahrplan v0.24):

- **Lizenz-Konsistenz**: Über-Dialog sagte „MIT License“, 16 Modul-Header ebenso. Das Projekt ist seit 07/2026 GPL-3.0-or-later (d6859fb). Beides korrigiert; der Über-Dialog verlinkt den Lizenztext.
- **LICENSE im Paket**: bisher weder im Installer noch im ZIP. Jetzt in `_internal/` (Spec, jeder Build), als `LICENSE.txt` neben der EXE im Installer (`installer.iss`) und im portablen ZIP (`release.yml`).
- **Erststart**: `close_splash()` lief vor `wizard.exec()` und plante die Erste-Schritte-/Backup-Hinweise, die dann über dem offenen Assistenten aufgingen. Neu: `_schedule_startup_hints()` wird beim Erststart erst nach dem Wizard aufgerufen.

## Tests

Neu: `test_schedule_startup_hints_shows_first_steps_before_backup`. Betroffene Suiten grün (Wizard + MainWindow); volle Suite lief auf dem Schwester-PR #119 mit 861 grün. Installer/ZIP-Änderung wird erst beim nächsten Release-Run sichtbar (Checkliste: `LICENSE.txt` im Setup-Ordner prüfen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
