### PR TITLE
feat(#108): Wartezeiger beim Erst-Klick, Analyse-Log, Worker-Dedupe (Teil B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Geaendert
+- **Erst-Klick auf eine noch nicht analysierte PDF** (#108, Teil 2): Waehrend
+  die Texterkennung laeuft, zeigt die Kachel „Analysiere…“, der Mauszeiger
+  wird zum Wartezeiger und die Statusleiste erklaert, dass OCR einige
+  Sekunden dauern kann. Dieselbe PDF wird nicht mehr mehrfach analysiert,
+  wenn sie gleichzeitig vom Vorab-Laden und vom Klick angefordert wird.
+- **Log:** Zu jeder Analyse steht jetzt eine Zeile `Analyse <datei> <ms>:
+  seiten … | ocr ja/nein | zeichen …`, und der Klick-Pfad nach einer
+  Analyse loggt als `Klick nach Analyse …`. Damit ist im Log sichtbar, ob
+  eine Wartezeit von der OCR oder von der Oberflaeche kommt.
+
 ## [0.23.0] - 2026-08-30
 
 ### Geaendert

--- a/src/core/pdf_analyzer.py
+++ b/src/core/pdf_analyzer.py
@@ -34,6 +34,8 @@ class PDFAnalyzer:
         self._doc: Optional[fitz.Document] = None
         self._text: Optional[str] = None
         self._thumbnail: Optional[QPixmap] = None
+        # True, sobald extract_text() auf OCR zurueckgreifen musste (Log, #108)
+        self.ocr_used = False
 
     def __enter__(self):
         """Context Manager Eintritt."""
@@ -138,6 +140,7 @@ class PDFAnalyzer:
 
         # Falls kein Text gefunden und OCR aktiviert
         if not self._text.strip() and use_ocr:
+            self.ocr_used = True
             self._text = self._extract_text_ocr()
 
         return self._text

--- a/src/core/pdf_cache.py
+++ b/src/core/pdf_cache.py
@@ -62,16 +62,48 @@ class PDFAnalysisWorker(QThread):
         self._running = True
         self._current_pdf: Optional[Path] = None
         self._lock = Lock()
+        # Eingereihte PDFs mit ihrer besten Prioritaet (Issue #108): dieselbe
+        # PDF landete vorher mehrfach in der Queue (Pre-Cache + Klick + Klick),
+        # jede Kopie lief die volle OCR erneut.
+        self._queued: dict[Path, int] = {}
 
     def add_task(self, pdf_path: Path, priority: int = 5):
         """
         Fügt eine Analyse-Aufgabe zur Queue hinzu.
 
+        Bereits eingereihte PDFs werden nicht doppelt analysiert; eine
+        dringendere Anfrage (kleinere Zahl) ueberholt eine wartende.
+
         Args:
             pdf_path: Pfad zur PDF
             priority: 1 = höchste Priorität (User-Interaktion), 10 = niedrigste (Pre-Cache)
         """
+        with self._lock:
+            known = self._queued.get(pdf_path)
+            if known is not None and known <= priority:
+                return
+            self._queued[pdf_path] = priority
         self._queue.put((priority, time.time(), pdf_path))
+
+    def queued_count(self) -> int:
+        """Anzahl unterschiedlicher PDFs, die noch auf Analyse warten."""
+        with self._lock:
+            return len(self._queued)
+
+    def _dequeue(self, timeout: float = 1.0) -> Optional[Path]:
+        """Naechste PDF aus der Queue; veraltete Duplikate werden uebersprungen.
+
+        Returns:
+            Pfad, oder None bei Timeout/Stop-Dummy/uebersprungenem Duplikat.
+        """
+        priority, _timestamp, pdf_path = self._queue.get(timeout=timeout)
+        if pdf_path is None:
+            return None
+        with self._lock:
+            if self._queued.get(pdf_path) != priority:
+                return None  # ueberholt oder schon analysiert
+            del self._queued[pdf_path]
+        return pdf_path
 
     def add_urgent(self, pdf_path: Path):
         """Fügt eine dringende Analyse hinzu (User hat geklickt)."""
@@ -100,7 +132,7 @@ class PDFAnalysisWorker(QThread):
             try:
                 # Warte auf nächste Aufgabe (mit Timeout für sauberes Beenden)
                 try:
-                    priority, timestamp, pdf_path = self._queue.get(timeout=1.0)
+                    pdf_path = self._dequeue(timeout=1.0)
                 except queue.Empty:
                     continue
 
@@ -115,6 +147,7 @@ class PDFAnalysisWorker(QThread):
                     if not pdf_path.exists():
                         continue
 
+                    t0 = time.perf_counter()
                     with PDFAnalyzer(pdf_path) as analyzer:
                         result = PDFAnalysisResult(
                             pdf_path=pdf_path,
@@ -123,6 +156,15 @@ class PDFAnalysisWorker(QThread):
                             dates=analyzer.extract_dates(),
                             file_modified=pdf_path.stat().st_mtime
                         )
+                        pages = analyzer.page_count
+                        ocr_used = analyzer.ocr_used
+                    ms = (time.perf_counter() - t0) * 1000.0
+                    # Gegenstueck zur "Klick ..."-Zeile des StepTimers: der
+                    # asynchrone Teil war im Log bisher unsichtbar (Issue #108)
+                    line = (f"Analyse {pdf_path.name} {ms:.0f} ms: seiten {pages} | "
+                            f"ocr {'ja' if ocr_used else 'nein'} | "
+                            f"zeichen {len(result.extracted_text)}")
+                    (logger.info if ms >= 100 else logger.debug)(line)
 
                     self.analysis_complete.emit(pdf_path, result)
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1593,6 +1593,9 @@ class MainWindow(QMainWindow):
 
         self.statusbar.showMessage(f"Ausgewählt: {pdf_path.name}")
 
+        # Wartezustand einer noch laufenden Erst-Analyse fuer die vorige PDF beenden
+        self._end_analysis_wait()
+
         # PDF analysieren und Vorschläge aktualisieren
         self._click_timer = StepTimer("Klick")
         self.update_suggestions_for_pdf(pdf_path)
@@ -1685,6 +1688,7 @@ class MainWindow(QMainWindow):
 
     def _clear_selection(self):
         """Hebt die aktuelle Auswahl vollständig auf."""
+        self._end_analysis_wait()
         try:
             # Alle Widgets deselektieren
             for widget in self.pdf_widgets:
@@ -1729,8 +1733,10 @@ class MainWindow(QMainWindow):
             # Sofort aus Cache verwenden - keine Verzögerung!
             self._apply_analysis_result(pdf_path, cached_result)
         else:
-            # Noch nicht analysiert - Hintergrund-Analyse starten
-            self.statusbar.showMessage(f"Analysiere {pdf_path.name}...")
+            # Noch nicht analysiert - Hintergrund-Analyse starten. Bei Scan-PDFs
+            # ist das die OCR (mehrere Sekunden): Wartezeiger + Kachelzustand,
+            # damit der Klick sichtbar angekommen ist (Issue #108)
+            self._begin_analysis_wait(pdf_path)
 
             # Analyse anfordern mit Callback
             self.pdf_cache.request_analysis(
@@ -1739,11 +1745,51 @@ class MainWindow(QMainWindow):
                 urgent=True  # Höchste Priorität weil User geklickt hat
             )
 
+    def _begin_analysis_wait(self, pdf_path: Path):
+        """Wartezeiger + "Analysiere…" auf der Kachel, bis die Erst-Analyse da ist."""
+        self._end_analysis_wait()
+        self._analysis_wait_pdf = pdf_path
+        QApplication.setOverrideCursor(Qt.CursorShape.BusyCursor)
+        self.statusbar.showMessage(
+            f"Analysiere {pdf_path.name}… (Texterkennung kann einige Sekunden dauern)"
+        )
+        widget = self._pdf_widget_for(pdf_path)
+        if widget is not None:
+            widget.analyzing = True
+
+    def _end_analysis_wait(self):
+        """Beendet den Wartezustand der Erst-Analyse (idempotent)."""
+        pdf_path = getattr(self, "_analysis_wait_pdf", None)
+        if pdf_path is None:
+            return
+        self._analysis_wait_pdf = None
+        QApplication.restoreOverrideCursor()
+        widget = self._pdf_widget_for(pdf_path)
+        if widget is not None:
+            widget.analyzing = False
+
+    def _pdf_widget_for(self, pdf_path: Path):
+        for widget in self.pdf_widgets:
+            try:
+                if widget.pdf_path == pdf_path:
+                    return widget
+            except RuntimeError:
+                continue  # Widget bereits von Qt geloescht
+        return None
+
     def _on_analysis_result_ready(self, pdf_path: Path, result: PDFAnalysisResult):
         """Wird aufgerufen wenn eine Analyse fertig ist (aus Cache-Worker)."""
+        # Wartezustand IMMER zuruecksetzen - auch wenn der Nutzer inzwischen
+        # etwas anderes ausgewaehlt hat, sonst bleibt der Wartezeiger haengen
+        if getattr(self, "_analysis_wait_pdf", None) == pdf_path:
+            self._end_analysis_wait()
         # Nur anwenden wenn diese PDF noch ausgewählt ist
         if self.selected_pdf == pdf_path:
+            # Eigene Log-Zeile fuer den asynchronen Pfad: der "Klick"-Timer
+            # ist laengst abgeschlossen, seine Schritte gingen bisher verloren
+            self._click_timer = StepTimer("Klick nach Analyse")
             self._apply_analysis_result(pdf_path, result)
+            self._click_timer.done()
 
     def _on_pdf_analyzed(self, pdf_path: Path):
         """Wird aufgerufen wenn irgendeine PDF analysiert wurde (Cache-Signal)."""

--- a/src/gui/pdf_thumbnail.py
+++ b/src/gui/pdf_thumbnail.py
@@ -71,6 +71,7 @@ class PDFThumbnailWidget(QFrame):
         self.pdf_path = pdf_path
         self._selected = False
         self._has_ai_suggestion = False  # Issue #81: KI-Vorschlag im Cache
+        self._analyzing = False  # Issue #108: Erst-Analyse (OCR) laeuft gerade
         self._loader_thread: Optional[ThumbnailLoaderThread] = None
         self._drag_start_position: Optional[QPoint] = None
 
@@ -181,6 +182,26 @@ class PDFThumbnailWidget(QFrame):
         self._has_ai_suggestion = value
         self.setToolTip(self._BASE_TOOLTIP + (self.AI_TOOLTIP_SUFFIX if value else ""))
         self._update_style()
+
+    ANALYZING_TEXT = "Analysiere…"
+
+    @property
+    def analyzing(self) -> bool:
+        """True, waehrend die Erst-Analyse (Text/OCR) fuer diese PDF laeuft."""
+        return self._analyzing
+
+    @analyzing.setter
+    def analyzing(self, value: bool):
+        value = bool(value)
+        if value == self._analyzing:
+            return
+        self._analyzing = value
+        if value:
+            self.name_label.setText(self.ANALYZING_TEXT)
+            self.name_label.setStyleSheet("font-size: 11px; line-height: 1.2; color: #b8860b; font-style: italic;")
+        else:
+            self.name_label.setStyleSheet("font-size: 11px; line-height: 1.2;")
+            self.update_name_display()
 
     @property
     def selected(self) -> bool:

--- a/tests/test_analysis_wait_108_gui.py
+++ b/tests/test_analysis_wait_108_gui.py
@@ -1,0 +1,167 @@
+"""Issue #108, Teil 2: Erst-Klick auf eine noch nicht analysierte PDF.
+
+- Analyse-Worker analysiert dieselbe PDF nicht mehrfach (Pre-Cache + Klick).
+- Waehrend der Erst-Analyse: Wartezeiger, Kachel "Analysiere…", Statusmeldung.
+- Der Wartezustand endet mit dem Ergebnis, auch wenn der Nutzer inzwischen
+  eine andere PDF gewaehlt hat; ein neuer Klick oder Abwaehlen beendet ihn.
+- Der asynchrone Pfad loggt eine eigene "Klick nach Analyse"-Zeile.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from PyQt6.QtWidgets import QApplication
+
+from src.core.pdf_cache import PDFAnalysisResult, PDFAnalysisWorker
+
+from tests.test_main_window_gui import fresh_singletons, main_window  # noqa: F401
+
+
+# --- Worker-Dedupe (ohne Thread-Start) --------------------------------------
+
+def test_worker_dedupes_same_pdf(tmp_path):
+    w = PDFAnalysisWorker()
+    pdf = tmp_path / "a.pdf"
+    w.add_background(pdf)
+    w.add_background(pdf)          # exakte Kopie: verworfen
+    assert w._queue.qsize() == 1
+    w.add_task(pdf, priority=5)    # dringender: ueberholt, alte Kopie wird stale
+    assert w._queue.qsize() == 2
+    assert w.queued_count() == 1
+    assert w._dequeue(timeout=0.01) == pdf
+    assert w._dequeue(timeout=0.01) is None   # stale Kopie uebersprungen
+    assert w.queued_count() == 0
+
+
+def test_worker_urgent_overtakes_background_and_skips_stale_copy(tmp_path):
+    w = PDFAnalysisWorker()
+    a, b = tmp_path / "a.pdf", tmp_path / "b.pdf"
+    w.add_background(a)
+    w.add_background(b)
+    w.add_urgent(b)          # Nutzer hat b geklickt: ueberholt a
+    assert w.queued_count() == 2
+    assert w._dequeue(timeout=0.01) == b
+    assert w._dequeue(timeout=0.01) == a
+    assert w._dequeue(timeout=0.01) is None   # die veraltete Hintergrund-Kopie von b
+    assert w.queued_count() == 0
+
+
+def test_worker_dequeue_after_analysis_allows_reanalysis(tmp_path):
+    w = PDFAnalysisWorker()
+    pdf = tmp_path / "a.pdf"
+    w.add_urgent(pdf)
+    assert w._dequeue(timeout=0.01) == pdf
+    w.add_urgent(pdf)        # z.B. Datei geaendert -> darf wieder rein
+    assert w._dequeue(timeout=0.01) == pdf
+
+
+# --- GUI: Wartezustand -------------------------------------------------------
+
+def _fake_pdf(folder: Path, name: str) -> Path:
+    folder.mkdir(parents=True, exist_ok=True)
+    p = folder / name
+    p.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    return p
+
+
+@pytest.fixture
+def window_with_pending_analysis(main_window, fresh_singletons, monkeypatch):  # noqa: F811
+    """Zwei PDFs im Scan-Ordner; request_analysis liefert nichts sofort, sondern
+    merkt sich den Callback (wie der Worker bei einer Scan-PDF)."""
+    from src.gui import pdf_thumbnail as th
+    monkeypatch.setattr(th.ThumbnailLoaderThread, "start", lambda self: None)
+
+    scan = fresh_singletons["tmp_path"] / "Scan"
+    a = _fake_pdf(scan, "a.pdf")
+    b = _fake_pdf(scan, "b.pdf")
+    main_window._navigate_to_folder(scan)
+    assert {w.pdf_path for w in main_window.pdf_widgets} == {a, b}
+
+    pending = {}
+    monkeypatch.setattr(
+        main_window.pdf_cache, "request_analysis",
+        lambda pdf_path, callback=None, urgent=False: pending.__setitem__(pdf_path, callback),
+    )
+    monkeypatch.setattr(main_window.pdf_cache, "get", lambda pdf_path: None)
+    monkeypatch.setattr(main_window.classifier, "is_model_ready", lambda: True)
+    yield main_window, a, b, pending
+    main_window._end_analysis_wait()
+    while QApplication.overrideCursor() is not None:
+        QApplication.restoreOverrideCursor()
+
+
+def test_first_click_shows_wait_state(window_with_pending_analysis):
+    win, a, b, pending = window_with_pending_analysis
+    win.on_pdf_clicked(a)
+
+    assert win._analysis_wait_pdf == a
+    assert QApplication.overrideCursor() is not None
+    assert win._pdf_widget_for(a).analyzing
+    assert win._pdf_widget_for(a).name_label.text() == "Analysiere…"
+    assert "Texterkennung" in win.statusbar.currentMessage()
+    assert a in pending
+
+
+def test_result_ends_wait_state_and_logs_async_click(window_with_pending_analysis, caplog, monkeypatch):
+    win, a, b, pending = window_with_pending_analysis
+    win.on_pdf_clicked(a)
+    monkeypatch.setattr(win, "display_suggestions", lambda s: None)
+
+    with caplog.at_level(logging.DEBUG, logger="pdf_sortier_meister.timing"):
+        pending[a](PDFAnalysisResult(pdf_path=a, extracted_text="Rechnung", keywords=["rechnung"]))
+
+    assert win._analysis_wait_pdf is None
+    assert QApplication.overrideCursor() is None
+    assert not win._pdf_widget_for(a).analyzing
+    assert win._pdf_widget_for(a).name_label.text() == "a"
+    assert any(r.message.startswith("Klick nach Analyse") for r in caplog.records)
+
+
+def test_result_for_deselected_pdf_still_resets_wait_state(window_with_pending_analysis):
+    """Reset VOR dem selected_pdf-Guard: Ergebnis kommt, Nutzer hat aber
+    inzwischen abgewaehlt -> Wartezeiger darf nicht haengen bleiben."""
+    win, a, b, pending = window_with_pending_analysis
+    win.on_pdf_clicked(a)
+    win.selected_pdf = None          # ohne _clear_selection, bewusst "roh"
+
+    pending[a](PDFAnalysisResult(pdf_path=a))
+
+    assert win._analysis_wait_pdf is None
+    assert QApplication.overrideCursor() is None
+    assert not win._pdf_widget_for(a).analyzing
+
+
+def test_new_click_moves_wait_state_to_new_pdf(window_with_pending_analysis):
+    win, a, b, pending = window_with_pending_analysis
+    win.on_pdf_clicked(a)
+    win.on_pdf_clicked(b)
+
+    assert win._analysis_wait_pdf == b
+    assert not win._pdf_widget_for(a).analyzing
+    assert win._pdf_widget_for(b).analyzing
+    # genau EIN Override-Cursor, nicht gestapelt
+    QApplication.restoreOverrideCursor()
+    assert QApplication.overrideCursor() is None
+    win._analysis_wait_pdf = None
+
+
+def test_clear_selection_ends_wait_state(window_with_pending_analysis):
+    win, a, b, pending = window_with_pending_analysis
+    win.on_pdf_clicked(a)
+    win._clear_selection()
+
+    assert win._analysis_wait_pdf is None
+    assert QApplication.overrideCursor() is None
+    assert not win._pdf_widget_for(a).analyzing
+
+
+def test_stale_result_for_other_pdf_does_not_end_wait(window_with_pending_analysis):
+    win, a, b, pending = window_with_pending_analysis
+    win.on_pdf_clicked(a)
+    win.on_pdf_clicked(b)
+    pending[a](PDFAnalysisResult(pdf_path=a))   # verspaetetes Ergebnis fuer a
+
+    assert win._analysis_wait_pdf == b
+    assert QApplication.overrideCursor() is not None


### PR DESCRIPTION
## Was

Ergänzt #121 (Teil A, Cache-Text durchreichen) um den sichtbaren Teil von #108:

- **Erst-Klick auf eine noch nicht analysierte PDF**: Wartezeiger, Kachel zeigt „Analysiere…“, Statusleiste erklärt, dass OCR einige Sekunden dauern kann. Der Reset läuft **vor** dem `selected_pdf`-Guard (sonst bliebe der Wartezeiger hängen, wenn man inzwischen abwählt), außerdem bei neuem Klick und in `_clear_selection`.
- **Worker-Dedupe**: `PDFAnalysisWorker` merkt sich eingereihte PDFs mit bester Priorität. Pre-Cache + Klick + Klick liefen die OCR bisher dreimal; eine dringende Anfrage überholt jetzt eine wartende, die veraltete Kopie wird beim Dequeue übersprungen.
- **Log**: `Analyse <datei> <ms>: seiten … | ocr ja/nein | zeichen …` aus dem Worker (INFO ab 100 ms) und `Klick nach Analyse …` für den asynchronen GUI-Pfad. Bisher hängte `_apply_analysis_result` seine Schritte an den längst abgeschlossenen „Klick“-Timer, die Zeile erschien nie.

Unabhängig von #121 mergebar (andere Dateien), sinnvoll aber zusammen.

## Tests

Neu: `tests/test_analysis_wait_108_gui.py` (9 Tests: Dedupe ohne Thread-Start, Wartezustand, Reset-Fälle, Log-Zeile). Volle Suite 865 grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
