### PR TITLE
feat(#113): Kategorie-Eingabe zieht den Dateinamen-Vorschlag sofort nach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Neu
+- **Kategorie sofort im Dateinamen** (#113): Wer im Detail-Panel eine
+  Kategorie, einen Korrespondenten oder ein anderes Metadaten-Feld
+  eintraegt, sieht den Dateinamen-Vorschlag sofort nachziehen: Die
+  Vorschlagsliste rendert mit den neuen Werten, und solange der Dateiname
+  aus der Liste stammt (oberste Zeile, angeklickte Zeile, KI-Ergebnis),
+  folgt er der Eingabe. Ein selbst getippter Name bleibt unangetastet. In
+  KI-Vorschlaegen werden „Sonstiges“/„Unbekannt“ und die alte Kategorie
+  bzw. der alte Korrespondent durch die Eingabe ersetzt.
+- **KI-Prompt:** Neue Regel gegen nichtssagende Dateinamen („Sonstiges“,
+  „Unbekannt“, „Dokument“, „Scan“); passt keine Standard-Kategorie, soll
+  die KI konkret benennen, worum es geht.
+
 ## [0.23.0] - 2026-08-30
 
 ### Geaendert

--- a/src/core/llm_name_adapt.py
+++ b/src/core/llm_name_adapt.py
@@ -1,0 +1,97 @@
+"""
+KI-Dateinamen an geaenderte Metadaten anpassen (Issue #113).
+
+Ein KI-Vorschlag wie ``2026-03-15_Sonstiges_Muster.pdf`` traegt die Kategorie
+nur als Text. Traegt der Nutzer im Detail-Panel eine bessere Kategorie oder
+einen anderen Korrespondenten ein, wird das entsprechende Wort im Namen
+ersetzt - der Vorschlag bleibt sonst unveraendert. Nichtssagende Platzhalter
+(``Sonstiges``, ``Unbekannt``) werden auch dann ersetzt, wenn die KI keine
+Kategorie mitgeliefert hat.
+
+Reine Funktionen ohne Qt, damit sie ohne GUI testbar sind.
+
+GPL-3.0-or-later - Copyright (c) 2026
+"""
+
+from __future__ import annotations
+
+import re
+
+# Woerter, die im Dateinamen nichts aussagen und durch eine vom Nutzer
+# eingetragene Kategorie ersetzt werden duerfen
+FALLBACK_CATEGORY_TOKENS = ("Sonstiges", "Unbekannt")
+
+# Zeichen, die innerhalb eines Tokens vorkommen (alles andere trennt Tokens)
+_WORD = r"A-Za-z0-9ÄÖÜäöüß"
+
+
+def _variants(value: str) -> list[str]:
+    """Schreibweisen, in denen ein Metadaten-Wert im Dateinamen stehen kann."""
+    value = value.strip()
+    if not value:
+        return []
+    seen: list[str] = []
+    for v in (value, value.replace(" ", "_"), value.replace(" ", "-")):
+        if v and v not in seen:
+            seen.append(v)
+    return seen
+
+
+def _for_filename(value: str, filename: str) -> str:
+    """Neuen Wert an den Stil des Dateinamens anpassen (Leerzeichen -> _)."""
+    value = value.strip()
+    if " " in value and " " not in filename:
+        return value.replace(" ", "_")
+    return value
+
+
+def replace_token(filename: str, old: str, new: str) -> str:
+    """Ersetzt ``old`` als ganzes Token im Dateinamen durch ``new``.
+
+    Token-Grenzen sind ``_``, ``-``, Leerzeichen, Anfang/Ende und ``.pdf``;
+    Gross-/Kleinschreibung ist egal. ``Rechnung`` trifft also nicht in
+    ``Rechnungen``. Mehrwortige Werte werden in allen Schreibweisen
+    (Leerzeichen, ``_``, ``-``) gefunden.
+    """
+    if not old or not new or not filename:
+        return filename
+    replacement = _for_filename(new, filename)
+    for variant in _variants(old):
+        pattern = rf"(?<![{_WORD}]){re.escape(variant)}(?![{_WORD}])"
+        filename, count = re.subn(pattern, lambda _m: replacement, filename, flags=re.IGNORECASE)
+        if count:
+            break
+    return filename
+
+
+def adapt_llm_filename(filename: str, llm_metadata: dict | None, current: dict | None) -> str:
+    """Zieht Kategorie und Korrespondent eines KI-Namens nach den aktuellen Feldern nach.
+
+    Args:
+        filename: KI-Vorschlag, z.B. ``2026-03-15_Sonstiges_Muster.pdf``
+        llm_metadata: Metadaten, die die KI zu diesem Namen geliefert hat
+        current: Aktuelle Feldwerte im Panel (``subject``, ``korrespondent``)
+
+    Returns:
+        Angepasster Name; unveraendert, wenn nichts zu ersetzen ist.
+    """
+    if not filename:
+        return filename
+    llm_metadata = llm_metadata or {}
+    current = current or {}
+    result = filename
+
+    for key in ("subject", "korrespondent"):
+        new = str(current.get(key, "") or "").strip()
+        old = str(llm_metadata.get(key, "") or "").strip()
+        if not new:
+            continue
+        if old and old.lower() != new.lower():
+            result = replace_token(result, old, new)
+        if key == "subject":
+            # Nichtssagendes Wort im Namen -> durch die echte Kategorie ersetzen,
+            # auch wenn die KI die Kategorie nicht (oder als "Sonstiges") lieferte
+            for token in FALLBACK_CATEGORY_TOKENS:
+                if token.lower() != new.lower():
+                    result = replace_token(result, token, new)
+    return result

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -189,6 +189,12 @@ class DetailPanel(QWidget):
         # Zuletzt automatisch (aus Vorschlag) gesetzter Dateiname - dient zur
         # Erkennung, ob der Nutzer den Namen selbst geaendert hat
         self._auto_name: str = ""
+        # Issue #113: True, solange der Dateiname aus der Vorschlagsliste
+        # stammt (oberste Zeile, Klick, KI-Ergebnis) und nicht getippt wurde.
+        # Dann zieht eine Metadaten-Eingabe (Kategorie, Korrespondent, ...)
+        # den Namen sofort nach; _name_kind merkt sich die Art der Zeile.
+        self._name_from_list: bool = False
+        self._name_kind: Optional[str] = None
         # Snapshot der zuletzt gespeicherten Metadaten (entspricht PDF-Stand)
         self._saved_metadata_snapshot: dict = {}
         # Felder, die tatsaechlich aus dem PDF (XMP/Info) gelesen wurden - nur
@@ -310,6 +316,8 @@ class DetailPanel(QWidget):
             "Neuer Dateiname für die PDF - wird beim Klick auf einen Zielordner übernommen."
         )
         self.name_input.textChanged.connect(self._update_preview)
+        # textEdited feuert nur bei Nutzereingaben, nicht bei setText()
+        self.name_input.textEdited.connect(self._on_name_typed)
         font = QFont()
         font.setPointSize(11)
         self.name_input.setFont(font)
@@ -703,6 +711,9 @@ class DetailPanel(QWidget):
         self._metadata = {}
         self._metadata_source = None
         self._saved_metadata_snapshot = {}
+        self._name_from_list = False
+        self._name_kind = None
+        self._auto_name = ""
         self.preview.clear()
 
         self.name_input.clear()
@@ -837,12 +848,46 @@ class DetailPanel(QWidget):
         self._refresh_save_btn()
 
     def _on_metadata_user_edit(self, *args):
-        """Wird aufgerufen wenn der User ein Metadaten-Feld ändert."""
+        """Wird aufgerufen wenn der User ein Metadaten-Feld ändert.
+
+        Issue #113: Die Vorschlagsliste wird mit den neuen Feldwerten neu
+        gerendert (Muster-Zeilen, Kategorie/Korrespondent in KI-Zeilen).
+        Stammt der Dateiname noch aus der Liste, zieht er sofort nach; ein
+        selbst getippter Name bleibt unangetastet.
+        """
         if self._loading_metadata:
             return
         if self._metadata_source != "user":
             self._metadata_source = "user"
+        if self._current_pdf is not None:
+            self._populate_suggestions()
+            if self._name_from_list:
+                self._apply_name_from_kind()
         self._refresh_save_btn()
+
+    def _on_name_typed(self, _text: str):
+        """Nutzer tippt im Namensfeld: ab jetzt keine automatische Nachfuehrung."""
+        self._name_from_list = False
+        self._name_kind = None
+
+    def _apply_name_from_kind(self):
+        """Setzt den Namen auf die Zeile der gemerkten Art (sonst die oberste)."""
+        if not self._displayed_suggestions:
+            return
+        idx = 0
+        if self._name_kind is not None and self._name_kind in self._displayed_kinds:
+            idx = self._displayed_kinds.index(self._name_kind)
+        self._set_name_from_row(idx)
+
+    def _set_name_from_row(self, idx: int):
+        """Uebernimmt Zeile ``idx`` als automatischen Dateinamen (koppelt an die Liste)."""
+        if not (0 <= idx < len(self._displayed_suggestions)):
+            return
+        name = self._displayed_suggestions[idx].name.replace('.pdf', '')
+        self.name_input.setText(name)
+        self._auto_name = name
+        self._name_from_list = True
+        self._name_kind = self._displayed_kinds[idx]
 
     def _refresh_save_btn(self):
         """Aktualisiert Text und Status des Speichern-Buttons und des Status-Labels."""
@@ -941,11 +986,14 @@ class DetailPanel(QWidget):
         zuletzt angeklickte Art zuoberst.
         """
         from src.core.suggestion_order import (
-            KIND_DATE, KIND_LEARNED, kind_from_reason, sort_by_kind,
+            KIND_DATE, KIND_KI, KIND_LEARNED, kind_from_reason, sort_by_kind,
         )
+
+        from src.core.llm_name_adapt import adapt_llm_filename
 
         self.suggestions_list.clear()
 
+        current_meta = self.get_metadata() if self._current_pdf else {}
         pairs: list[tuple[RenameSuggestion, str]] = []
         for s in self._suggestions:
             kind = kind_from_reason(s.reason)
@@ -954,6 +1002,13 @@ class DetailPanel(QWidget):
                 # alter Dateiname) ebenso - die Historie fliesst stattdessen als
                 # Beispiel in den KI-Prompt (src.core.rename_examples)
                 continue
+            if kind == KIND_KI:
+                # Issue #113: "Sonstiges"/alte Kategorie im KI-Namen durch die
+                # aktuelle Feld-Eingabe ersetzen (Anzeige-Kopie, Original bleibt)
+                adapted = adapt_llm_filename(s.name, s.metadata, current_meta)
+                if adapted != s.name:
+                    s = RenameSuggestion(name=adapted, reason=s.reason,
+                                         confidence=s.confidence, metadata=s.metadata)
             pairs.append((s, kind))
         pattern_pairs = self._pattern_suggestions()
         pairs.extend(pattern_pairs)
@@ -1008,11 +1063,7 @@ class DetailPanel(QWidget):
 
     def _apply_top_suggestion(self):
         """Uebernimmt die oberste Zeile als (automatischen) Dateinamen."""
-        if not self._displayed_suggestions:
-            return
-        name = self._displayed_suggestions[0].name.replace('.pdf', '')
-        self.name_input.setText(name)
-        self._auto_name = name
+        self._set_name_from_row(0)
 
     # -- Metadaten-Hilfen (Issues #109/#110) ------------------------------- #
 
@@ -1273,6 +1324,10 @@ class DetailPanel(QWidget):
             idx = self.suggestions_list.row(item)
             if 0 <= idx < len(self._displayed_kinds):
                 self._remember_kind(self._displayed_kinds[idx])
+                # Issue #113: angeklickte Zeile bleibt an die Felder gekoppelt
+                self._auto_name = name.replace('.pdf', '')
+                self._name_from_list = True
+                self._name_kind = self._displayed_kinds[idx]
 
             # Metadaten des Vorschlags übernehmen
             shown = self._displayed_suggestions
@@ -1428,6 +1483,13 @@ class DetailPanel(QWidget):
             text += f" ({estimate})"
         self.llm_btn.setText(text)
 
+    def _couple_name_to_llm(self, filename: str):
+        """KI-Name gilt als automatisch gesetzt und folgt Feld-Aenderungen (#113)."""
+        from src.core.suggestion_order import KIND_KI
+        self._auto_name = filename.replace('.pdf', '')
+        self._name_from_list = True
+        self._name_kind = KIND_KI
+
     def _on_llm_metadata_ready(self, pdf_path: Path, suggestions: list, error: str):
         """Traegt das KI-Ergebnis ein - nur, wenn die PDF noch ausgewaehlt ist."""
         self._llm_timer.stop()
@@ -1475,12 +1537,14 @@ class DetailPanel(QWidget):
                             pass
                     self._loading_metadata = False
                     self._metadata_source = "llm"
+                    self._couple_name_to_llm(s.filename)
                     self._refresh_save_btn()
                     break
             else:
                 for s in suggestions:
                     if s.source == "llm":
                         self.name_input.setText(s.filename.replace('.pdf', ''))
+                        self._couple_name_to_llm(s.filename)
                         break
                 else:
                     # Kein KI-Vorschlag angekommen - Grund anzeigen (z.B. Token-Limit)

--- a/src/ml/llm_provider.py
+++ b/src/ml/llm_provider.py
@@ -439,6 +439,10 @@ REGELN FÜR DEN DATEINAMEN:
    (z.B. Kathrin_Haerle, Agentur_fuer_Arbeit, HUK-Coburg), niemals eine E-Mail-Adresse,
    Telefonnummer, IBAN oder Web-Adresse. Steht nur eine E-Mail-Adresse im Dokument,
    leite den Namen daraus ab (kathrin.haerle@web.de -> Kathrin_Haerle).
+6. Keine nichtssagenden Woerter wie "Sonstiges", "Unbekannt", "Dokument" oder "Scan"
+   im Dateinamen. Passt keine der Standard-Kategorien, benenne konkret, worum es
+   geht (z.B. Klaviernoten_Bach_Praeludium, Bedienungsanleitung_Waschmaschine).
+   "Sonstiges" ist nur als Kategorie in den Metadaten erlaubt, nie im Dateinamen.
 
 Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
 {{

--- a/tests/test_detail_panel_category_follow_113_gui.py
+++ b/tests/test_detail_panel_category_follow_113_gui.py
@@ -1,0 +1,96 @@
+"""Issue #113: Eine Metadaten-Eingabe zieht den Dateinamen-Vorschlag sofort nach.
+
+Solange der Name aus der Liste stammt (oberste Zeile, Klick, KI-Ergebnis),
+folgt er der Eingabe in Kategorie/Korrespondent. Ein getippter Name bleibt.
+"""
+from PyQt6.QtTest import QTest
+
+from src.gui.rename_dialog import RenameSuggestion
+
+from tests.test_llm_metadata_extraction import provider  # noqa: F401 - Fixture
+
+from tests.test_detail_panel_pattern_suggestions_gui import (  # noqa: F401
+    RECHNUNGEN, _ki_suggestion, _panel, _reasons, _rows, _select,
+)
+
+
+def _ki_sonstiges():
+    return RenameSuggestion(
+        name="2024-01-31_Sonstiges_Noten.pdf", reason="KI-Vorschlag", confidence=0.9,
+        metadata={"subject": "Sonstiges", "korrespondent": "Musikverlag"},
+    )
+
+
+def test_category_edit_updates_ki_row_and_name(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
+    _select(panel, tmp_path, [_ki_sonstiges()])
+    assert panel.name_input.text() == "2024-01-31_Sonstiges_Noten"
+    assert panel._name_from_list
+
+    cat = panel._metadata_inputs["subject"]
+    cat.setText("")
+    QTest.keyClicks(cat, "Klaviernoten")
+
+    assert _rows(panel)[0].startswith("2024-01-31_Klaviernoten_Noten.pdf")
+    assert panel.name_input.text() == "2024-01-31_Klaviernoten_Noten"
+    assert not panel.has_user_edits() or panel._metadata_source == "user"
+    assert panel._auto_name == "2024-01-31_Klaviernoten_Noten"
+
+
+def test_pattern_row_follows_korrespondent_edit(qtbot, monkeypatch, tmp_path):
+    panel, cfg = _panel(qtbot, monkeypatch, tmp_path, filename_pattern=RECHNUNGEN)
+    _select(panel, tmp_path, [])            # nur Muster-Zeilen
+    assert _reasons(panel)[0].startswith("Muster")
+    assert panel.name_input.text() == "2024-01-31_Rechnung"
+
+    korr = panel._metadata_inputs["korrespondent"]
+    QTest.keyClicks(korr, "Beispiel AG")
+
+    assert panel.name_input.text() == "2024-01-31_Rechnung_Beispiel-AG"
+
+
+def test_typed_name_is_not_overwritten(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
+    _select(panel, tmp_path, [_ki_sonstiges()])
+
+    panel.name_input.clear()
+    QTest.keyClicks(panel.name_input, "Mein eigener Name")
+    assert not panel._name_from_list
+
+    QTest.keyClicks(panel._metadata_inputs["subject"], "X")
+
+    assert panel.name_input.text() == "Mein eigener Name"
+    # Liste rendert trotzdem neu
+    assert "SonstigesX" in _rows(panel)[0] or "X" in _rows(panel)[0]
+
+
+def test_clicked_row_stays_coupled_to_its_kind(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path, filename_pattern=RECHNUNGEN)
+    _select(panel, tmp_path, [_ki_suggestion()])
+    reasons = _reasons(panel)
+    idx = reasons.index("Muster: Rechnungen & Belege")
+    panel._on_suggestion_clicked(panel.suggestions_list.item(idx))
+    assert panel.name_input.text().startswith("2024-01-31_Rechnung_Testfirma-GmbH")
+    assert panel._name_from_list
+
+    korr = panel._metadata_inputs["korrespondent"]
+    korr.setText("")
+    QTest.keyClicks(korr, "Neue Firma")
+
+    # Folgt der MUSTER-Zeile, nicht der KI-Zeile
+    assert panel.name_input.text().startswith("2024-01-31_Rechnung_Neue-Firma")
+
+
+def test_clear_resets_coupling(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
+    _select(panel, tmp_path, [_ki_sonstiges()])
+    panel.clear()
+    assert not panel._name_from_list and panel._name_kind is None
+    # Kein Absturz bei Feld-Aenderung ohne PDF
+    panel._on_metadata_user_edit("x")
+    assert panel.name_input.text() == ""
+
+
+def test_prompt_contains_rule_against_meaningless_names(provider):  # noqa: F811
+    prompt = provider._build_filename_prompt(text="text", current_filename="scan.pdf")
+    assert "Sonstiges" in prompt and "nie im Dateinamen" in prompt

--- a/tests/test_llm_name_adapt.py
+++ b/tests/test_llm_name_adapt.py
@@ -1,0 +1,37 @@
+"""Issue #113: KI-Dateinamen an geaenderte Metadaten anpassen (ohne Qt)."""
+from src.core.llm_name_adapt import adapt_llm_filename, replace_token
+
+
+def test_replace_whole_token_only():
+    assert replace_token("2026-03-15_Rechnung_Muster.pdf", "Rechnung", "Mahnung") == "2026-03-15_Mahnung_Muster.pdf"
+    assert replace_token("2026-03-15_Rechnungen_Muster.pdf", "Rechnung", "Mahnung") == "2026-03-15_Rechnungen_Muster.pdf"
+
+
+def test_replace_is_case_insensitive_and_handles_multiword_values():
+    assert replace_token("Sonstiges_Muster-GmbH.pdf", "muster gmbh", "Beispiel AG") == "Sonstiges_Beispiel_AG.pdf"
+    assert replace_token("JK 2026-03-15-Muster GmbH.pdf", "Muster GmbH", "Beispiel AG") == "JK 2026-03-15-Beispiel AG.pdf"
+
+
+def test_adapt_replaces_old_category_and_fallback_tokens():
+    assert adapt_llm_filename(
+        "2026-03-15_Sonstiges_Noten.pdf", {"subject": "Sonstiges"}, {"subject": "Klaviernoten"}
+    ) == "2026-03-15_Klaviernoten_Noten.pdf"
+    # KI lieferte keine Kategorie (normalize_llm_metadata verwirft "Unbekannt")
+    assert adapt_llm_filename(
+        "2026-03-15_Unbekannt_Bach.pdf", {}, {"subject": "Klaviernoten"}
+    ) == "2026-03-15_Klaviernoten_Bach.pdf"
+
+
+def test_adapt_replaces_korrespondent_and_leaves_rest():
+    assert adapt_llm_filename(
+        "2026-03-15_Rechnung_Testfirma-GmbH.pdf",
+        {"subject": "Rechnung", "korrespondent": "Testfirma GmbH"},
+        {"subject": "Rechnung", "korrespondent": "Beispiel AG"},
+    ) == "2026-03-15_Rechnung_Beispiel_AG.pdf"
+
+
+def test_adapt_without_changes_or_fields_is_identity():
+    name = "2026-03-15_Rechnung_Testfirma.pdf"
+    assert adapt_llm_filename(name, {"subject": "Rechnung"}, {"subject": "Rechnung"}) == name
+    assert adapt_llm_filename(name, {"subject": "Rechnung"}, {}) == name
+    assert adapt_llm_filename("", {}, {"subject": "X"}) == ""


### PR DESCRIPTION
## Was

Closes #113.

Wer im Detail-Panel eine Kategorie, einen Korrespondenten oder ein anderes Metadaten-Feld eintippt, sieht den Dateinamen sofort nachziehen:

- `_on_metadata_user_edit` rendert die Vorschlagsliste mit den neuen Feldwerten neu (Muster-Zeilen bauen aus den Feldern, KI-Zeilen bekommen die Eingabe eingesetzt).
- Solange der Name aus der Liste stammt (oberste Zeile, angeklickte Zeile, KI-Ergebnis), folgt er der Eingabe. Dafür ein eigenes Flag `_name_from_list` plus `_name_kind` (Art der Zeile), nicht `_auto_name`, das `has_user_edits()` weiter für die Abweichungserkennung braucht. `textEdited` im Namensfeld (feuert nur bei Nutzereingaben) löst die Kopplung.
- Neues Modul `src/core/llm_name_adapt.py` (rein, ohne Qt): ersetzt in KI-Namen die alte Kategorie / den alten Korrespondenten und die Rückfall-Wörter „Sonstiges“/„Unbekannt“ als ganze Tokens, case-insensitive, mehrwortig in `_`/`-`/Leerzeichen-Schreibweise. „Unbekannt“ wird von `normalize_llm_metadata` verworfen, deshalb der Rückfall über die Wörter im Namen.
- Prompt-Regel 6 gegen nichtssagende Dateinamen („Sonstiges“, „Unbekannt“, „Dokument“, „Scan“).

Nicht überschrieben wird ein selbst getippter Name (Entscheidung aus dem Fahrplan).

## Tests

Neu: `tests/test_llm_name_adapt.py` (5) und `tests/test_detail_panel_category_follow_113_gui.py` (6: Kategorie-Eingabe ändert KI-Zeile + Name, Muster folgt Korrespondent, getippter Name bleibt, angeklickte Zeile bleibt an ihre Art gekoppelt, `clear()` ohne Absturz, Prompt-Regel). Bestehendes `test_no_update_when_user_already_edited` hält ohne Änderung. Volle Suite 867 grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)