### PR TITLE
fix(#108): Klick auf Scan-PDF wiederholt keine OCR mehr (Teil A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Behoben
+- **Klick auf eine gescannte PDF dauerte 7 Sekunden** (#108, Teil 1): Beim
+  Anklicken lief die Texterkennung (OCR) noch einmal komplett durch, obwohl
+  der Text laengst im Cache lag. Die Dateinamen-Vorschlaege „Automatisch
+  erkannt“ nutzen jetzt den Cache und oeffnen die PDF nur noch, wenn
+  wirklich etwas fehlt. Betrifft alle vier Wege: Klick, KI-Nachlieferung,
+  Suchfeld leeren und den Umbenennen-Dialog. Nebenbei: Datumsangaben aus dem
+  Cache erscheinen in den Vorschlaegen wieder als „2026-05-12“ statt
+  „2026-05-12 00:00:00“.
+
 ## [0.23.0] - 2026-08-30
 
 ### Geaendert

--- a/src/core/pdf_analyzer.py
+++ b/src/core/pdf_analyzer.py
@@ -311,16 +311,33 @@ class PDFAnalyzer:
 
         return found_keywords
 
-    def suggest_filename(self) -> str:
+    def suggest_filename(
+        self,
+        text: Optional[str] = None,
+        keywords: Optional[list[str]] = None,
+        dates: Optional[list] = None,
+    ) -> str:
         """
         Schlägt einen sinnvollen Dateinamen basierend auf dem Inhalt vor.
+
+        Args:
+            text: Bereits extrahierter Text (z.B. aus dem Cache). Wird er
+                uebergeben, wird die PDF NICHT erneut geoeffnet und keine
+                OCR wiederholt (Issue #108: 7 s Freeze pro Klick).
+            keywords: Bereits extrahierte Schluesselwoerter
+            dates: Bereits extrahierte Datumsangaben; datetime-Objekte oder
+                Strings wie "2026-05-12 00:00:00" (so liegen sie im Cache)
 
         Returns:
             Vorgeschlagener Dateiname
         """
-        text = self.extract_text()
-        keywords = self.extract_keywords()
-        dates = self.extract_dates()
+        if text is None:
+            text = self.extract_text()
+        if keywords is None:
+            keywords = self.extract_keywords()
+        if dates is None:
+            dates = self.extract_dates()
+        dates = coerce_dates(dates)
 
         parts = []
 
@@ -381,6 +398,45 @@ class PDFAnalyzer:
 
         return None
 
+
+
+def coerce_date(value) -> Optional[datetime]:
+    """Macht aus einem Cache-Datum wieder ein datetime.
+
+    Der PDF-Cache speichert Datumsangaben als ``str(datetime)``, also
+    "2026-05-12 00:00:00"; aeltere Eintraege oder LLM-Antworten liefern
+    "2026-05-12". Alles andere ergibt None.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if hasattr(value, "strftime"):  # date
+        return datetime(value.year, value.month, value.day)
+    if isinstance(value, str):
+        text = value.strip()
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d", "%d.%m.%Y"):
+            try:
+                return datetime.strptime(text, fmt)
+            except ValueError:
+                continue
+        try:
+            return datetime.fromisoformat(text)
+        except ValueError:
+            return None
+    return None
+
+
+def coerce_dates(values) -> list[datetime]:
+    """Wie :func:`coerce_date`, fuer Listen; unbrauchbare Eintraege fallen weg."""
+    if not values:
+        return []
+    result = []
+    for v in values:
+        d = coerce_date(v)
+        if d is not None:
+            result.append(d)
+    return result
 
 
 def _tesseract_candidates() -> list[Path]:

--- a/src/gui/rename_dialog.py
+++ b/src/gui/rename_dialog.py
@@ -535,26 +535,42 @@ def generate_rename_suggestions(
     """
     suggestions = []
 
-    # 1. Vorschlag aus PDF-Analyzer
+    # 1. Vorschlag aus PDF-Analyzer.
+    # Issue #108: Liegen Text, Stichwoerter und Datumsangaben schon vor (aus
+    # dem PDF-Cache), wird die PDF NICHT geoeffnet - vorher lief hier bei
+    # jedem Klick auf eine Scan-PDF die komplette OCR noch einmal im
+    # GUI-Thread (7 s Freeze). Nur fehlende Teile werden nachgeladen.
     try:
-        from src.core.pdf_analyzer import PDFAnalyzer
+        from src.core.pdf_analyzer import PDFAnalyzer, coerce_dates
 
-        with PDFAnalyzer(pdf_path) as analyzer:
-            if extracted_text is None:
-                extracted_text = analyzer.extract_text()
-            if keywords is None:
-                keywords = analyzer.extract_keywords()
-            if dates is None:
-                dates = analyzer.extract_dates()
+        if dates is not None:
+            dates = coerce_dates(dates)
 
-            # Standard-Vorschlag
-            suggested = analyzer.suggest_filename()
-            if suggested and suggested != pdf_path.name:
-                suggestions.append(RenameSuggestion(
-                    name=suggested,
-                    reason="Automatisch erkannt",
-                    confidence=0.6
-                ))
+        analyzer = PDFAnalyzer(pdf_path)
+        needs_pdf = extracted_text is None or keywords is None or dates is None
+        try:
+            if needs_pdf:
+                analyzer.open()
+                if extracted_text is None:
+                    extracted_text = analyzer.extract_text()
+                if keywords is None:
+                    keywords = analyzer.extract_keywords()
+                if dates is None:
+                    dates = analyzer.extract_dates()
+
+            # Standard-Vorschlag - rein aus den vorliegenden Werten
+            suggested = analyzer.suggest_filename(
+                text=extracted_text, keywords=keywords, dates=dates
+            )
+        finally:
+            analyzer.close()
+
+        if suggested and suggested != pdf_path.name:
+            suggestions.append(RenameSuggestion(
+                name=suggested,
+                reason="Automatisch erkannt",
+                confidence=0.6
+            ))
 
     except Exception as e:
         print(f"Fehler bei PDF-Analyse für Vorschläge: {e}")
@@ -568,7 +584,7 @@ def generate_rename_suggestions(
                 date_str = first_date.strftime("%Y-%m-%d")
             else:
                 # Falls es bereits ein String ist
-                date_str = str(first_date)
+                date_str = str(first_date)[:10]
 
             # Nur Datum
             suggestions.append(RenameSuggestion(

--- a/tests/test_rename_suggestions_cache_108.py
+++ b/tests/test_rename_suggestions_cache_108.py
@@ -1,0 +1,97 @@
+"""Issue #108: Dateinamen-Vorschlaege duerfen die PDF nicht erneut oeffnen,
+wenn Text, Stichwoerter und Datumsangaben schon aus dem Cache vorliegen.
+
+Vorher rief generate_rename_suggestions() trotz uebergebener Cache-Werte
+PDFAnalyzer.suggest_filename() auf, das alles neu extrahierte - bei
+Scan-PDFs inklusive Tesseract-OCR ueber 5 Seiten im GUI-Thread (7 s Freeze
+pro Klick im Log des Users vom 30.08.2026).
+"""
+from datetime import datetime
+from pathlib import Path
+
+import fitz
+import pytest
+
+from src.core.pdf_analyzer import PDFAnalyzer, coerce_date, coerce_dates
+from src.gui.rename_dialog import generate_rename_suggestions
+
+
+def _pdf(path: Path, text: str) -> Path:
+    d = fitz.open(); p = d.new_page(); p.insert_text((72, 72), text); d.save(str(path)); d.close()
+    return path
+
+
+# --- coerce_date ----------------------------------------------------------
+
+@pytest.mark.parametrize("value", [
+    "2026-05-12 00:00:00",          # so speichert der PDF-Cache (str(datetime))
+    "2026-05-12",
+    "12.05.2026",
+    datetime(2026, 5, 12),
+])
+def test_coerce_date_accepts_cache_formats(value):
+    assert coerce_date(value) == datetime(2026, 5, 12)
+
+
+def test_coerce_dates_drops_garbage():
+    assert coerce_dates(["2026-05-12 00:00:00", "kein datum", None]) == [datetime(2026, 5, 12)]
+    assert coerce_dates(None) == []
+
+
+# --- suggest_filename mit Cache-Werten --------------------------------------
+
+def test_suggest_filename_with_cache_values_does_not_open_pdf(tmp_path):
+    """Die Datei existiert nicht - jedes Oeffnen wuerde fliegen."""
+    analyzer = PDFAnalyzer(tmp_path / "gibt_es_nicht.pdf")
+    name = analyzer.suggest_filename(
+        text="Rechnung der Muster GmbH vom 15.03.2026",
+        keywords=["rechnung"],
+        dates=["2026-03-15 00:00:00"],
+    )
+    assert name == "Rechnung Muster 2026-03.pdf"
+
+
+def test_suggest_filename_without_args_still_extracts(tmp_path):
+    pdf = _pdf(tmp_path / "scan.pdf", "Rechnung Nr. 42 vom 15.03.2026, zahlbar sofort.")
+    with PDFAnalyzer(pdf) as a:
+        assert a.suggest_filename().startswith("Rechnung")
+
+
+# --- generate_rename_suggestions --------------------------------------------
+
+def test_generate_suggestions_from_cache_never_opens_pdf(tmp_path, monkeypatch):
+    opened = []
+    real_open = PDFAnalyzer.open
+    monkeypatch.setattr(PDFAnalyzer, "open", lambda self: opened.append(self.pdf_path) or real_open(self))
+
+    suggestions = generate_rename_suggestions(
+        pdf_path=tmp_path / "gibt_es_nicht.pdf",
+        extracted_text="Rechnung der Muster GmbH vom 15.03.2026",
+        keywords=["rechnung"],
+        dates=["2026-03-15 00:00:00"],
+    )
+
+    assert opened == []
+    reasons = {s.reason: s.name for s in suggestions}
+    assert reasons["Automatisch erkannt"] == "Rechnung Muster 2026-03.pdf"
+    assert reasons["Nur Datum"] == "2026-03-15.pdf"          # vorher "2026-03-15 00:00:00.pdf"
+    assert reasons["Datum + Kategorie (Rechnung)"] == "2026-03-15 Rechnung.pdf"
+
+
+def test_generate_suggestions_empty_cache_text_means_no_ocr_retry(tmp_path, monkeypatch):
+    """Leerer Text im Cache (OCR fand nichts) ist ein Ergebnis, kein Fehlen:
+    die PDF darf trotzdem nicht erneut geoeffnet werden."""
+    opened = []
+    monkeypatch.setattr(PDFAnalyzer, "open", lambda self: opened.append(1))
+
+    generate_rename_suggestions(
+        pdf_path=tmp_path / "scan.pdf", extracted_text="", keywords=[], dates=[]
+    )
+
+    assert opened == []
+
+
+def test_generate_suggestions_opens_pdf_only_when_something_is_missing(tmp_path):
+    pdf = _pdf(tmp_path / "scan.pdf", "Rechnung Nr. 42 vom 15.03.2026, zahlbar sofort.")
+    suggestions = generate_rename_suggestions(pdf_path=pdf, extracted_text=None)
+    assert any(s.reason == "Automatisch erkannt" for s in suggestions)


### PR DESCRIPTION
## Ursache

`generate_rename_suggestions()` in `rename_dialog.py` kopierte den übergebenen Cache-Text nur in lokale Variablen und rief trotzdem `PDFAnalyzer.suggest_filename()`, das Text, Stichwörter und Daten komplett neu extrahierte. Bei Scan-PDFs ohne Textebene heißt das: Tesseract-OCR über 5 Seiten im GUI-Thread, bei jedem Klick. Im Log des Users vom 30.08. zwölf Klicks mit `detail` 6839 bis 7720 ms. Code seit dem Initial-Commit unverändert.

Vier Einstiege lösen dieselbe Funktion aus (Klick, KI-Nachlieferung, Suchfeld leeren, Umbenennen-Dialog); alle profitieren.

## Änderung

- `PDFAnalyzer.suggest_filename(text=None, keywords=None, dates=None)`: mit Cache-Werten wird die PDF nicht geöffnet.
- `coerce_date()` / `coerce_dates()`: Cache-Datumsstrings (`"2026-03-15 00:00:00"`) werden wieder `datetime`. Nebeneffekt: „Nur Datum“ heißt wieder `2026-03-15.pdf` statt `2026-03-15 00:00:00.pdf`.
- `generate_rename_suggestions()` öffnet die PDF nur noch, wenn etwas fehlt. Leerer Cache-Text (OCR fand nichts) zählt als Ergebnis, nicht als Fehlen.

## Messung

Synthetische 5-seitige Bild-PDF, `generate_rename_suggestions()`:

| | Dauer |
|---|---|
| ohne Cache-Werte (OCR) | 2524 ms |
| mit Cache-Werten | 4.9 ms |

Erwartung im Log nach dem Update: `Klick … detail` unter 300 ms für die Teilungserklärung.

## Noch offen (Teil B, eigener PR)

Wartezeiger + Kachelzustand „Analysiere…“ für den Erst-Klick, StepTimer-Zeile für den asynchronen Pfad, Deduplizierung im Analyse-Worker.

## Tests

Neu: `tests/test_rename_suggestions_cache_108.py` (10 Tests). Volle Suite: 871 grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
