### PR TITLE
Sprint D: Reaktion & Aufräumen (v0.24.0-Kandidat)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Portables Zip erstellen
         run: |
           $version = (Select-String -Path src/main.py -Pattern '^__version__\s*=\s*"([^"]+)"').Matches[0].Groups[1].Value
+          Copy-Item LICENSE dist\PDF_Sortier_Meister\LICENSE.txt
           Compress-Archive -Path dist\PDF_Sortier_Meister -DestinationPath "dist\installer\PDF_Sortier_Meister-v$version-win64.zip"
 
       - uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Neu
+- **Kategorie sofort im Dateinamen** (#113): Wer im Detail-Panel eine
+  Kategorie, einen Korrespondenten oder ein anderes Metadaten-Feld
+  eintraegt, sieht den Dateinamen-Vorschlag sofort nachziehen: Die
+  Vorschlagsliste rendert mit den neuen Werten, und solange der Dateiname
+  aus der Liste stammt (oberste Zeile, angeklickte Zeile, KI-Ergebnis),
+  folgt er der Eingabe. Ein selbst getippter Name bleibt unangetastet. In
+  KI-Vorschlaegen werden „Sonstiges“/„Unbekannt“ und die alte Kategorie
+  bzw. der alte Korrespondent durch die Eingabe ersetzt.
+- **KI-Prompt:** Neue Regel gegen nichtssagende Dateinamen („Sonstiges“,
+  „Unbekannt“, „Dokument“, „Scan“); passt keine Standard-Kategorie, soll
+  die KI konkret benennen, worum es geht.
+
 ## [0.23.0] - 2026-08-30
 
 ### Geaendert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Behoben
+- **Klick auf eine gescannte PDF dauerte 7 Sekunden** (#108, Teil 1): Beim
+  Anklicken lief die Texterkennung (OCR) noch einmal komplett durch, obwohl
+  der Text laengst im Cache lag. Die Dateinamen-Vorschlaege „Automatisch
+  erkannt“ nutzen jetzt den Cache und oeffnen die PDF nur noch, wenn
+  wirklich etwas fehlt. Betrifft alle vier Wege: Klick, KI-Nachlieferung,
+  Suchfeld leeren und den Umbenennen-Dialog. Nebenbei: Datumsangaben aus dem
+  Cache erscheinen in den Vorschlaegen wieder als „2026-05-12“ statt
+  „2026-05-12 00:00:00“.
+
 ## [0.23.0] - 2026-08-30
 
 ### Geaendert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Geaendert
+- **Vergleich mit paperless-ngx neu geschrieben** (#112): Stand 09/2026 gegen
+  paperless-ngx v3.1.3 (native KI und RAG seit v3.0), mit Feature-Tabellen,
+  21 belegten Luecken, Bewertung der Server-Frage (Antwort: nein) und
+  Hinweisen zum Zusammenspiel. README nennt jetzt die bekannten Grenzen
+  (Loeschen ohne Papierkorb, OCR fuenf Seiten, Suchindex 5.000 Zeichen),
+  die Regeln ehrlich als Hinweis und 850+ Tests; Docstrings und
+  ENTWICKLUNGSSTAND entsprechend angeglichen, Release-Checkliste um den
+  Vergleich ergaenzt.
+
 ## [0.23.0] - 2026-08-30
 
 ### Geaendert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Behoben
+- **Lizenz-Angaben konsistent:** Der Über-Dialog nannte „MIT License“, 16
+  Modul-Header ebenfalls; das Projekt steht seit Juli 2026 unter
+  GPL-3.0-or-later. Beides korrigiert, der Lizenztext liegt jetzt als
+  `LICENSE.txt` im Installer und im portablen ZIP (und in `_internal/`).
+- **Erststart:** Die Hinweise „Erste Schritte“ und „Backup empfohlen“
+  erschienen über dem noch offenen Einrichtungsassistenten. Sie kommen jetzt
+  erst, wenn der Assistent geschlossen ist.
+
 ## [0.23.0] - 2026-08-30
 
 ### Geaendert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Neu
+- **Kategorie sofort im Dateinamen** (#113): Wer im Detail-Panel eine
+  Kategorie, einen Korrespondenten oder ein anderes Metadaten-Feld
+  eintraegt, sieht den Dateinamen-Vorschlag sofort nachziehen: Die
+  Vorschlagsliste rendert mit den neuen Werten, und solange der Dateiname
+  aus der Liste stammt (oberste Zeile, angeklickte Zeile, KI-Ergebnis),
+  folgt er der Eingabe. Ein selbst getippter Name bleibt unangetastet. In
+  KI-Vorschlaegen werden „Sonstiges“/„Unbekannt“ und die alte Kategorie
+  bzw. der alte Korrespondent durch die Eingabe ersetzt.
+- **KI-Prompt:** Neue Regel gegen nichtssagende Dateinamen („Sonstiges“,
+  „Unbekannt“, „Dokument“, „Scan“); passt keine Standard-Kategorie, soll
+  die KI konkret benennen, worum es geht.
+
+### Geaendert
+- **Erst-Klick auf eine noch nicht analysierte PDF** (#108, Teil 2): Waehrend
+  die Texterkennung laeuft, zeigt die Kachel „Analysiere…“, der Mauszeiger
+  wird zum Wartezeiger und die Statusleiste erklaert, dass OCR einige
+  Sekunden dauern kann. Dieselbe PDF wird nicht mehr mehrfach analysiert,
+  wenn sie gleichzeitig vom Vorab-Laden und vom Klick angefordert wird.
+- **Log:** Zu jeder Analyse steht jetzt eine Zeile `Analyse <datei> <ms>:
+  seiten … | ocr ja/nein | zeichen …`, und der Klick-Pfad nach einer
+  Analyse loggt als `Klick nach Analyse …`. Damit ist im Log sichtbar, ob
+  eine Wartezeit von der OCR oder von der Oberflaeche kommt.
+- **Vergleich mit paperless-ngx neu geschrieben** (#112): Stand 09/2026 gegen
+  paperless-ngx v3.1.3 (native KI und RAG seit v3.0), mit Feature-Tabellen,
+  21 belegten Luecken, Bewertung der Server-Frage (Antwort: nein) und
+  Hinweisen zum Zusammenspiel. README nennt jetzt die bekannten Grenzen
+  (Loeschen ohne Papierkorb, OCR fuenf Seiten, Suchindex 5.000 Zeichen),
+  die Regeln ehrlich als Hinweis und 850+ Tests; Docstrings und
+  ENTWICKLUNGSSTAND entsprechend angeglichen, Release-Checkliste um den
+  Vergleich ergaenzt.
+
 ### Behoben
 - **Fehlerdialog nach „Verschieben nach…“:** Das Verschieben ueber den
   Ordnerauswahl-Dialog lief durch, meldete danach aber „Verschieben
@@ -37,40 +69,6 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   Suchfeld leeren und den Umbenennen-Dialog. Nebenbei: Datumsangaben aus dem
   Cache erscheinen in den Vorschlaegen wieder als „2026-05-12“ statt
   „2026-05-12 00:00:00“.
-
-### Geaendert
-- **Erst-Klick auf eine noch nicht analysierte PDF** (#108, Teil 2): Waehrend
-  die Texterkennung laeuft, zeigt die Kachel „Analysiere…“, der Mauszeiger
-  wird zum Wartezeiger und die Statusleiste erklaert, dass OCR einige
-  Sekunden dauern kann. Dieselbe PDF wird nicht mehr mehrfach analysiert,
-  wenn sie gleichzeitig vom Vorab-Laden und vom Klick angefordert wird.
-- **Log:** Zu jeder Analyse steht jetzt eine Zeile `Analyse <datei> <ms>:
-  seiten … | ocr ja/nein | zeichen …`, und der Klick-Pfad nach einer
-  Analyse loggt als `Klick nach Analyse …`. Damit ist im Log sichtbar, ob
-  eine Wartezeit von der OCR oder von der Oberflaeche kommt.
-
-### Neu
-- **Kategorie sofort im Dateinamen** (#113): Wer im Detail-Panel eine
-  Kategorie, einen Korrespondenten oder ein anderes Metadaten-Feld
-  eintraegt, sieht den Dateinamen-Vorschlag sofort nachziehen: Die
-  Vorschlagsliste rendert mit den neuen Werten, und solange der Dateiname
-  aus der Liste stammt (oberste Zeile, angeklickte Zeile, KI-Ergebnis),
-  folgt er der Eingabe. Ein selbst getippter Name bleibt unangetastet. In
-  KI-Vorschlaegen werden „Sonstiges“/„Unbekannt“ und die alte Kategorie
-  bzw. der alte Korrespondent durch die Eingabe ersetzt.
-- **KI-Prompt:** Neue Regel gegen nichtssagende Dateinamen („Sonstiges“,
-  „Unbekannt“, „Dokument“, „Scan“); passt keine Standard-Kategorie, soll
-  die KI konkret benennen, worum es geht.
-
-### Geaendert
-- **Vergleich mit paperless-ngx neu geschrieben** (#112): Stand 09/2026 gegen
-  paperless-ngx v3.1.3 (native KI und RAG seit v3.0), mit Feature-Tabellen,
-  21 belegten Luecken, Bewertung der Server-Frage (Antwort: nein) und
-  Hinweisen zum Zusammenspiel. README nennt jetzt die bekannten Grenzen
-  (Loeschen ohne Papierkorb, OCR fuenf Seiten, Suchindex 5.000 Zeichen),
-  die Regeln ehrlich als Hinweis und 850+ Tests; Docstrings und
-  ENTWICKLUNGSSTAND entsprechend angeglichen, Release-Checkliste um den
-  Vergleich ergaenzt.
 
 ## [0.23.0] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Behoben
+- **MwSt-Satz 7 % wurde staendig vorgeschlagen**, auch bei Dokumenten ohne
+  jede Steuerangabe: Im KI-Prompt stand „7“ als Beispielwert, den viele
+  Modelle einfach uebernahmen. Die Beispiele heissen jetzt „19 oder 7 oder
+  UNBEKANNT“ bzw. „JJJJ oder UNBEKANNT“, eine Prompt-Regel verlangt
+  Betraege/MwSt/IBAN nur bei Rechnungen und Belegen, und ein Steuersatz, der
+  im Dokumenttext nicht vorkommt, wird verworfen. Das Feld bleibt dann leer.
+
 ### Neu
 - **Kategorie sofort im Dateinamen** (#113): Wer im Detail-Panel eine
   Kategorie, einen Korrespondenten oder ein anderes Metadaten-Feld

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Behoben
+- **Fehlerdialog nach „Verschieben nach…“:** Das Verschieben ueber den
+  Ordnerauswahl-Dialog lief durch, meldete danach aber „Verschieben
+  fehlgeschlagen“ (undefinierte Variable beim Aktualisieren der
+  Ordneransicht).
+- **Drop auf gruene Vorschlagskacheln** verschiebt die PDF jetzt wirklich;
+  vorher passierte beim Loslassen nichts.
+- **Kontextmenue der Vorschlagskacheln:** Der wirkungslose Eintrag „Aus
+  Zielliste entfernen“ ist dort weg (Vorschlaege sind Unterordner, keine
+  Eintraege der Zielliste).
+- **Zielordner entfernen** scannt den Zielbaum nur noch einmal statt zweimal.
+- **Tooltip im Zielbaum** nennt jetzt die Tastatur-Navigation (Pfeil rechts
+  klappt auf, * alle Unterordner) und den Rechtsklick.
+
 ## [0.23.0] - 2026-08-30
 
 ### Geaendert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Geaendert
+- **Erst-Klick auf eine noch nicht analysierte PDF** (#108, Teil 2): Waehrend
+  die Texterkennung laeuft, zeigt die Kachel „Analysiere…“, der Mauszeiger
+  wird zum Wartezeiger und die Statusleiste erklaert, dass OCR einige
+  Sekunden dauern kann. Dieselbe PDF wird nicht mehr mehrfach analysiert,
+  wenn sie gleichzeitig vom Vorab-Laden und vom Klick angefordert wird.
+- **Log:** Zu jeder Analyse steht jetzt eine Zeile `Analyse <datei> <ms>:
+  seiten … | ocr ja/nein | zeichen …`, und der Klick-Pfad nach einer
+  Analyse loggt als `Klick nach Analyse …`. Damit ist im Log sichtbar, ob
+  eine Wartezeit von der OCR oder von der Oberflaeche kommt.
+
 ## [0.23.0] - 2026-08-30
 
 ### Geaendert

--- a/ENTWICKLUNGSSTAND.md
+++ b/ENTWICKLUNGSSTAND.md
@@ -92,6 +92,8 @@
 - [x] Poe.com API Integration (`src/ml/poe_provider.py`)
 - [x] Hybrid-Klassifikator (`src/ml/hybrid_classifier.py`)
 - [x] Automatische Entscheidung: Lokal vs. LLM basierend auf Konfidenz
+  - Hinweis (09/2026): der KI-Ordnerpfad `suggest_folders` wird aus der GUI nicht aufgerufen;
+    Ordnervorschläge kommen heute rein aus dem lokalen Klassifikator (Issue #116, Sprint F)
 - [x] API-Key Verwaltung in Config (`src/utils/config.py`)
 - [x] Einstellungsdialog mit LLM-Konfiguration (`src/gui/settings_dialog.py`)
 - [x] Verbindungstest für API-Keys
@@ -208,7 +210,7 @@
 
 ### Phase 15: Layout-Optimierungen (NEU - Mittlere Priorität)
 
-- [ ] **Dynamische Thumbnail-Spalten** (to do #16)
+- [x] **Dynamische Thumbnail-Spalten** *(erledigt, Issue #50, v0.17.0)*
   - Mehr Spalten bei größerem Fenster
   - Responsive Grid-Layout
 
@@ -621,6 +623,10 @@ Die LLM-Integration ermöglicht optional bessere Klassifikations- und Benennungs
 ---
 
 ## Wettbewerbsanalyse: paperless-ai (März 2026)
+
+> Veraltet: Aktueller Vergleich mit paperless-ngx v3.1 (native KI, RAG) in
+> [Vergleich paperless-ngx.md](Vergleich%20paperless-ngx.md), Stand 09/2026.
+> Die Tabelle unten bleibt als historischer Stand stehen.
 
 Vergleich mit [paperless-ai](https://github.com/clusterzx/paperless-ai) (Add-On für Paperless-ngx):
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ Texterkennung (OCR, Tesseract) ist auch hier **enthalten**. Einstellungen und Le
 
 ### Korrespondenten und Regeln
 - **Korrespondenten-Verwaltung** (Absender mit Aliasen, Kategorie, Farbe) — Klick filtert die PDF-Liste
-- **WENN-DANN-Regeln**: z. B. *Korrespondent = Stadtwerke → Ordner `Wohnung/Nebenkosten`,
-  Dateiname `{datum} Stadtwerke {betrag_brutto}`* — mit Prioritäten und visuellem Editor
+- **WENN-DANN-Regeln** mit Prioritäten und visuellem Editor: z. B. *Korrespondent = Stadtwerke →
+  Ordner `Wohnung/Nebenkosten`*. Heute zeigen Regeln nur einen Hinweis in der Statusleiste; das
+  automatische Anwenden ist ein offenes Vorhaben (#125)
 
 ### KI — optional, lokal oder Cloud
 - Ohne KI: alles oben funktioniert mit dem lokalen Klassifikator
@@ -155,7 +156,7 @@ python run.py
 - OCR im Quellcode-Betrieb: Tesseract installieren — Windows: `winget install UB-Mannheim.TesseractOCR`,
   macOS: `brew install tesseract tesseract-lang` — die App findet es in den Standardordnern;
   in den Builds ist es gebündelt
-- Tests: `python -m pytest tests -q` (450+ Tests, pytest-qt); laufen per GitHub Actions auf Windows und macOS
+- Tests: `python -m pytest tests -q` (850+ Tests, pytest-qt); laufen per GitHub Actions auf Windows und macOS
 - Windows-Build: `build.bat` — PyInstaller (`pdf_sortier_meister.spec`), kopiert Tesseract nach `vendor/`
   und baut mit Inno Setup 6 den Installer (`scripts/build_installer.py`)
 - macOS-Build: `./build.sh` — gleicher PyInstaller-Spec, bündelt Tesseract (`scripts/prepare_tesseract_mac.py`,
@@ -176,8 +177,13 @@ Offene Vorhaben: [Issues](https://github.com/Josi-create/PDF_Sortier_Meister/iss
 
 paperless-ngx ist ein Server-System mit eigener Dokumentenablage; PDF Sortier Meister ist ein
 Desktop-Werkzeug, das **deine bestehende Ordnerstruktur** beibehält und die Metadaten in die PDFs
-selbst schreibt. Beides lässt sich kombinieren (erst hier sortieren, dann in paperless importieren).
-Details: [Vergleich paperless-ngx.md](Vergleich%20paperless-ngx.md)
+selbst schreibt. Beides lässt sich kombinieren (erst hier sortieren, dann in paperless importieren);
+paperless übernimmt dabei Datum und Titel aus dem **Dateinamen**, die eingebetteten XMP-Metadaten
+liest es nicht aus. Was PDFSM gegenüber paperless-ngx (v3.1, mit eigener KI) noch fehlt und was
+nicht: [Vergleich paperless-ngx.md](Vergleich%20paperless-ngx.md) (Stand 09/2026).
+
+Bekannte Grenzen: Löschen fragt nach, ist danach aber endgültig (kein Papierkorb); OCR liest die
+ersten fünf Seiten; der Suchindex hält pro Dokument die ersten 5.000 Zeichen.
 
 ---
 
@@ -188,7 +194,7 @@ Details: [Vergleich paperless-ngx.md](Vergleich%20paperless-ngx.md)
 | PyQt6 | Desktop-GUI |
 | PyMuPDF | PDF-Rendering, Textextraktion |
 | pikepdf | XMP-Metadaten in PDFs schreiben |
-| pytesseract / Tesseract | OCR für Scans ohne Textebene (Deutsch) |
+| pytesseract / Tesseract | OCR für Scans ohne Textebene (Deutsch, erste 5 Seiten; siehe #46) |
 | scikit-learn | TF-IDF-Klassifikator (lokal, lernend) |
 | SQLAlchemy + SQLite FTS5 | Lernhistorie, Metadaten-Index, Volltextsuche |
 | anthropic / openai (optional) | Cloud-KI-Anbieter |

--- a/Vergleich paperless-ngx.md
+++ b/Vergleich paperless-ngx.md
@@ -1,56 +1,207 @@
 # PDF Sortier Meister vs. paperless-ngx
 
-## Grundkonzept
+**Stand: September 2026** — verglichen werden PDF Sortier Meister **v0.23.0** (30.08.2026) und paperless-ngx **v3.1.3** (04.09.2026) samt den KI-Erweiterungen **paperless-ai** (v3.0.9, letztes Release 04.11.2025) und **paperless-gpt** (v0.27.0, 21.07.2026). Ersetzt die Fassung vom März 2026. Zeilenangaben beziehen sich auf den Stand v0.23.0 (Commit 72d4389).
+
+> Kurzfassung: paperless-ngx ist ein Server-Archiv, das Dokumente *übernimmt* und in einer eigenen Ablage verwaltet — mit allem, was ein Mehrgeräte-/Mehrbenutzer-System braucht. PDF Sortier Meister ist ein Desktop-Werkzeug, das Scans *in der eigenen Ordnerstruktur* sortiert, benennt und die Metadaten in die PDF selbst schreibt. Seit v3.0 (Juli 2026) hat paperless-ngx eingebaute KI (Vorschläge, Embedding-Index, Dokumenten-Chat) — der frühere Vorsprung von PDFSM bei „KI ohne Zusatz-Container“ ist damit kleiner geworden. Umgekehrt hat PDFSM fast alles nachgezogen, was im März noch „geplant“ war: Volltextsuche, RAG-Chat, Korrespondenten, Regeln, XMP-Metadaten, Merge/Split, Ollama.
+
+---
+
+## 1. Grundkonzept
 
 | | **PDF Sortier Meister** | **paperless-ngx** |
 |---|---|---|
-| **Typ** | Desktop-App (Windows) | Web-App (Self-hosted Server) |
-| **Zielgruppe** | Einzelperson, Heimanwender | Heimserver, kleine Teams |
-| **Betrieb** | Lokal, keine Installation nötig | Docker/Server, immer laufend |
-| **Datenhaltung** | Dateien bleiben im eigenen Ordner | Zentrales Archiv (eigene Struktur) |
+| **Typ** | Desktop-App (Windows 10/11, macOS) | Web-App, self-hosted (Docker, Linux) |
+| **Zielgruppe** | Einzelperson, Haushalt, Selbstständige, Steuerbüro-Zuarbeit | Heimserver, Familien, kleine Teams |
+| **Betrieb** | Installer/DMG, läuft nur, wenn das Fenster offen ist | Dauerhaft laufende Container: App, PostgreSQL/MariaDB/SQLite, Redis; optional Tika/Gotenberg |
+| **Datenhaltung** | Dateien bleiben in den eigenen Ordnern (auch OneDrive); Metadaten **in der PDF** (XMP + Info-Dictionary) und als SQLite-Index | Zentrales Medienverzeichnis mit eigenem Schema (Original + PDF/A-Archivkopie), Metadaten **nur in der Datenbank** |
+| **Bedienidee** | Explorer-artig: Scan-Ordner links, Zielordner rechts, Klick/Drag & Drop verschiebt und benennt | Posteingang → automatische Verarbeitung → Tags/Korrespondent/Typ; man arbeitet mit Filtern und Ansichten, nicht mit Ordnern |
+| **Lizenz / Größe** | GPL-3.0, Solo-Projekt, rund 28.000 Zeilen Python in `src/` plus Tests, 856 Tests | GPL-3.0, Team-Projekt, ~45.000 GitHub-Sterne |
 
 ---
 
-## Feature-Vergleich
+## 2. Was sich seit März 2026 geändert hat
 
-| Feature | PDF Sortier Meister | paperless-ngx |
-|---|---|---|
-| **Ordnerstruktur frei wählbar** | Ja — volle Kontrolle | Nein — eigenes Archiv-Schema |
-| **Dateinamen selbst bestimmen** | Ja — mit KI-Vorschlägen | Begrenzt (Namensregeln) |
-| **KI-Klassifikation** | Hybrid TF-IDF + LLM | Regelbasiert + optionale LLM-Addons |
-| **LLM-Integration** | Claude, OpenAI, Poe, (Ollama geplant) | Über paperless-ai Addon (Ollama, OpenAI) |
-| **OCR** | Tesseract (Fallback) | Tesseract (immer, für alle Dokumente) |
-| **Volltext-Suche** | Geplant (Phase 17) | Ja, ausgereift |
-| **Web-Interface** | Nein | Ja — auch mobil erreichbar |
-| **Mehrbenutzer** | Nein | Ja (Benutzer, Gruppen, Berechtigungen) |
-| **Tags / Labels** | Kategorien (10 Typen) | Flexibles Tag-System |
-| **Korrespondenten** | Geplant (Phase 20) | Ja, vollständig |
-| **Metadaten in PDF** | Geplant (Phase 16) | Nein (nur interne DB) |
-| **Drag & Drop Sortierung** | Ja | Nein |
-| **Lernfähig aus Entscheidungen** | Ja (TF-IDF lernt) | Nein |
-| **PDF Merge/Split** | Geplant | Nein |
-| **Automatisierungsregeln** | Geplant (Phase 21) | Ja, ausgereift (Workflows) |
-| **RAG-Chat** | Geplant (Phase 19) | Über paperless-ai Addon |
-| **Portabilität der Metadaten** | Ja (XMP in PDF, Phase 16) | Nein (DB-gebunden) |
+**PDF Sortier Meister** (v0.12 → v0.23): RAG-Chat mit Quellen (v0.12.0), Korrespondenten-Verwaltung und WENN-DANN-Regeln (v0.13.0), OpenRouter/Ollama Cloud, Windows-Installer mit gebündeltem Tesseract, macOS-Build, integrierte PDF-Vorschau, Update-Prüfung, Dateinamen-Muster mit Platzhaltern, Backup/Restore, Text aus der Vorschau in Metadaten übernehmen (siehe CHANGELOG.md).
+
+**paperless-ngx**: v2.19 (Okt. 2025) verschachtelte Tags; **v3.0.0 (22.07.2026)**: native KI (LLM-Vorschläge für Titel/Datum/Tags/Korrespondent/Typ, Embedding-Index, Dokumenten-Chat mit Quellen, Ollama oder OpenAI-kompatibel), neue Volltextsuche (Tantivy), Dokumentversionen, Remote-OCR (Azure AI), Share-Link-Bundles, Parser-Plugins; **v3.1.0 (27.08.2026)**: Workflow-Aktion „KI-Vorschläge anwenden“, Dateien als Versionen zusammenführen.
+
+**KI-Addons**: paperless-ai (Auto-Tagging + RAG-Chat) hat seit November 2025 kein Release mehr — die Kernfunktionen sind jetzt in paperless-ngx selbst. paperless-gpt ist aktiv und hat sich auf **LLM-Vision-OCR** spezialisiert (schlechte Scans per Bildmodell lesen, durchsuchbare PDFs erzeugen).
 
 ---
 
-## Wann welches Programm?
+## 3. Feature-Vergleich
 
-**PDF Sortier Meister** ist besser wenn:
-- Man Dokumente im eigenen Ordnersystem behalten will (kein Lock-in)
-- Man aktiv mit PDFs arbeitet und sie manuell/halb-automatisch sortiert
-- Kein Server betrieben werden soll (reines Desktop-Tool)
-- Die Metadaten portabel in den Dateien selbst stecken sollen (Phase 16)
+Legende: ✅ vorhanden · ◐ teilweise · ❌ nicht vorhanden. „Beleg“ nennt die Stelle im PDFSM-Code oder die CHANGELOG-Version.
 
-**paperless-ngx** ist besser wenn:
-- Ein dauerhaft laufendes Archiv gewünscht ist (Posteingang → automatisch archiviert)
-- Volltext-Suche und ausgefeilte Filter sofort gebraucht werden
-- Mehrere Personen oder Geräte auf die Dokumente zugreifen sollen
-- Man kein Problem mit dem eigenen Archivschema von paperless hat
+### 3.1 Dokumenteneingang und Automatisierung
+
+| Feature | paperless-ngx | PDF Sortier Meister | Beleg |
+|---|---|---|---|
+| Eingangsordner wird **automatisch überwacht** | ✅ Consume-Ordner, Verarbeitung im Hintergrund | ❌ Analyse startet nur, wenn die App offen ist und der Ordner geladen wird (Vorab-Analyse und KI-Queue laufen dann im Hintergrund) | `watchdog` steht in `requirements.txt:19`, wird aber nirgends importiert; `main_window._schedule_pre_caching`, `pdf_cache.PDFAnalysisWorker` |
+| Upload per Web-Oberfläche / Drag & Drop | ✅ | — (nicht anwendbar, Dateien liegen lokal) | |
+| **E-Mail-Abruf** (IMAP, Regeln, OAuth Gmail/Outlook, alle 10 min) | ✅ | ❌ | grep imap: keine Treffer |
+| REST-API / Webhooks / Pre-/Post-Consume-Skripte | ✅ | ❌ (nur Startparameter „Ordner oder PDF-Datei öffnen“ und Explorer-Kontextmenü auf Ordnern) | `src/main.py:59-62 _extract_path_arg`, `src/utils/explorer_integration.py:12-14` |
+| **Regeln / Workflows** | ✅ Trigger (Eingang, hinzugefügt, geändert, zeitgesteuert), Aktionen (Zuweisen/Entfernen von Tags, Korrespondent, Typ, Pfad, Custom Fields, Besitzer, E-Mail, Webhook, Papierkorb, Passwort entfernen, KI-Vorschläge anwenden) | ◐ WENN-DANN-Regeln mit 5 Bedingungen (Korrespondent, Kategorie, Betrag, Datum, Stichwörter) und 4 Aktionstypen — **aber nur als Hinweis in der Statusleiste**, und der wird erst *nach* dem Verschieben geprüft, in zwei von drei Pfaden ohne Metadaten. Praktisch greift heute keine Regel. | `src/core/rule_engine.py:50-56`, `src/gui/main_window.py:537-573` („KEIN Auto-Move ohne User-Bestätigung in v1“), Aufrufe `:2067, :2144, :2655` |
+| **Lernender Klassifikator** | ✅ „Auto“-Matching (Klassifikator wird stündlich aus den Dokumenten trainiert) | ✅ TF-IDF lernt aus jeder Verschiebung, Jahres-Varianten von Ordnern; LLM nur bei niedriger Konfidenz | `src/ml/classifier.py:349 learn`, `:604-608 _year_variant` (v0.15.0 #30), `hybrid_classifier.py:63 LOCAL_CONFIDENCE_THRESHOLD` |
+| **Barcodes / ASN** (Trennseiten, Archivnummer, Tag-Barcodes) | ✅ | ❌ | grep barcode: keine Treffer |
+| Duplikaterkennung (Prüfsumme) | ✅ prüfsummenbasiert, Duplikate werden markiert (optional verworfen) | ❌ | — |
+| Weitere Formate (Bilder, Office, E-Mail) | ✅ (Office via Tika/Gotenberg) | ❌ nur `*.pdf` | `src/core/file_manager.py:67-70` |
+
+### 3.2 Metadaten und Organisation
+
+| Feature | paperless-ngx | PDF Sortier Meister | Beleg |
+|---|---|---|---|
+| **Ordnerstruktur frei wählbar** | ◐ Storage Paths mit Jinja2-Vorlagen (`{{created_year}}/{{correspondent}}`), aber innerhalb des paperless-Medienordners | ✅ Bestehende Ordner bleiben; Vorschläge kommen aus der eigenen Struktur (gelernt + Jahres-Variante). Der KI-Ordnerpfad (`suggest_folders`) ist vorhanden, wird aber aus der Oberfläche nicht aufgerufen (siehe Issue #116) | `classifier.py:604-608`, `hybrid_classifier.py:221-283` |
+| **Dateiname** selbst bestimmen | ◐ Dateinamen-Format global/pro Storage Path | ✅ Muster mit Platzhaltern (`{datum}_{kontakt}_{betreff}`, eigene Muster speichern), KI füllt sie aus; Ordnernummern-Präfix (`JK 069-03-05-…`) | `src/core/filename_placeholders.py:23-79`, `folder_naming.py` (v0.17.0 #42, v0.21–0.23) |
+| **Tags** (mehrwertig, verschachtelt, farbig) | ✅ inkl. Nested Tags (Tiefe 5) | ❌ eine einwertige **Kategorie**; Stichwörter landen als `pdf:Keywords` in der PDF, sind aber nicht als Tag-System bedienbar | `src/core/metadata_choices.py:9-12`, `pdf_metadata.py:91-92` |
+| **Korrespondenten** | ✅ mit Matching-Regeln | ✅ Tabelle mit Aliasen, Farbe, Notizen, Zusammenführen, automatisches Sammeln aus der Historie, Wiedererkennung im Text; Klick filtert | `database.py:136, 1934, 2031, 2190`, `korrespondent_match.py:32` (v0.13.0, v0.23.0 #109) |
+| Dokumenttypen | ✅ | ✅ als Kategorie (Rechnung, Vertrag, Steuer, Versicherung, Bank, Gehalt, Arzt, Energie, …) | `metadata_choices.py` (#110) |
+| **Custom Fields** (Text, Zahl, Datum, Währung, Auswahl, Dokument-Link, URL, Boolean) | ✅ 9 Feldtypen, frei definierbar | ◐ fester Satz Steuer-/Buchhaltungsfelder: Korrespondent, Buchungsdatum, Steuerjahr, Netto, Brutto, Währung, MwSt, IBAN, steuerlich absetzbar, Zusammenfassung | `src/core/pdf_metadata.py:20-38` |
+| **Metadaten in der PDF-Datei** (portabel) | ❌ nur Datenbank; eingebettete PDF-Metadaten werden beim Import **nicht ausgewertet** (Maintainer, Discussion #5053) | ✅ XMP (`dc:title`, `dc:subject`, `dc:description`, `pdf:Keywords`) + Info-Dictionary (`/Korrespondent`, `/Steuerjahr`, `/IBAN`, …), im Hintergrund geschrieben und gelesen | `pdf_metadata.py:82-92, 171-190`; `main_window.py:1057`; `detail_panel.py:49` |
+| Notizen pro Dokument, Audit-Historie, **Dokumentversionen** | ✅ | ❌ (nur Undo-Stack der letzten Aktionen) | `main_window.py:2785` |
+| Gespeicherte Ansichten / Dashboard | ✅ | ❌ | — |
+| Mehrfachauswahl / Stapelbearbeitung | ✅ Bulk-Edit | ✅ Shift/Ctrl-Auswahl, Verschieben, Kopieren, LLM-Stapelumbenennung | `main_window.py:2151, 2933` |
+
+### 3.3 Suche und KI
+
+| Feature | paperless-ngx | PDF Sortier Meister | Beleg |
+|---|---|---|---|
+| **Volltextsuche** | ✅ Tantivy (seit v3.0), Autovervollständigung, Feldsyntax (`tag:… created:[2024 to 2025]`), Fuzzy, „Mehr wie dieses“ | ✅ SQLite FTS5 (`unicode61`), Live-Suche ab 2 Zeichen, Filter Steuerjahr/Kategorie/Korrespondent/Datum/Betrag; OR/AND/NEAR/NOT werden durchgereicht; kein „Mehr wie dieses“, keine Feldsyntax | `database.py:400-416, 976-1028`, `main_window.py:3452, 3622` (v0.9.0/v0.11.0 #18) |
+| Index-Umfang | ganzes Archiv automatisch, Volltext | ◐ alles, was verschoben/umbenannt wurde (über `update_pdf_path`); Bestandsordner **manuell** über „Ordner zum Suchindex hinzufügen“. **Von jedem Dokument stehen nur die ersten 5.000 Zeichen** (etwa zwei Seiten) im Index und im RAG-Kontext | `database.py:230 MAX_EXTRACTED_TEXT_LENGTH`, `:602, :677, :731`; `main_window.py:2034, 2125, 3702`; Entscheidung Q3/R8 in `docs/ARCHITECTURE.md` |
+| **KI-Vorschläge** (Titel/Name, Kategorie, Korrespondent, Datum) | ✅ nativ seit v3.0 (Ollama oder OpenAI-kompatibel, `PAPERLESS_AI_ENABLED`); Addons paperless-ai/-gpt zusätzlich | ✅ Ollama (lokal, Auto-Start, Hardware-Empfehlung im Assistenten), Ollama Cloud, OpenRouter, Claude, OpenAI, Poe; Metadaten-Extraktion (Betrag, MwSt, IBAN, Steuerjahr); gelernte Stil-Beispiele im Prompt | `src/ml/*_provider.py`, `llm_provider.py:396`, `src/utils/hardware.py` (v0.16.0, v0.20.0) |
+| **RAG-Chat** über die eigenen Dokumente | ✅ nativ seit v3.0: Embedding-Index (HuggingFace/Ollama/OpenAI-kompatibel, täglicher Cron), Chat über ein oder mehrere Dokumente mit Quellenlinks | ✅ Chat-Tab, Antworten mit klickbaren Quellen, Whitelist gegen erfundene Zitate, Offline-Fallback als Trefferliste; **Retrieval rein stichwortbasiert** (FTS5-OR-Query, Top-8, 1 PDF = 1 Chunk à 2000 Zeichen), keine Embeddings (bewusste v1-Entscheidung in `docs/ARCHITECTURE.md`), Verlauf nur in der Sitzung | `src/rag/retrieval.py:240`, `rag_controller.py:85 ask`, `config.py:36-40`, `chat_view.py:87` (v0.12.0 #20) |
+| KI-Datenschutz | Opt-in, Warnhinweis; lokale Modelle möglich | Consent-Gate für Cloud-Provider, nur Textauszug (500–5000 Zeichen), Standard „keine KI“ | `config.py:95 cloud_consent` |
+| LLM-Vision-OCR für schlechte Scans | ◐ über paperless-gpt (OpenAI/Ollama/Mistral/Claude, Azure DI, Google Document AI) | ❌ | — |
+
+### 3.4 OCR und PDF-Verarbeitung
+
+| Feature | paperless-ngx | PDF Sortier Meister | Beleg |
+|---|---|---|---|
+| **OCR** | ✅ Tesseract für alle Dokumente, 100+ Sprachen, OCRmyPDF; optional Azure AI | ◐ Tesseract gebündelt (Win/Mac), aber nur als **Fallback ohne Textebene**, nur die **ersten 5 Seiten**, nur Deutsch (fest kodiert, kein Config-Schlüssel) | `pdf_analyzer.py:139-141, 170, 182`; offene Issues #46, #47 |
+| Durchsuchbare PDF / **PDF/A-Archivkopie** | ✅ Textebene wird eingebettet, PDF/A erzeugt | ❌ Originaldatei bleibt unverändert (nur Metadaten werden geschrieben) | kein ocrmypdf/PDF-A im Code |
+| Seiten **trennen / zusammenfügen** | ✅ | ✅ alle Seiten einzeln oder Bereich; Merge per Kontextmenü | `file_manager.py:227, 273` (#12) |
+| Seiten drehen, löschen, umsortieren | ✅ | ❌ | grep rotate: keine Treffer |
+| Integrierte Vorschau | ✅ (PDF.js/PNGX) | ✅ QtPdf-Vorschau, Text markieren → als Metadatum übernehmen | `pdf_preview_widget.py` (v0.19.0, v0.23.0 #109) |
+| Passwortgeschützte PDFs entschlüsseln | ✅ Workflow-Aktion | ❌ | — |
+
+### 3.5 Betrieb, Sicherheit, Daten
+
+| Feature | paperless-ngx | PDF Sortier Meister | Beleg |
+|---|---|---|---|
+| **Mehrbenutzer, Berechtigungen** (global + pro Objekt), OIDC/SSO, 2FA | ✅ | ❌ (Einzelnutzer, keine Anmeldung) | — |
+| **Mobil / anderes Gerät** | ✅ Web-UI, Apps „Paperless Mobile“ (Android), „Swift Paperless“ (iOS) | ◐ keine App; Dateien und XMP-Metadaten sind über OneDrive/iCloud auf dem Handy sichtbar, Suche/Chat nicht | — |
+| **Freigabe-Links** (öffentlich, ablaufend, Bundles) | ✅ | ❌ (Datei per Explorer/OneDrive teilen) | — |
+| **Papierkorb** (30 Tage), Wiederherstellen | ✅ | ❌ Löschen nach Rückfrage, danach endgültig (`unlink`, kein Papierkorb); Undo nur für Verschieben/Umbenennen | `file_manager.py:225`, `main_window.py:2613-2620, 2785` |
+| Backup / Export | ✅ Document-Exporter (Dateien + Metadaten), Importer | ✅ ZIP mit Datenbank, KI-Cache, Modell, Einstellungen; Wiederherstellen beim nächsten Start; Backup-Erinnerung | `src/utils/backup.py:1-45` (v0.22.0 #98, v0.14.0 #7) |
+| **Steuerauswertung** (Summen je Jahr/Kategorie, CSV) | ❌ (nur über Custom Fields + Export selbst bauen) | ✅ | `database.py:1809`, `steuerauswertung_dialog.py:130-143` |
+| Update-Mechanismus | Container-Image ziehen | ✅ Hinweis auf neue Version (GitHub `releases/latest`), Drüberinstallieren | `update_check.py:22-24` (v0.19.0 #73) |
+| Plattform | Linux/Docker (Windows „not supported“, nur via WSL/NAS) | Windows 10/11, macOS (Intel + Apple Silicon), signiert/notarisiert | README, `build.sh` (v0.18.0) |
+| Cloud-Sync-Ordner (OneDrive „Dateien bei Bedarf“) | ⚠ Medienordner gehört nicht in Sync-Ordner | ✅ ausdrücklich unterstützt, langsame Zugriffe laufen in Threads | CHANGELOG 0.15.1 |
+| Einrichtung | Docker Compose oder Installationsskript, Reverse-Proxy für Zugriff von außen | ✅ Setup.exe/DMG, Assistent (Ordner, GPU-Check, Ollama-Modell per Klick) | `setup_wizard.py:96-102` (v0.16.0, v0.20.0) |
 
 ---
 
-## Fazit
+## 4. Lücken-Tabelle: Was paperless-ngx kann und PDFSM heute nicht
 
-Die Programme schließen sich nicht aus — PDF Sortier Meister kann als Frontend zum manuellen Sortieren/Umbenennen dienen, bevor Dokumente in paperless-ngx importiert werden. Mit Phase 16 (XMP-Metadaten in PDF) würden Tags und Kategorien beim Import automatisch übernommen.
+Relevanz bezieht sich auf eine **Desktop-App für Einzelnutzer**. Aufwand: S < 0,5 Tag · M 0,5–1,5 Tage · L 2–4 Tage · XL > 1 Woche (Grobschätzung ohne Spike).
+
+| # | Feature | paperless-ngx | PDFSM heute (Beleg) | Relevanz | Aufwand | Anmerkung |
+|---|---|---|---|---|---|---|
+| 1 | **Papierkorb** statt endgültigem Löschen (#124) | Trash, 30 Tage | Rückfrage, dann `unlink()` (`file_manager.py:225`) | mittel–hoch | S | `QFile.moveToTrash` ist in Qt 6.11 vorhanden; Undo-Eintrag ergänzen; Test für `delete_file` fehlt bisher ganz |
+| 2 | **Regeln wirklich anwenden** (#125) | Workflows setzen Felder, Pfad, Tags automatisch | Hinweis erst nach dem Verschieben, in zwei von drei Pfaden ohne Metadaten (`main_window.py:537-573, 2067, 2144, 2655`); kein Konsument für die Aktionen | **hoch** | M–L | Auswertung *vor* den Move in alle drei Pfade ziehen, mit `detail_panel.get_metadata()` füttern (liegt erst nach der KI-Analyse vor), Zielordner/Dateiname im Detail-Panel vorbelegen; Auto-Verschieben ab Konfidenz 0,9 als Opt-in; Tests fehlen bisher |
+| 3 | **OCR aller Seiten, mehrsprachig, Textebene zurückschreiben** | OCRmyPDF, PDF/A, 100+ Sprachen | 5 Seiten, `deu`, keine Textebene (`pdf_analyzer.py:170, 182`); Suchindex zusätzlich bei **jedem** Dokument auf 5.000 Zeichen gekappt (`database.py:230`) | **hoch** (Suche/RAG sehen sonst nur den Anfang) | M–L | Bereits als #46/#47 offen; dort ergänzen: alle Seiten, `deu+eng`, Textebene per `image_to_pdf_or_hocr` + pikepdf, und `MAX_EXTRACTED_TEXT_LENGTH` bzw. Chunking pro Seite mitziehen, sonst bringt OCR aller Seiten der Suche nichts. Erst nach #108 (Klick-Freeze), sonst wächst der Freeze auf 30 s |
+| 4 | **Eingang im Hintergrund** (Watch-Folder, Tray, Autostart, #126) | Consume-Ordner 24/7 | nur bei offenem Fenster; `watchdog` ungenutzt | **hoch** — das ist der eigentliche Kern der „Server-Frage“ | L | Nur der Trigger fehlt: `QFileSystemWatcher`/watchdog auf den Scan-Ordner, dann die vorhandene Vorab-Analyse (`PDFAnalysisWorker`) und KI-Queue (`_llm_queued`) nutzen; `QSystemTrayIcon`, Autostart (HKCU Run / LaunchAgent) |
+| 5 | **Mehrwertige Tags** (verschachtelt, farbig, filterbar) | Nested Tags | einwertige Kategorie; `pdf:Keywords` nur geschrieben | mittel | L | Tags in `pdf:Keywords` + FTS-Spalte `keywords` abbilden; Filterleiste erweitern |
+| 6 | **Semantische Suche / Embeddings im RAG** | Vektorindex (HF/Ollama/OpenAI) + Chat | FTS5-Stichwort-Retrieval (`retrieval.py:240`); „Keine Embeddings“ ist in `docs/ARCHITECTURE.md` als v1-Entscheidung festgehalten | mittel (Fragen ohne Stichworttreffer scheitern) | L | Hybrid: FTS5 + Ollama-Embeddings (`/api/embeddings`) mit `sqlite-vec` oder numpy; Chunking pro Seite; setzt #3 voraus, sonst indexiert man Lücken. Entscheidung in ARCHITECTURE.md dann fortschreiben |
+| 7 | Duplikaterkennung | Prüfsumme, Duplikate markiert | keine | mittel | S–M | Hash in `pdfs`-Mastertabelle (#25) |
+| 8 | Bilder (JPG/PNG) als Eingang | ja | nur PDF (`file_manager.py:67-70`) | mittel | M | PyMuPDF wandelt Bild → PDF, dann normaler Weg |
+| 9 | Seiten drehen / löschen / umsortieren | PDF-Editor | Merge/Split nur | mittel | M | pikepdf/PyMuPDF; in `split_pdf_dialog` andocken |
+| 10 | Freie **Custom Fields** | 9 Feldtypen | fester Feldsatz (`pdf_metadata.py:20-38`); die Konstante `CUSTOM_NS` existiert, wird aber nicht genutzt — Custom-Felder landen im Info-Dictionary | mittel | L | Eigener XMP-Namespace, UI und FTS-Spalten dynamisch |
+| 11 | Gespeicherte Suchen / Ansichten | Saved Views, Dashboard | keine | niedrig–mittel | S–M | Filterzustand als benannte Config-Einträge |
+| 12 | Suchsyntax mit Feldern (`kategorie:Rechnung`, Datumsbereich im Text) | Tantivy-Syntax | nur Dropdown-Filter; FTS5-Spaltenfilter wären nativ möglich | niedrig | S–M | `search_documents` erkennt heute nur OR/AND/NEAR/NOT (`database.py:1023-1028`) |
+| 13 | LLM-Vision-OCR (paperless-gpt) | ja | nein | mittel bei vielen schlechten Scans | M | Ollama-Vision-Modelle (gemma3) und Claude/OpenAI können Bilder; an `_extract_text_ocr` als 2. Fallback |
+| 14 | **E-Mail-Abruf** (Rechnungen aus dem Postfach) | IMAP-Regeln, OAuth | nein | mittel (viele Rechnungen kommen per Mail), aber nur sinnvoll mit #4 | L | `imaplib` (stdlib), Anhänge in den Scan-Ordner legen; läuft nur, wenn die App läuft |
+| 15 | Barcode-Trennseiten / ASN | ja | nein | niedrig (Haushalt) / mittel (Steuerbüro, Stapelscan) | M–L | `pyzbar` + zbar-DLL bündeln |
+| 16 | Notizen, Audit-Historie, Dokumentversionen | ja | nein | niedrig | L | widerspricht teils „Datei bleibt Datei“ |
+| 17 | Passwort entfernen | Workflow-Aktion | nein | niedrig | S | pikepdf `open(password=…)` |
+| 18 | **Mobil / Web-UI / Apps** | Web + 2 Apps | nein; Dateien via OneDrive | niedrig–mittel | XL | nur mit Server; siehe Abschnitt 6 |
+| 19 | **Mehrbenutzer, Berechtigungen, Freigabe-Links** | ja | nein | niedrig | XL | nur mit Server |
+| 20 | REST-API / Webhooks / Skript-Hooks | ja | nein | niedrig | L–XL | Kommandozeilen-Hooks (Post-Move-Skript) wären eine Desktop-Variante (M) |
+| 21 | Office-Formate (Tika/Gotenberg) | ja | nein | niedrig | XL | außerhalb des Produktkerns (siehe Issue #9) |
+
+---
+
+## 5. Wo PDF Sortier Meister voraus ist
+
+- **Kein Lock-in:** Dateien bleiben normale PDFs in normalen Ordnern — Explorer, OneDrive, Steuerberater-Upload funktionieren unverändert. paperless-ngx übernimmt die Datei in sein Medienverzeichnis; wer aussteigt, braucht den Exporter.
+- **Metadaten reisen mit der Datei:** Kategorie, Korrespondent, Betrag, MwSt, IBAN, Steuerjahr, Zusammenfassung stehen als XMP/Info-Dictionary in der PDF (`pdf_metadata.py`) und sind in Acrobat, DEVONthink oder den Windows-Eigenschaften sichtbar. paperless-ngx hält Metadaten nur in der Datenbank (Feature-Request #7049 ohne Umsetzung).
+- **Steuer- und Buchhaltungsfelder plus Auswertung:** Netto/Brutto/MwSt/absetzbar je Steuerjahr mit CSV-Export (`steuerauswertung_dialog.py`) — in paperless nur über selbst angelegte Custom Fields und externe Auswertung.
+- **Explorer-artiges Sortieren:** Zielordner-Vorschläge aus der eigenen Struktur, Jahres-Varianten („Steuer 2025“ → „Steuer 2026“), Drag & Drop, Ctrl+Z, Explorer-Kontextmenü.
+- **Dateinamen mit Verstand:** Muster mit Platzhaltern, die die KI ausfüllt, Ordnernummern-Präfix aus dem Zielpfad, gelernte Stil-Beispiele im Prompt (v0.21–0.23).
+- **Zero-Setup-KI:** Assistent prüft die Grafikkarte, empfiehlt ein Modell, startet Ollama automatisch und lädt das Modell per Klick — ohne Terminal, ohne Docker.
+- **Native Desktop-Apps** für Windows und macOS mit gebündeltem Tesseract; paperless-ngx läuft offiziell nur unter Linux/Docker.
+- **Text aus der Vorschau in Metadaten** übernehmen, Korrespondent wird daraus gelernt (#109).
+
+---
+
+## 6. Braucht man die Server-Funktionalität wirklich?
+
+„Server“ bedeutet bei paperless-ngx zwei verschiedene Dinge, die getrennt zu bewerten sind:
+
+### 6.1 Nur mit Server möglich
+
+| Nutzen | Für wen relevant |
+|---|---|
+| **Zugriff von mehreren Geräten / mobil** auf Suche, Metadaten, Chat (Web-UI, Android-/iOS-Apps) | Wer unterwegs *suchen* will. Wer nur die *Dateien* braucht, hat sie bei PDFSM ohnehin via OneDrive/iCloud auf dem Handy — samt XMP-Metadaten. |
+| **Mehrbenutzer** mit Berechtigungen, Besitzer, Gruppen, SSO | Familien-/Teamarchiv. Für Einzelnutzer irrelevant. |
+| **Freigabe-Links** (ablaufend, ohne Login) | Belege an Steuerberater/Vermieter schicken — geht bei PDFSM per OneDrive-Freigabe oder E-Mail-Anhang. |
+| **Verarbeitung rund um die Uhr, auch bei ausgeschaltetem PC** (Mail-Abruf, Consume-Ordner, geplante Workflows, Embedding-Index per Cron) | Nur, wenn Dokumente eintreffen, während kein Rechner läuft (z. B. Scanner schickt direkt per Mail/SMB). |
+| **API/Webhooks** für andere Systeme (Home Assistant, n8n, Nextcloud) | Automatisierer. |
+
+### 6.2 Geht auch als Desktop-App (heute teils fehlend, siehe Lücken #1–#4)
+
+- **Eingangsordner beobachten** und neue Scans sofort analysieren, OCR-en und KI-Vorschläge vorbereiten — solange die App läuft (Tray-Icon, Autostart). Analyse-Worker und KI-Queue laufen heute schon im Hintergrund, es fehlt nur der Auslöser. Der Scanner legt sowieso in einen lokalen/OneDrive-Ordner ab; ob die Auswertung um 3 Uhr nachts oder beim nächsten Einschalten passiert, ist für einen Haushalt egal.
+- **Regeln automatisch anwenden** (Stadtwerke → Wohnung/Nebenkosten) — braucht keinen Server. Heute läuft die Prüfung erst nach dem Verschieben und meist ohne Metadaten; sie muss vor den Move und an die Metadaten des Detail-Panels (M–L, Lücke #2).
+- **Mail-Import**: IMAP-Abruf beim App-Start oder alle n Minuten ist Desktop-tauglich; er läuft eben nur, wenn der PC an ist.
+- **Volltext + RAG**: läuft bereits lokal; Embeddings wären auch lokal (Ollama) möglich.
+- **Backup/Restore**: vorhanden.
+
+### 6.3 Bewertung
+
+Für die Zielgruppe von PDF Sortier Meister — Einzelnutzer, Scans landen ohnehin in einem (OneDrive-)Ordner, Ordnerstruktur soll erhalten bleiben — ist ein Server **nicht nötig**. Die spürbaren Vorteile von paperless-ngx im Alltag sind nicht der Server an sich, sondern **(a) alles passiert automatisch im Hintergrund**, **(b) OCR ist immer vollständig und in der Datei**, **(c) Regeln greifen ohne Klick**. Alle drei sind als Desktop-Funktionen umsetzbar (Lücken #2–#4) und sollten Vorrang vor jeder Server-Überlegung haben. Ein eigener Web-/Server-Modus (XL) würde dagegen genau das Kernversprechen („kein Docker, kein Server, keine Datenbank-Silo“) aufgeben, mit dem sich PDFSM von paperless-ngx unterscheidet.
+
+Wer Mehrbenutzer, Handy-Suche oder 24/7-Mail-Abruf wirklich braucht, ist bei paperless-ngx richtig — und kann PDFSM davor schalten (Abschnitt 7).
+
+---
+
+## 7. Beide zusammen verwenden
+
+PDFSM als „Vorsortierer“ vor paperless-ngx funktioniert, aber anders als im März 2026 angenommen: **paperless-ngx liest eingebettete PDF-Metadaten nicht aus** („embedded PDF metadata … is not utilized by paperless, nor is it changed by paperless“, Maintainer in Discussion #5053). Was beim Import ankommt, ist der **Dateiname** (paperless erkennt Datum und Titel aus dem Dateinamen, z. B. `2026-03-12 Telekom - Rechnung.pdf`) und der Ordnerpfad (per Workflow-Filter auf den Consume-Pfad). Praktisch heißt das:
+
+1. In PDFSM sortieren und mit sprechendem Muster benennen (`{datum}_{kontakt}_{betreff}`).
+2. Den fertigen Ordner in den paperless-Consume-Ordner kopieren (oder paperless auf den PDFSM-Zielordner zeigen lassen).
+3. In paperless per Workflow „Consumption Started“ mit Pfadfilter Tags/Korrespondent zuweisen — oder die native KI Vorschläge machen lassen.
+
+Die XMP-Metadaten bleiben in der Originaldatei erhalten und sind in paperless im Tab „Metadata“ sichtbar, werden aber nicht zu Tags. Umgekehrt (paperless → PDFSM) übernimmt PDFSM die Ordnerstruktur des Exporters und liest vorhandene XMP-Felder.
+
+---
+
+## 8. Fazit und Empfehlung für die PDFSM-Roadmap
+
+1. **Kein Server, kein Web-Modus.** Die Differenzierung „Dateien bleiben deine Dateien, Metadaten in der PDF, kein Docker“ ist intakt und durch paperless' Roadmap (v3: KI, Versionen, Remote-OCR — alles serverseitig) eher schärfer geworden.
+2. **Die Alltagslücken schließen**, die paperless-Nutzer als „Server-Vorteil“ empfinden, aber keine sind: Papierkorb (#124, S), Regeln anwenden (#125, M–L), OCR vollständig mit Textebene und ohne 5.000-Zeichen-Deckel (#46/#47, M–L), Postfach-Modus mit Watch-Folder + Tray (#126, L).
+3. **RAG ehrlich einordnen:** PDFSM-Chat ist stichwortbasiert (FTS5) und damit robust, aber bei Fragen ohne Wortüberschneidung unterlegen. „Keine Embeddings“ war eine bewusste v1-Entscheidung (`docs/ARCHITECTURE.md`, Abschnitt 3; Zusammenfassung in `docs/RAG_ARCHITECTURE_SUMMARY.md`). Ein hybrider Modus mit lokalen Embeddings (Ollama) ist der nächste sinnvolle Schritt, sobald OCR alle Seiten liefert und der Index nicht mehr kappt — vorher indexiert man Lücken. Die Entscheidung dann in ARCHITECTURE.md fortschreiben.
+4. **Tags** erst danach; Kategorie + Korrespondent + Steuerfelder decken den Steuer-/Haushalts-Fall ab, verschachtelte Tags sind ein paperless-Konzept, das ohne Ordnerbezug arbeitet.
+5. Dieses Dokument bei jedem Release gegen die aktuelle paperless-ngx-Version prüfen (Punkt in `docs/RELEASE_CHECKLISTE.md`), sonst ist es in sechs Monaten wieder falsch.
+
+---
+
+## Quellen (abgerufen 05.09.2026)
+
+- paperless-ngx Dokumentation (Branch `dev`, docs.paperless-ngx.com blockt automatisierte Abrufe): Usage <https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/dev/docs/usage.md>, Advanced Usage <https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/dev/docs/advanced_usage.md>, Configuration <https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/dev/docs/configuration.md>, Setup <https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/dev/docs/setup.md>, Übersicht <https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/dev/docs/index.md>
+- paperless-ngx Releases: v3.0.0 (22.07.2026) <https://github.com/paperless-ngx/paperless-ngx/releases/tag/v3.0.0>, v3.1.0 (27.08.2026) <https://github.com/paperless-ngx/paperless-ngx/releases/tag/v3.1.0>, v2.19.0 (21.10.2025, Nested Tags) <https://github.com/paperless-ngx/paperless-ngx/releases/tag/v2.19.0>
+- PDF-Metadaten werden von paperless nicht ausgewertet: <https://github.com/paperless-ngx/paperless-ngx/discussions/5053>; Feature-Request Metadaten in PDF speichern: <https://github.com/paperless-ngx/paperless-ngx/discussions/7049>
+- paperless-ai (clusterzx): <https://github.com/clusterzx/paperless-ai>, Funktionen <https://github.com/clusterzx/paperless-ai/wiki/3.-Functions>
+- paperless-gpt (icereed): <https://github.com/icereed/paperless-gpt>
+- Mobile Apps: Paperless Mobile <https://github.com/astubenbord/paperless-mobile>, Swift Paperless <https://github.com/paulgessinger/swift-paperless>, Related Projects <https://github.com/paperless-ngx/paperless-ngx/wiki/Related-Projects>
+- PDF Sortier Meister: CHANGELOG.md, README.md, docs/ARCHITECTURE.md (RAG), Quellcode v0.23.0 (Belege in den Tabellen).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,6 +74,12 @@
 
 **FTS5 ist ausreichend für v1.** Keine Embeddings.
 
+> Stand 09/2026: Entscheidung gilt weiter. paperless-ngx hat seit v3.0 einen
+> Embedding-Index; ein hybrider Modus (FTS5 + Ollama-Embeddings) ist als Lücke #6
+> in [Vergleich paperless-ngx.md](../Vergleich%20paperless-ngx.md) beschrieben und
+> erst sinnvoll, wenn OCR alle Seiten liefert und der 5.000-Zeichen-Cap (Q3/R8)
+> fällt.
+
 **Query-Konstruktion**:
 1. Stopword-Strip (deutsche Stopwords, inline-Liste ~80 Wörter)
 2. LLM-Keyword-Extraktion (optional, Mini-Prompt)

--- a/docs/RELEASE_CHECKLISTE.md
+++ b/docs/RELEASE_CHECKLISTE.md
@@ -12,6 +12,12 @@ Ablauf fuer einen neuen Release von PDF Sortier Meister (`vX.Y.Z`).
       Gemma-Generationen, ist `gpt-oss:120b` noch das sinnvolle Cloud-Default?
       `MODEL_TIERS_CHECKED_ON` in `hardware.py` auf das heutige Datum setzen.
       (Hintergrund: Issue #63 - Empfehlungen veralten schnell.)
+- [ ] **Vergleich paperless-ngx pruefen** (`Vergleich paperless-ngx.md`): gibt es
+      ein neues paperless-ngx-Release (<https://github.com/paperless-ngx/paperless-ngx/releases>),
+      das die Tabellen aendert? Versionsnummer und "Stand" im Kopf des Dokuments
+      aktualisieren; PDFSM-Features, die seit dem letzten Release dazukamen, in
+      Abschnitt 2/3 nachtragen. (Hintergrund: Issue #112 - das Dokument vom
+      Maerz 2026 war nach fuenf Monaten in sieben Punkten falsch.)
 
 ## 2. Release-Branch
 

--- a/installer.iss
+++ b/installer.iss
@@ -58,6 +58,8 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 [Files]
 ; Kompletten PyInstaller-onedir-Ordner mitnehmen
 Source: "dist\PDF_Sortier_Meister\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+; Lizenztext (GPL-3.0-or-later) gut sichtbar neben der EXE
+Source: "LICENSE"; DestDir: "{app}"; DestName: "LICENSE.txt"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"

--- a/pdf_sortier_meister.spec
+++ b/pdf_sortier_meister.spec
@@ -44,6 +44,9 @@ if SPLASH_IMG.exists():
 if (ROOT_DIR / "icon.png").exists():
     # Fenster-/Taskleisten-Icon zur Laufzeit (app.setWindowIcon)
     datas.append((str(ROOT_DIR / "icon.png"), "."))
+# Lizenztext (GPL-3.0-or-later) muss mit jedem Binary ausgeliefert werden
+if (ROOT_DIR / "LICENSE").exists():
+    datas.append((str(ROOT_DIR / "LICENSE"), "."))
 # Gebuendelte Tesseract-Laufzeit (vorher scripts/prepare_tesseract.py bzw.
 # scripts/prepare_tesseract_mac.py ausfuehren).
 # Landet in _internal/tesseract/ und wird von find_tesseract() zuerst gefunden.

--- a/src/core/llm_name_adapt.py
+++ b/src/core/llm_name_adapt.py
@@ -1,0 +1,97 @@
+"""
+KI-Dateinamen an geaenderte Metadaten anpassen (Issue #113).
+
+Ein KI-Vorschlag wie ``2026-03-15_Sonstiges_Muster.pdf`` traegt die Kategorie
+nur als Text. Traegt der Nutzer im Detail-Panel eine bessere Kategorie oder
+einen anderen Korrespondenten ein, wird das entsprechende Wort im Namen
+ersetzt - der Vorschlag bleibt sonst unveraendert. Nichtssagende Platzhalter
+(``Sonstiges``, ``Unbekannt``) werden auch dann ersetzt, wenn die KI keine
+Kategorie mitgeliefert hat.
+
+Reine Funktionen ohne Qt, damit sie ohne GUI testbar sind.
+
+GPL-3.0-or-later - Copyright (c) 2026
+"""
+
+from __future__ import annotations
+
+import re
+
+# Woerter, die im Dateinamen nichts aussagen und durch eine vom Nutzer
+# eingetragene Kategorie ersetzt werden duerfen
+FALLBACK_CATEGORY_TOKENS = ("Sonstiges", "Unbekannt")
+
+# Zeichen, die innerhalb eines Tokens vorkommen (alles andere trennt Tokens)
+_WORD = r"A-Za-z0-9ÄÖÜäöüß"
+
+
+def _variants(value: str) -> list[str]:
+    """Schreibweisen, in denen ein Metadaten-Wert im Dateinamen stehen kann."""
+    value = value.strip()
+    if not value:
+        return []
+    seen: list[str] = []
+    for v in (value, value.replace(" ", "_"), value.replace(" ", "-")):
+        if v and v not in seen:
+            seen.append(v)
+    return seen
+
+
+def _for_filename(value: str, filename: str) -> str:
+    """Neuen Wert an den Stil des Dateinamens anpassen (Leerzeichen -> _)."""
+    value = value.strip()
+    if " " in value and " " not in filename:
+        return value.replace(" ", "_")
+    return value
+
+
+def replace_token(filename: str, old: str, new: str) -> str:
+    """Ersetzt ``old`` als ganzes Token im Dateinamen durch ``new``.
+
+    Token-Grenzen sind ``_``, ``-``, Leerzeichen, Anfang/Ende und ``.pdf``;
+    Gross-/Kleinschreibung ist egal. ``Rechnung`` trifft also nicht in
+    ``Rechnungen``. Mehrwortige Werte werden in allen Schreibweisen
+    (Leerzeichen, ``_``, ``-``) gefunden.
+    """
+    if not old or not new or not filename:
+        return filename
+    replacement = _for_filename(new, filename)
+    for variant in _variants(old):
+        pattern = rf"(?<![{_WORD}]){re.escape(variant)}(?![{_WORD}])"
+        filename, count = re.subn(pattern, lambda _m: replacement, filename, flags=re.IGNORECASE)
+        if count:
+            break
+    return filename
+
+
+def adapt_llm_filename(filename: str, llm_metadata: dict | None, current: dict | None) -> str:
+    """Zieht Kategorie und Korrespondent eines KI-Namens nach den aktuellen Feldern nach.
+
+    Args:
+        filename: KI-Vorschlag, z.B. ``2026-03-15_Sonstiges_Muster.pdf``
+        llm_metadata: Metadaten, die die KI zu diesem Namen geliefert hat
+        current: Aktuelle Feldwerte im Panel (``subject``, ``korrespondent``)
+
+    Returns:
+        Angepasster Name; unveraendert, wenn nichts zu ersetzen ist.
+    """
+    if not filename:
+        return filename
+    llm_metadata = llm_metadata or {}
+    current = current or {}
+    result = filename
+
+    for key in ("subject", "korrespondent"):
+        new = str(current.get(key, "") or "").strip()
+        old = str(llm_metadata.get(key, "") or "").strip()
+        if not new:
+            continue
+        if old and old.lower() != new.lower():
+            result = replace_token(result, old, new)
+        if key == "subject":
+            # Nichtssagendes Wort im Namen -> durch die echte Kategorie ersetzen,
+            # auch wenn die KI die Kategorie nicht (oder als "Sonstiges") lieferte
+            for token in FALLBACK_CATEGORY_TOKENS:
+                if token.lower() != new.lower():
+                    result = replace_token(result, token, new)
+    return result

--- a/src/core/pdf_analyzer.py
+++ b/src/core/pdf_analyzer.py
@@ -34,6 +34,8 @@ class PDFAnalyzer:
         self._doc: Optional[fitz.Document] = None
         self._text: Optional[str] = None
         self._thumbnail: Optional[QPixmap] = None
+        # True, sobald extract_text() auf OCR zurueckgreifen musste (Log, #108)
+        self.ocr_used = False
 
     def __enter__(self):
         """Context Manager Eintritt."""
@@ -138,6 +140,7 @@ class PDFAnalyzer:
 
         # Falls kein Text gefunden und OCR aktiviert
         if not self._text.strip() and use_ocr:
+            self.ocr_used = True
             self._text = self._extract_text_ocr()
 
         return self._text

--- a/src/core/pdf_analyzer.py
+++ b/src/core/pdf_analyzer.py
@@ -311,16 +311,33 @@ class PDFAnalyzer:
 
         return found_keywords
 
-    def suggest_filename(self) -> str:
+    def suggest_filename(
+        self,
+        text: Optional[str] = None,
+        keywords: Optional[list[str]] = None,
+        dates: Optional[list] = None,
+    ) -> str:
         """
         Schlägt einen sinnvollen Dateinamen basierend auf dem Inhalt vor.
+
+        Args:
+            text: Bereits extrahierter Text (z.B. aus dem Cache). Wird er
+                uebergeben, wird die PDF NICHT erneut geoeffnet und keine
+                OCR wiederholt (Issue #108: 7 s Freeze pro Klick).
+            keywords: Bereits extrahierte Schluesselwoerter
+            dates: Bereits extrahierte Datumsangaben; datetime-Objekte oder
+                Strings wie "2026-05-12 00:00:00" (so liegen sie im Cache)
 
         Returns:
             Vorgeschlagener Dateiname
         """
-        text = self.extract_text()
-        keywords = self.extract_keywords()
-        dates = self.extract_dates()
+        if text is None:
+            text = self.extract_text()
+        if keywords is None:
+            keywords = self.extract_keywords()
+        if dates is None:
+            dates = self.extract_dates()
+        dates = coerce_dates(dates)
 
         parts = []
 
@@ -381,6 +398,45 @@ class PDFAnalyzer:
 
         return None
 
+
+
+def coerce_date(value) -> Optional[datetime]:
+    """Macht aus einem Cache-Datum wieder ein datetime.
+
+    Der PDF-Cache speichert Datumsangaben als ``str(datetime)``, also
+    "2026-05-12 00:00:00"; aeltere Eintraege oder LLM-Antworten liefern
+    "2026-05-12". Alles andere ergibt None.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if hasattr(value, "strftime"):  # date
+        return datetime(value.year, value.month, value.day)
+    if isinstance(value, str):
+        text = value.strip()
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d", "%d.%m.%Y"):
+            try:
+                return datetime.strptime(text, fmt)
+            except ValueError:
+                continue
+        try:
+            return datetime.fromisoformat(text)
+        except ValueError:
+            return None
+    return None
+
+
+def coerce_dates(values) -> list[datetime]:
+    """Wie :func:`coerce_date`, fuer Listen; unbrauchbare Eintraege fallen weg."""
+    if not values:
+        return []
+    result = []
+    for v in values:
+        d = coerce_date(v)
+        if d is not None:
+            result.append(d)
+    return result
 
 
 def _tesseract_candidates() -> list[Path]:

--- a/src/core/pdf_cache.py
+++ b/src/core/pdf_cache.py
@@ -62,16 +62,48 @@ class PDFAnalysisWorker(QThread):
         self._running = True
         self._current_pdf: Optional[Path] = None
         self._lock = Lock()
+        # Eingereihte PDFs mit ihrer besten Prioritaet (Issue #108): dieselbe
+        # PDF landete vorher mehrfach in der Queue (Pre-Cache + Klick + Klick),
+        # jede Kopie lief die volle OCR erneut.
+        self._queued: dict[Path, int] = {}
 
     def add_task(self, pdf_path: Path, priority: int = 5):
         """
         Fügt eine Analyse-Aufgabe zur Queue hinzu.
 
+        Bereits eingereihte PDFs werden nicht doppelt analysiert; eine
+        dringendere Anfrage (kleinere Zahl) ueberholt eine wartende.
+
         Args:
             pdf_path: Pfad zur PDF
             priority: 1 = höchste Priorität (User-Interaktion), 10 = niedrigste (Pre-Cache)
         """
+        with self._lock:
+            known = self._queued.get(pdf_path)
+            if known is not None and known <= priority:
+                return
+            self._queued[pdf_path] = priority
         self._queue.put((priority, time.time(), pdf_path))
+
+    def queued_count(self) -> int:
+        """Anzahl unterschiedlicher PDFs, die noch auf Analyse warten."""
+        with self._lock:
+            return len(self._queued)
+
+    def _dequeue(self, timeout: float = 1.0) -> Optional[Path]:
+        """Naechste PDF aus der Queue; veraltete Duplikate werden uebersprungen.
+
+        Returns:
+            Pfad, oder None bei Timeout/Stop-Dummy/uebersprungenem Duplikat.
+        """
+        priority, _timestamp, pdf_path = self._queue.get(timeout=timeout)
+        if pdf_path is None:
+            return None
+        with self._lock:
+            if self._queued.get(pdf_path) != priority:
+                return None  # ueberholt oder schon analysiert
+            del self._queued[pdf_path]
+        return pdf_path
 
     def add_urgent(self, pdf_path: Path):
         """Fügt eine dringende Analyse hinzu (User hat geklickt)."""
@@ -100,7 +132,7 @@ class PDFAnalysisWorker(QThread):
             try:
                 # Warte auf nächste Aufgabe (mit Timeout für sauberes Beenden)
                 try:
-                    priority, timestamp, pdf_path = self._queue.get(timeout=1.0)
+                    pdf_path = self._dequeue(timeout=1.0)
                 except queue.Empty:
                     continue
 
@@ -115,6 +147,7 @@ class PDFAnalysisWorker(QThread):
                     if not pdf_path.exists():
                         continue
 
+                    t0 = time.perf_counter()
                     with PDFAnalyzer(pdf_path) as analyzer:
                         result = PDFAnalysisResult(
                             pdf_path=pdf_path,
@@ -123,6 +156,15 @@ class PDFAnalysisWorker(QThread):
                             dates=analyzer.extract_dates(),
                             file_modified=pdf_path.stat().st_mtime
                         )
+                        pages = analyzer.page_count
+                        ocr_used = analyzer.ocr_used
+                    ms = (time.perf_counter() - t0) * 1000.0
+                    # Gegenstueck zur "Klick ..."-Zeile des StepTimers: der
+                    # asynchrone Teil war im Log bisher unsichtbar (Issue #108)
+                    line = (f"Analyse {pdf_path.name} {ms:.0f} ms: seiten {pages} | "
+                            f"ocr {'ja' if ocr_used else 'nein'} | "
+                            f"zeichen {len(result.extracted_text)}")
+                    (logger.info if ms >= 100 else logger.debug)(line)
 
                     self.analysis_complete.emit(pdf_path, result)
 

--- a/src/core/pdf_metadata.py
+++ b/src/core/pdf_metadata.py
@@ -2,7 +2,9 @@
 PDF-Metadaten-Writer für XMP-Standard.
 
 Schreibt Metadaten direkt in PDF-Dateien (dual: XMP in PDF + SQLite-Index).
-Kompatibel mit Paperless-ngx, DEVONthink, Adobe Acrobat.
+Lesbar in Adobe Acrobat, DEVONthink und den Windows-Eigenschaften.
+paperless-ngx wertet eingebettete PDF-Metadaten beim Import NICHT aus
+(Maintainer in Discussion #5053); dort zaehlt nur der Dateiname.
 """
 
 import re

--- a/src/gui/chat_view.py
+++ b/src/gui/chat_view.py
@@ -7,7 +7,7 @@ Status-/Banner-Bereich. Der eigentliche RAG-Aufruf laeuft asynchron
 ueber :class:`~src.gui.chat_worker.ChatWorker` in einem ``QThread``,
 damit die GUI nicht einfriert.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 from html import escape

--- a/src/gui/chat_worker.py
+++ b/src/gui/chat_worker.py
@@ -7,7 +7,7 @@ nicht einfriert. Der Worker ist ein ``QObject`` und wird per
 ``moveToThread`` in einen ``QThread`` verschoben (Architektur-Vorgabe
 R3: striktes QObject-move-to-thread-Pattern, kein QThread-Subclassing).
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import threading

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -189,6 +189,12 @@ class DetailPanel(QWidget):
         # Zuletzt automatisch (aus Vorschlag) gesetzter Dateiname - dient zur
         # Erkennung, ob der Nutzer den Namen selbst geaendert hat
         self._auto_name: str = ""
+        # Issue #113: True, solange der Dateiname aus der Vorschlagsliste
+        # stammt (oberste Zeile, Klick, KI-Ergebnis) und nicht getippt wurde.
+        # Dann zieht eine Metadaten-Eingabe (Kategorie, Korrespondent, ...)
+        # den Namen sofort nach; _name_kind merkt sich die Art der Zeile.
+        self._name_from_list: bool = False
+        self._name_kind: Optional[str] = None
         # Snapshot der zuletzt gespeicherten Metadaten (entspricht PDF-Stand)
         self._saved_metadata_snapshot: dict = {}
         # Felder, die tatsaechlich aus dem PDF (XMP/Info) gelesen wurden - nur
@@ -310,6 +316,8 @@ class DetailPanel(QWidget):
             "Neuer Dateiname für die PDF - wird beim Klick auf einen Zielordner übernommen."
         )
         self.name_input.textChanged.connect(self._update_preview)
+        # textEdited feuert nur bei Nutzereingaben, nicht bei setText()
+        self.name_input.textEdited.connect(self._on_name_typed)
         font = QFont()
         font.setPointSize(11)
         self.name_input.setFont(font)
@@ -703,6 +711,9 @@ class DetailPanel(QWidget):
         self._metadata = {}
         self._metadata_source = None
         self._saved_metadata_snapshot = {}
+        self._name_from_list = False
+        self._name_kind = None
+        self._auto_name = ""
         self.preview.clear()
 
         self.name_input.clear()
@@ -837,12 +848,46 @@ class DetailPanel(QWidget):
         self._refresh_save_btn()
 
     def _on_metadata_user_edit(self, *args):
-        """Wird aufgerufen wenn der User ein Metadaten-Feld ändert."""
+        """Wird aufgerufen wenn der User ein Metadaten-Feld ändert.
+
+        Issue #113: Die Vorschlagsliste wird mit den neuen Feldwerten neu
+        gerendert (Muster-Zeilen, Kategorie/Korrespondent in KI-Zeilen).
+        Stammt der Dateiname noch aus der Liste, zieht er sofort nach; ein
+        selbst getippter Name bleibt unangetastet.
+        """
         if self._loading_metadata:
             return
         if self._metadata_source != "user":
             self._metadata_source = "user"
+        if self._current_pdf is not None:
+            self._populate_suggestions()
+            if self._name_from_list:
+                self._apply_name_from_kind()
         self._refresh_save_btn()
+
+    def _on_name_typed(self, _text: str):
+        """Nutzer tippt im Namensfeld: ab jetzt keine automatische Nachfuehrung."""
+        self._name_from_list = False
+        self._name_kind = None
+
+    def _apply_name_from_kind(self):
+        """Setzt den Namen auf die Zeile der gemerkten Art (sonst die oberste)."""
+        if not self._displayed_suggestions:
+            return
+        idx = 0
+        if self._name_kind is not None and self._name_kind in self._displayed_kinds:
+            idx = self._displayed_kinds.index(self._name_kind)
+        self._set_name_from_row(idx)
+
+    def _set_name_from_row(self, idx: int):
+        """Uebernimmt Zeile ``idx`` als automatischen Dateinamen (koppelt an die Liste)."""
+        if not (0 <= idx < len(self._displayed_suggestions)):
+            return
+        name = self._displayed_suggestions[idx].name.replace('.pdf', '')
+        self.name_input.setText(name)
+        self._auto_name = name
+        self._name_from_list = True
+        self._name_kind = self._displayed_kinds[idx]
 
     def _refresh_save_btn(self):
         """Aktualisiert Text und Status des Speichern-Buttons und des Status-Labels."""
@@ -941,11 +986,14 @@ class DetailPanel(QWidget):
         zuletzt angeklickte Art zuoberst.
         """
         from src.core.suggestion_order import (
-            KIND_DATE, KIND_LEARNED, kind_from_reason, sort_by_kind,
+            KIND_DATE, KIND_KI, KIND_LEARNED, kind_from_reason, sort_by_kind,
         )
+
+        from src.core.llm_name_adapt import adapt_llm_filename
 
         self.suggestions_list.clear()
 
+        current_meta = self.get_metadata() if self._current_pdf else {}
         pairs: list[tuple[RenameSuggestion, str]] = []
         for s in self._suggestions:
             kind = kind_from_reason(s.reason)
@@ -954,6 +1002,13 @@ class DetailPanel(QWidget):
                 # alter Dateiname) ebenso - die Historie fliesst stattdessen als
                 # Beispiel in den KI-Prompt (src.core.rename_examples)
                 continue
+            if kind == KIND_KI:
+                # Issue #113: "Sonstiges"/alte Kategorie im KI-Namen durch die
+                # aktuelle Feld-Eingabe ersetzen (Anzeige-Kopie, Original bleibt)
+                adapted = adapt_llm_filename(s.name, s.metadata, current_meta)
+                if adapted != s.name:
+                    s = RenameSuggestion(name=adapted, reason=s.reason,
+                                         confidence=s.confidence, metadata=s.metadata)
             pairs.append((s, kind))
         pattern_pairs = self._pattern_suggestions()
         pairs.extend(pattern_pairs)
@@ -1008,11 +1063,7 @@ class DetailPanel(QWidget):
 
     def _apply_top_suggestion(self):
         """Uebernimmt die oberste Zeile als (automatischen) Dateinamen."""
-        if not self._displayed_suggestions:
-            return
-        name = self._displayed_suggestions[0].name.replace('.pdf', '')
-        self.name_input.setText(name)
-        self._auto_name = name
+        self._set_name_from_row(0)
 
     # -- Metadaten-Hilfen (Issues #109/#110) ------------------------------- #
 
@@ -1273,6 +1324,10 @@ class DetailPanel(QWidget):
             idx = self.suggestions_list.row(item)
             if 0 <= idx < len(self._displayed_kinds):
                 self._remember_kind(self._displayed_kinds[idx])
+                # Issue #113: angeklickte Zeile bleibt an die Felder gekoppelt
+                self._auto_name = name.replace('.pdf', '')
+                self._name_from_list = True
+                self._name_kind = self._displayed_kinds[idx]
 
             # Metadaten des Vorschlags übernehmen
             shown = self._displayed_suggestions
@@ -1428,6 +1483,13 @@ class DetailPanel(QWidget):
             text += f" ({estimate})"
         self.llm_btn.setText(text)
 
+    def _couple_name_to_llm(self, filename: str):
+        """KI-Name gilt als automatisch gesetzt und folgt Feld-Aenderungen (#113)."""
+        from src.core.suggestion_order import KIND_KI
+        self._auto_name = filename.replace('.pdf', '')
+        self._name_from_list = True
+        self._name_kind = KIND_KI
+
     def _on_llm_metadata_ready(self, pdf_path: Path, suggestions: list, error: str):
         """Traegt das KI-Ergebnis ein - nur, wenn die PDF noch ausgewaehlt ist."""
         self._llm_timer.stop()
@@ -1475,12 +1537,14 @@ class DetailPanel(QWidget):
                             pass
                     self._loading_metadata = False
                     self._metadata_source = "llm"
+                    self._couple_name_to_llm(s.filename)
                     self._refresh_save_btn()
                     break
             else:
                 for s in suggestions:
                     if s.source == "llm":
                         self.name_input.setText(s.filename.replace('.pdf', ''))
+                        self._couple_name_to_llm(s.filename)
                         break
                 else:
                     # Kein KI-Vorschlag angekommen - Grund anzeigen (z.B. Token-Limit)

--- a/src/gui/folder_tree_widget.py
+++ b/src/gui/folder_tree_widget.py
@@ -80,7 +80,9 @@ class FolderTreeWidget(QWidget):
     # Kern-Workflow, der sonst fuer neue Nutzer unsichtbar ist (Issue #51).
     _CLICK_HINT = (
         "\n\nEinfachklick: ausgewaehlte PDF hierher verschieben.\n"
-        "Doppelklick: als Scan-Ordner links oeffnen (Navigation)."
+        "Doppelklick: als Scan-Ordner links oeffnen (Navigation).\n"
+        "Pfeil rechts klappt auf, * klappt alle Unterordner auf.\n"
+        "Rechtsklick: weitere Aktionen."
     )
 
     # Signale
@@ -146,6 +148,8 @@ class FolderTreeWidget(QWidget):
         self.tree.setToolTip(
             "Einfachklick auf einen Ordner: ausgewaehlte PDF hierher verschieben.\n"
             "Doppelklick: Ordner links als Scan-Ordner oeffnen (Navigation).\n"
+            "Pfeil rechts klappt einen Ordner auf, * alle Unterordner.\n"
+            "Rechtsklick: weitere Aktionen.\n"
             "PDFs koennen auch per Drag & Drop hierher gezogen werden."
         )
 

--- a/src/gui/folder_tree_widget.py
+++ b/src/gui/folder_tree_widget.py
@@ -4,7 +4,7 @@ Ordner-Baum-Widget für PDF Sortier Meister
 Zeigt eine hierarchische Ordnerstruktur als Baumansicht an.
 Unterstützt Unterordner und zeigt PDF-Anzahlen an.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import os

--- a/src/gui/folder_widget.py
+++ b/src/gui/folder_widget.py
@@ -150,6 +150,10 @@ class FolderWidget(QFrame):
 
     def contextMenuEvent(self, event):
         """Zeigt das Kontextmenü an."""
+        self._build_context_menu().exec(event.globalPos())
+
+    def _build_context_menu(self) -> QMenu:
+        """Baut das Kontextmenue (getrennt, damit es testbar ist)."""
         menu = QMenu(self)
 
         # Im Dateimanager öffnen
@@ -157,13 +161,16 @@ class FolderWidget(QFrame):
         open_action = menu.addAction(f"Im {file_manager_name()} öffnen")
         open_action.triggered.connect(lambda: self._open_in_explorer())
 
-        menu.addSeparator()
+        # Aus Liste entfernen - nur fuer echte Zielordner-Kacheln. Auf den
+        # gruenen Vorschlagskacheln war der Eintrag wirkungslos (Signal nie
+        # verbunden) und inhaltlich falsch: Vorschlaege sind meist Unterordner,
+        # keine Eintraege der Zielliste.
+        if not self._is_suggestion:
+            menu.addSeparator()
+            remove_action = menu.addAction("Aus Zielliste entfernen")
+            remove_action.triggered.connect(lambda: self.remove_requested.emit(self.folder_path))
 
-        # Aus Liste entfernen
-        remove_action = menu.addAction("Aus Zielliste entfernen")
-        remove_action.triggered.connect(lambda: self.remove_requested.emit(self.folder_path))
-
-        menu.exec(event.globalPos())
+        return menu
 
     def _open_in_explorer(self):
         """Öffnet den Ordner im Dateimanager des Systems."""

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1593,6 +1593,9 @@ class MainWindow(QMainWindow):
 
         self.statusbar.showMessage(f"Ausgewählt: {pdf_path.name}")
 
+        # Wartezustand einer noch laufenden Erst-Analyse fuer die vorige PDF beenden
+        self._end_analysis_wait()
+
         # PDF analysieren und Vorschläge aktualisieren
         self._click_timer = StepTimer("Klick")
         self.update_suggestions_for_pdf(pdf_path)
@@ -1685,6 +1688,7 @@ class MainWindow(QMainWindow):
 
     def _clear_selection(self):
         """Hebt die aktuelle Auswahl vollständig auf."""
+        self._end_analysis_wait()
         try:
             # Alle Widgets deselektieren
             for widget in self.pdf_widgets:
@@ -1729,8 +1733,10 @@ class MainWindow(QMainWindow):
             # Sofort aus Cache verwenden - keine Verzögerung!
             self._apply_analysis_result(pdf_path, cached_result)
         else:
-            # Noch nicht analysiert - Hintergrund-Analyse starten
-            self.statusbar.showMessage(f"Analysiere {pdf_path.name}...")
+            # Noch nicht analysiert - Hintergrund-Analyse starten. Bei Scan-PDFs
+            # ist das die OCR (mehrere Sekunden): Wartezeiger + Kachelzustand,
+            # damit der Klick sichtbar angekommen ist (Issue #108)
+            self._begin_analysis_wait(pdf_path)
 
             # Analyse anfordern mit Callback
             self.pdf_cache.request_analysis(
@@ -1739,11 +1745,51 @@ class MainWindow(QMainWindow):
                 urgent=True  # Höchste Priorität weil User geklickt hat
             )
 
+    def _begin_analysis_wait(self, pdf_path: Path):
+        """Wartezeiger + "Analysiere…" auf der Kachel, bis die Erst-Analyse da ist."""
+        self._end_analysis_wait()
+        self._analysis_wait_pdf = pdf_path
+        QApplication.setOverrideCursor(Qt.CursorShape.BusyCursor)
+        self.statusbar.showMessage(
+            f"Analysiere {pdf_path.name}… (Texterkennung kann einige Sekunden dauern)"
+        )
+        widget = self._pdf_widget_for(pdf_path)
+        if widget is not None:
+            widget.analyzing = True
+
+    def _end_analysis_wait(self):
+        """Beendet den Wartezustand der Erst-Analyse (idempotent)."""
+        pdf_path = getattr(self, "_analysis_wait_pdf", None)
+        if pdf_path is None:
+            return
+        self._analysis_wait_pdf = None
+        QApplication.restoreOverrideCursor()
+        widget = self._pdf_widget_for(pdf_path)
+        if widget is not None:
+            widget.analyzing = False
+
+    def _pdf_widget_for(self, pdf_path: Path):
+        for widget in self.pdf_widgets:
+            try:
+                if widget.pdf_path == pdf_path:
+                    return widget
+            except RuntimeError:
+                continue  # Widget bereits von Qt geloescht
+        return None
+
     def _on_analysis_result_ready(self, pdf_path: Path, result: PDFAnalysisResult):
         """Wird aufgerufen wenn eine Analyse fertig ist (aus Cache-Worker)."""
+        # Wartezustand IMMER zuruecksetzen - auch wenn der Nutzer inzwischen
+        # etwas anderes ausgewaehlt hat, sonst bleibt der Wartezeiger haengen
+        if getattr(self, "_analysis_wait_pdf", None) == pdf_path:
+            self._end_analysis_wait()
         # Nur anwenden wenn diese PDF noch ausgewählt ist
         if self.selected_pdf == pdf_path:
+            # Eigene Log-Zeile fuer den asynchronen Pfad: der "Klick"-Timer
+            # ist laengst abgeschlossen, seine Schritte gingen bisher verloren
+            self._click_timer = StepTimer("Klick nach Analyse")
             self._apply_analysis_result(pdf_path, result)
+            self._click_timer.done()
 
     def _on_pdf_analyzed(self, pdf_path: Path):
         """Wird aufgerufen wenn irgendeine PDF analysiert wurde (Cache-Signal)."""

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1893,6 +1893,9 @@ class MainWindow(QMainWindow):
 
             widget.clicked.connect(self.on_suggestion_clicked)
             widget.double_clicked.connect(self.on_folder_double_clicked)
+            # Drop auf eine gruene Vorschlagskachel verschiebt wie ein Drop
+            # auf den Baum (vorher stilles No-op, weil nie verbunden)
+            widget.pdf_dropped.connect(self.on_pdf_dropped_on_folder)
 
             self.suggestions_layout.addWidget(widget)
             self.suggestion_widgets.append(widget)
@@ -2650,7 +2653,7 @@ class MainWindow(QMainWindow):
                 # Nur das verschobene PDF-Widget entfernen
                 self._remove_pdf_widget_and_select_next(pdf_path)
                 # Ordneransicht aktualisieren
-                self._refresh_after_move(folder_path, pdf_path.parent)
+                self._refresh_after_move(Path(folder), pdf_path.parent)
                 # Phase 21: Automation-Regeln (Vorschlag im Statusbar)
                 self._check_automation_rules(pdf_path)
                 # Phase 20: Korrespondenten aus Historie sammeln
@@ -3396,7 +3399,11 @@ class MainWindow(QMainWindow):
         """Wird aufgerufen wenn ein Ordner aus der Liste entfernt werden soll."""
         self.config.remove_target_folder(folder_path)
         self.folder_manager.remove_folder(folder_path)
-        self.load_folders()
+        # Der Baum hat sich beim Kontextmenue-Aufruf bereits selbst neu
+        # gescannt; ein zweiter Voll-Scan ueber load_folders() ist nur noetig,
+        # wenn der Aufruf von woanders kam (z.B. aus dem versteckten Raster).
+        if self.folder_tree.has_folder(Path(folder_path)):
+            self.load_folders()
 
         # Auch aus den Vorschlag-Widgets entfernen (grüne Buttons)
         for widget in self.suggestion_widgets[:]:  # Kopie der Liste für sichere Iteration

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -4304,10 +4304,12 @@ class MainWindow(QMainWindow):
         # Lizenz
         license_label = QLabel(
             "<p style='color: #666; font-size: 11px;'>"
-            "<b>Lizenz:</b> MIT License<br>"
+            "<b>Lizenz:</b> GPL-3.0-or-later<br>"
             "Copyright (c) 2024-2026<br>"
-            "Freie Software - Open Source</p>"
+            "Freie Software - Open Source. Lizenztext: "
+            '<a href="https://www.gnu.org/licenses/gpl-3.0.html">gnu.org/licenses/gpl-3.0</a></p>'
         )
+        license_label.setOpenExternalLinks(True)
         license_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(license_label)
 

--- a/src/gui/pdf_thumbnail.py
+++ b/src/gui/pdf_thumbnail.py
@@ -71,6 +71,7 @@ class PDFThumbnailWidget(QFrame):
         self.pdf_path = pdf_path
         self._selected = False
         self._has_ai_suggestion = False  # Issue #81: KI-Vorschlag im Cache
+        self._analyzing = False  # Issue #108: Erst-Analyse (OCR) laeuft gerade
         self._loader_thread: Optional[ThumbnailLoaderThread] = None
         self._drag_start_position: Optional[QPoint] = None
 
@@ -181,6 +182,26 @@ class PDFThumbnailWidget(QFrame):
         self._has_ai_suggestion = value
         self.setToolTip(self._BASE_TOOLTIP + (self.AI_TOOLTIP_SUFFIX if value else ""))
         self._update_style()
+
+    ANALYZING_TEXT = "Analysiere…"
+
+    @property
+    def analyzing(self) -> bool:
+        """True, waehrend die Erst-Analyse (Text/OCR) fuer diese PDF laeuft."""
+        return self._analyzing
+
+    @analyzing.setter
+    def analyzing(self, value: bool):
+        value = bool(value)
+        if value == self._analyzing:
+            return
+        self._analyzing = value
+        if value:
+            self.name_label.setText(self.ANALYZING_TEXT)
+            self.name_label.setStyleSheet("font-size: 11px; line-height: 1.2; color: #b8860b; font-style: italic;")
+        else:
+            self.name_label.setStyleSheet("font-size: 11px; line-height: 1.2;")
+            self.update_name_display()
 
     @property
     def selected(self) -> bool:

--- a/src/gui/rename_dialog.py
+++ b/src/gui/rename_dialog.py
@@ -535,26 +535,42 @@ def generate_rename_suggestions(
     """
     suggestions = []
 
-    # 1. Vorschlag aus PDF-Analyzer
+    # 1. Vorschlag aus PDF-Analyzer.
+    # Issue #108: Liegen Text, Stichwoerter und Datumsangaben schon vor (aus
+    # dem PDF-Cache), wird die PDF NICHT geoeffnet - vorher lief hier bei
+    # jedem Klick auf eine Scan-PDF die komplette OCR noch einmal im
+    # GUI-Thread (7 s Freeze). Nur fehlende Teile werden nachgeladen.
     try:
-        from src.core.pdf_analyzer import PDFAnalyzer
+        from src.core.pdf_analyzer import PDFAnalyzer, coerce_dates
 
-        with PDFAnalyzer(pdf_path) as analyzer:
-            if extracted_text is None:
-                extracted_text = analyzer.extract_text()
-            if keywords is None:
-                keywords = analyzer.extract_keywords()
-            if dates is None:
-                dates = analyzer.extract_dates()
+        if dates is not None:
+            dates = coerce_dates(dates)
 
-            # Standard-Vorschlag
-            suggested = analyzer.suggest_filename()
-            if suggested and suggested != pdf_path.name:
-                suggestions.append(RenameSuggestion(
-                    name=suggested,
-                    reason="Automatisch erkannt",
-                    confidence=0.6
-                ))
+        analyzer = PDFAnalyzer(pdf_path)
+        needs_pdf = extracted_text is None or keywords is None or dates is None
+        try:
+            if needs_pdf:
+                analyzer.open()
+                if extracted_text is None:
+                    extracted_text = analyzer.extract_text()
+                if keywords is None:
+                    keywords = analyzer.extract_keywords()
+                if dates is None:
+                    dates = analyzer.extract_dates()
+
+            # Standard-Vorschlag - rein aus den vorliegenden Werten
+            suggested = analyzer.suggest_filename(
+                text=extracted_text, keywords=keywords, dates=dates
+            )
+        finally:
+            analyzer.close()
+
+        if suggested and suggested != pdf_path.name:
+            suggestions.append(RenameSuggestion(
+                name=suggested,
+                reason="Automatisch erkannt",
+                confidence=0.6
+            ))
 
     except Exception as e:
         print(f"Fehler bei PDF-Analyse für Vorschläge: {e}")
@@ -568,7 +584,7 @@ def generate_rename_suggestions(
                 date_str = first_date.strftime("%Y-%m-%d")
             else:
                 # Falls es bereits ein String ist
-                date_str = str(first_date)
+                date_str = str(first_date)[:10]
 
             # Nur Datum
             suggestions.append(RenameSuggestion(

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -3,7 +3,7 @@ Einstellungsdialog für PDF Sortier Meister
 
 Ermöglicht die Konfiguration von LLM-Providern und anderen Einstellungen.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 from PyQt6.QtWidgets import (

--- a/src/main.py
+++ b/src/main.py
@@ -40,6 +40,22 @@ from src.utils.explorer_integration import update_launcher_script
 __version__ = "0.23.0"
 
 
+def _schedule_startup_hints(window, delay_ms: int = 300) -> None:
+    """Zeigt Erste-Schritte- und Backup-Hinweis kurz nach dem Start.
+
+    Reihenfolge: Erste Schritte (Issue #51) vor dem Backup-Hinweis, weil der
+    Workflow wichtiger ist als die Backup-Erinnerung. Beim Erststart wird die
+    Funktion erst NACH dem Einrichtungsassistenten aufgerufen, damit die
+    Dialoge nicht ueber dem offenen Assistenten erscheinen.
+    """
+
+    def show_startup_hints():
+        window.show_first_steps_hint()
+        window.show_backup_hint()
+
+    QTimer.singleShot(delay_ms, show_startup_hints)
+
+
 def _apply_wizard_result(window, config):
     """Aktualisiert das Hauptfenster nach dem Einrichtungs-Assistenten.
 
@@ -242,7 +258,7 @@ def main():
     # Scan-Ordner konfiguriert ist und thumbnails_loaded nicht feuert.
     _splash_closed = {"done": False}
 
-    def close_splash():
+    def close_splash(show_hints: bool = True):
         if _splash_closed["done"]:
             return
         _splash_closed["done"] = True
@@ -255,15 +271,11 @@ def main():
                 pass
         window.raise_()
         window.activateWindow()
-
-        def show_startup_hints():
-            # Erste-Schritte-Hinweis (Issue #51) vor dem Backup-Hinweis zeigen,
-            # weil der Workflow wichtiger ist als die Backup-Erinnerung.
-            window.show_first_steps_hint()
-            window.show_backup_hint()
-
-        # Hinweise erst zeigen, wenn der Splash weg ist
-        QTimer.singleShot(300, show_startup_hints)
+        # Hinweise erst zeigen, wenn der Splash weg ist. Beim Erststart
+        # uebernimmt das der Wizard-Zweig unten, sonst laegen die Dialoge
+        # ueber dem offenen Assistenten.
+        if show_hints:
+            _schedule_startup_hints(window)
 
     window.thumbnails_loaded.connect(close_splash)
     QTimer.singleShot(15000, close_splash)
@@ -272,12 +284,15 @@ def main():
     if not config.get_scan_folder():
         # Splash sofort schliessen: ohne Scan-Ordner feuert thumbnails_loaded
         # nie und der Splash laege 15s ueber dem Wizard (Issue #50)
-        close_splash()
+        close_splash(show_hints=False)
         wizard = SetupWizard(window)
         wizard.exec()
         # Nach dem Wizard: Hauptfenster mit neuem Scan-Ordner und LLM-Status
         # aktualisieren (Closes #65)
         _apply_wizard_result(window, config)
+        # Erst jetzt die Erste-Schritte-/Backup-Hinweise, nicht waehrend
+        # der Assistent offen ist
+        _schedule_startup_hints(window)
 
     # Update-Pruefung im Hintergrund, kurz nach dem Start (Issue #73).
     # Bewusst hier und nicht im MainWindow-Konstruktor, damit Tests und

--- a/src/ml/claude_provider.py
+++ b/src/ml/claude_provider.py
@@ -126,7 +126,7 @@ class ClaudeProvider(LLMProvider):
             )
             if problem:
                 return LLMResponse(success=False, error_message=problem)
-            parsed = self._parse_response(response_text)
+            parsed = self._parse_response(response_text, document_text=text)
             if parsed.get("error"):
                 return LLMResponse(
                     success=False,
@@ -223,7 +223,7 @@ class ClaudeProvider(LLMProvider):
             )
             if problem:
                 return LLMResponse(success=False, error_message=problem)
-            parsed = self._parse_response(response_text)
+            parsed = self._parse_response(response_text, document_text=text)
             if parsed.get("error"):
                 return LLMResponse(
                     success=False,

--- a/src/ml/claude_provider.py
+++ b/src/ml/claude_provider.py
@@ -3,7 +3,7 @@ Claude API Provider für PDF Sortier Meister
 
 Implementiert die LLM-Schnittstelle für Anthropic's Claude API.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import json

--- a/src/ml/hybrid_classifier.py
+++ b/src/ml/hybrid_classifier.py
@@ -4,7 +4,7 @@ Hybrid-Klassifikator für PDF Sortier Meister
 Kombiniert lokale TF-IDF Klassifikation mit optionaler LLM-Unterstützung
 für bessere Sortier- und Benennungsvorschläge.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 from pathlib import Path

--- a/src/ml/llm_provider.py
+++ b/src/ml/llm_provider.py
@@ -90,6 +90,35 @@ METADATA_KEY_ALIASES: dict[str, str] = {
 _UNKNOWN_VALUES = {"", "unbekannt", "unknown", "null", "none", "n/a", "-"}
 
 
+# Woerter, die einen Steuersatz im Dokument belegen
+_MWST_WORDS = re.compile(r"mwst|m\.w\.st|ust\b|u\.st|mehrwertsteuer|umsatzsteuer|vat\b|steuersatz", re.I)
+
+
+def drop_unsupported_mwst(metadata: dict, document_text: str | None) -> dict:
+    """Entfernt einen MwSt-Satz, der im Dokumenttext nicht vorkommt.
+
+    Kleine Modelle uebernehmen gern einen Beispielwert (frueher stand ``7`` im
+    Prompt-Schema) oder raten 19 %. Der Satz bleibt nur, wenn ``<Satz> %`` im
+    Text steht oder das Dokument ueberhaupt von Steuer spricht (dann kann das
+    Modell ihn aus einer Tabelle gelesen haben). Ohne Text: unveraendert.
+    """
+    if not isinstance(metadata, dict) or document_text is None:
+        return metadata
+    rate = metadata.get("mwst_satz")
+    if rate in (None, ""):
+        return metadata
+    m = re.search(r"\d+(?:[.,]\d+)?", str(rate))
+    if not m:
+        return metadata
+    number = m.group(0).replace(",", ".").rstrip("0").rstrip(".")
+    pattern = re.compile(r"(?<!\d)" + re.escape(number).replace(r"\.", r"[.,]") + r"(?:[.,]0+)?\s*%")
+    if pattern.search(document_text) or _MWST_WORDS.search(document_text):
+        return metadata
+    result = dict(metadata)
+    del result["mwst_satz"]
+    return result
+
+
 def normalize_llm_metadata(metadata) -> dict:
     """Bildet LLM-Metadaten auf die kanonischen Schluessel ab.
 
@@ -354,6 +383,8 @@ AUFGABE:
 1. Analysiere den Dokumentinhalt.
 2. Wähle den passendsten Ordner aus der Liste (exakter Name).
 3. Begründe deine Wahl kurz.
+4. Metadaten nur aus dem Dokument: "mwst" nur, wenn der Steuersatz ausdruecklich im Text
+   steht, sonst UNBEKANNT; bei Nicht-Rechnungen sind Betraege, mwst und iban UNBEKANNT.
 
 Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
 {{
@@ -366,9 +397,9 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
     "betrag_netto": "123.45 oder UNBEKANNT",
     "betrag_brutto": "123.45 oder UNBEKANNT",
     "waehrung": "EUR/USD oder UNBEKANNT",
-    "mwst": 7,
+    "mwst": "19 oder 7 oder UNBEKANNT",
     "iban": "IBAN oder UNBEKANNT",
-    "steuerjahr": 2024,
+    "steuerjahr": "JJJJ oder UNBEKANNT",
     "beschreibung": "Zusammenfassung des Dokuments in einem Satz"
   }}
 }}"""
@@ -443,6 +474,10 @@ REGELN FÜR DEN DATEINAMEN:
    im Dateinamen. Passt keine der Standard-Kategorien, benenne konkret, worum es
    geht (z.B. Klaviernoten_Bach_Praeludium, Bedienungsanleitung_Waschmaschine).
    "Sonstiges" ist nur als Kategorie in den Metadaten erlaubt, nie im Dateinamen.
+7. Metadaten nur aus dem Dokument: "mwst" nur, wenn der Steuersatz ausdruecklich im Text
+   steht (z.B. "19 % MwSt", "USt 7 %"), sonst UNBEKANNT. Kein Rechnungs-/Beleg-Dokument
+   (Brief, Vertrag, Befund, Noten, Anleitung): betrag_netto, betrag_brutto, mwst und iban
+   sind UNBEKANNT. Niemals einen Standardwert raten.
 
 Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
 {{
@@ -455,9 +490,9 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
     "betrag_netto": "123.45 oder UNBEKANNT",
     "betrag_brutto": "123.45 oder UNBEKANNT",
     "waehrung": "EUR/USD oder UNBEKANNT",
-    "mwst": 7,
+    "mwst": "19 oder 7 oder UNBEKANNT",
     "iban": "IBAN oder UNBEKANNT",
-    "steuerjahr": 2024,
+    "steuerjahr": "JJJJ oder UNBEKANNT",
     "beschreibung": "Zusammenfassung in einem Satz"
   }}
 }}"""
@@ -569,7 +604,9 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
             return f"KI-Antwort abgeschnitten - {hint}"
         return None
 
-    def _parse_json_response(self, response_text: str) -> tuple[Optional[dict], Optional[str]]:
+    def _parse_json_response(
+        self, response_text: str, document_text: str | None = None
+    ) -> tuple[Optional[dict], Optional[str]]:
         """
         Extrahiert und parst das JSON aus einer Antwort.
 
@@ -593,7 +630,9 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
 
             # Metadaten-Schluessel vereinheitlichen (beschreibung -> description, ...)
             if "metadata" in data:
-                data["metadata"] = normalize_llm_metadata(data.get("metadata"))
+                data["metadata"] = drop_unsupported_mwst(
+                    normalize_llm_metadata(data.get("metadata")), document_text
+                )
 
             return data, None
         except json.JSONDecodeError as e:
@@ -601,7 +640,7 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
         except Exception as e:
             return None, f"Fehler beim Extrahieren von JSON: {str(e)}"
 
-    def _parse_response(self, response_text: str) -> dict:
+    def _parse_response(self, response_text: str, document_text: str | None = None) -> dict:
         """
         Parst die (JSON-)Antwort des LLMs in das von den Cloud-Providern
         erwartete Dictionary-Format (folder/filename/reason/confidence/metadata).
@@ -617,7 +656,7 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
             "metadata": {},
         }
 
-        data, error = self._parse_json_response(response_text)
+        data, error = self._parse_json_response(response_text, document_text)
         if error or not data:
             # Fehler mitgeben, damit Provider das als Misserfolg melden koennen
             result["error"] = error or "Keine JSON-Antwort gefunden"

--- a/src/ml/llm_provider.py
+++ b/src/ml/llm_provider.py
@@ -439,6 +439,10 @@ REGELN FÜR DEN DATEINAMEN:
    (z.B. Kathrin_Haerle, Agentur_fuer_Arbeit, HUK-Coburg), niemals eine E-Mail-Adresse,
    Telefonnummer, IBAN oder Web-Adresse. Steht nur eine E-Mail-Adresse im Dokument,
    leite den Namen daraus ab (kathrin.haerle@web.de -> Kathrin_Haerle).
+6. Keine nichtssagenden Woerter wie "Sonstiges", "Unbekannt", "Dokument" oder "Scan"
+   im Dateinamen. Passt keine der Standard-Kategorien, benenne konkret, worum es
+   geht (z.B. Klaviernoten_Bach_Praeludium, Bedienungsanleitung_Waschmaschine).
+   "Sonstiges" ist nur als Kategorie in den Metadaten erlaubt, nie im Dateinamen.
 
 Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
 {{

--- a/src/ml/llm_provider.py
+++ b/src/ml/llm_provider.py
@@ -4,7 +4,7 @@ LLM Provider-Abstraktion für PDF Sortier Meister
 Bietet eine einheitliche Schnittstelle für verschiedene LLM-Anbieter
 (Claude, OpenAI, etc.) zur Klassifikation und Benennung von PDFs.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import json

--- a/src/ml/ollama_provider.py
+++ b/src/ml/ollama_provider.py
@@ -18,7 +18,7 @@ Nachteile:
 Diese Implementierung spricht die native Ollama-API (/api/chat) ueber
 urllib (stdlib), um keine zusaetzliche Dependency einzufuehren.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import json

--- a/src/ml/ollama_provider.py
+++ b/src/ml/ollama_provider.py
@@ -275,7 +275,7 @@ class OllamaProvider(LLMProvider):
             return LLMResponse(success=False, error_message=error)
 
         cleaned = self._strip_code_fences(response_text)
-        parsed, parse_err = self._parse_json_response(cleaned)
+        parsed, parse_err = self._parse_json_response(cleaned, document_text=text)
 
         if parse_err:
             return LLMResponse(success=False, error_message=parse_err)
@@ -314,7 +314,7 @@ class OllamaProvider(LLMProvider):
             return LLMResponse(success=False, error_message=error)
 
         cleaned = self._strip_code_fences(response_text)
-        parsed, parse_err = self._parse_json_response(cleaned)
+        parsed, parse_err = self._parse_json_response(cleaned, document_text=text)
 
         if parse_err:
             return LLMResponse(success=False, error_message=parse_err)

--- a/src/ml/openai_provider.py
+++ b/src/ml/openai_provider.py
@@ -3,7 +3,7 @@ OpenAI API Provider für PDF Sortier Meister
 
 Implementiert die LLM-Schnittstelle für OpenAI's GPT API.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import json

--- a/src/ml/openai_provider.py
+++ b/src/ml/openai_provider.py
@@ -138,7 +138,7 @@ class OpenAIProvider(LLMProvider):
             )
             if problem:
                 return LLMResponse(success=False, error_message=problem)
-            parsed = self._parse_response(response_text)
+            parsed = self._parse_response(response_text, document_text=text)
             if parsed.get("error"):
                 return LLMResponse(
                     success=False,
@@ -240,7 +240,7 @@ class OpenAIProvider(LLMProvider):
             )
             if problem:
                 return LLMResponse(success=False, error_message=problem)
-            parsed = self._parse_response(response_text)
+            parsed = self._parse_response(response_text, document_text=text)
             if parsed.get("error"):
                 return LLMResponse(
                     success=False,

--- a/src/ml/poe_provider.py
+++ b/src/ml/poe_provider.py
@@ -5,7 +5,7 @@ Implementiert die LLM-Schnittstelle für Poe.com's API.
 Poe bietet Zugang zu verschiedenen Modellen (GPT, Claude, Gemini, etc.)
 über eine einheitliche OpenAI-kompatible API.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import json

--- a/src/ml/poe_provider.py
+++ b/src/ml/poe_provider.py
@@ -172,7 +172,7 @@ class PoeProvider(LLMProvider):
             )
             if problem:
                 return LLMResponse(success=False, error_message=problem)
-            parsed = self._parse_response(response_text)
+            parsed = self._parse_response(response_text, document_text=text)
             if parsed.get("error"):
                 return LLMResponse(
                     success=False,
@@ -274,7 +274,7 @@ class PoeProvider(LLMProvider):
             )
             if problem:
                 return LLMResponse(success=False, error_message=problem)
-            parsed = self._parse_response(response_text)
+            parsed = self._parse_response(response_text, document_text=text)
             if parsed.get("error"):
                 return LLMResponse(
                     success=False,

--- a/src/rag/__init__.py
+++ b/src/rag/__init__.py
@@ -17,7 +17,7 @@ Stellt die Kernbausteine des RAG-Chat-Features bereit:
 Die GUI-Komponenten (``ChatView``, ``ChatWorker``) sind Bestandteil
 von M2 und werden hier nicht exportiert.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 from src.rag.chat_session import ChatSession, ChatTurn

--- a/src/rag/chat_session.py
+++ b/src/rag/chat_session.py
@@ -6,7 +6,7 @@ Token-Schaetzung und History-Slicing fuer den Prompt-Builder.
 
 Persistence (SQLite) ist explizit Q1-deferred und nicht Teil von M1.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 from dataclasses import dataclass, field

--- a/src/rag/citation.py
+++ b/src/rag/citation.py
@@ -13,7 +13,7 @@ Implementiert in M1, weil die ``RAGController.ask``-Pipeline den Parser
 bereits aufrufen soll (M3 wird das ganze noch verfeinern: Ranking,
 Footer-Rekonstruktion, Whitelist-Heuristiken).
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import re

--- a/src/rag/prompts.py
+++ b/src/rag/prompts.py
@@ -8,7 +8,7 @@ bereit:
 * :func:`build_context_block` erzeugt den ``=== DOKUMENTE ===``-Block.
 * :func:`build_user_prompt` baut die User-Message inkl. History.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 # System-Prompt - VERBATIM aus docs/ARCHITECTURE.md Section 4.

--- a/src/rag/rag_controller.py
+++ b/src/rag/rag_controller.py
@@ -9,7 +9,7 @@ Der Controller haelt zusaetzlich eine ``ChatSession`` (Konversationshistorie)
 und einen simplen LRU-Cache fuer Frage/Antwort-Paaren, damit
 wiederholt gestellte Fragen nicht erneut das LLM rufen.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 from __future__ import annotations

--- a/src/rag/retrieval.py
+++ b/src/rag/retrieval.py
@@ -9,7 +9,7 @@ und produziert ``RetrievedDoc``-Objekte mit trunc-Snippets
 Kein LLM noetig - alles in stdlib (re, str) plus der bestehende
 ``Database.search_documents``-Methode.
 
-MIT License - Copyright (c) 2026
+GPL-3.0-or-later - Copyright (c) 2026
 """
 
 import re

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -566,8 +566,10 @@ class Database:
         """
         Fügt ein Dokument zum Volltext-Suchindex hinzu.
 
-        Wird beim Verschieben/Sortieren aufgerufen, damit das Dokument
-        später per Suche gefunden werden kann.
+        Aufgerufen beim manuellen Indexieren eines Ordners ("Ordner zum
+        Suchindex hinzufuegen"); beim Verschieben/Umbenennen pflegt
+        ``update_pdf_path`` den Index. Der Text wird auf
+        ``MAX_EXTRACTED_TEXT_LENGTH`` (5000 Zeichen) gekappt.
 
         Phase 2 (Issue #25): Vor dem INSERT in ``document_search`` wird
         ueber ``get_or_create_pdf_id`` sichergestellt, dass ein

--- a/tests/test_analysis_wait_108_gui.py
+++ b/tests/test_analysis_wait_108_gui.py
@@ -1,0 +1,167 @@
+"""Issue #108, Teil 2: Erst-Klick auf eine noch nicht analysierte PDF.
+
+- Analyse-Worker analysiert dieselbe PDF nicht mehrfach (Pre-Cache + Klick).
+- Waehrend der Erst-Analyse: Wartezeiger, Kachel "Analysiere…", Statusmeldung.
+- Der Wartezustand endet mit dem Ergebnis, auch wenn der Nutzer inzwischen
+  eine andere PDF gewaehlt hat; ein neuer Klick oder Abwaehlen beendet ihn.
+- Der asynchrone Pfad loggt eine eigene "Klick nach Analyse"-Zeile.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from PyQt6.QtWidgets import QApplication
+
+from src.core.pdf_cache import PDFAnalysisResult, PDFAnalysisWorker
+
+from tests.test_main_window_gui import fresh_singletons, main_window  # noqa: F401
+
+
+# --- Worker-Dedupe (ohne Thread-Start) --------------------------------------
+
+def test_worker_dedupes_same_pdf(tmp_path):
+    w = PDFAnalysisWorker()
+    pdf = tmp_path / "a.pdf"
+    w.add_background(pdf)
+    w.add_background(pdf)          # exakte Kopie: verworfen
+    assert w._queue.qsize() == 1
+    w.add_task(pdf, priority=5)    # dringender: ueberholt, alte Kopie wird stale
+    assert w._queue.qsize() == 2
+    assert w.queued_count() == 1
+    assert w._dequeue(timeout=0.01) == pdf
+    assert w._dequeue(timeout=0.01) is None   # stale Kopie uebersprungen
+    assert w.queued_count() == 0
+
+
+def test_worker_urgent_overtakes_background_and_skips_stale_copy(tmp_path):
+    w = PDFAnalysisWorker()
+    a, b = tmp_path / "a.pdf", tmp_path / "b.pdf"
+    w.add_background(a)
+    w.add_background(b)
+    w.add_urgent(b)          # Nutzer hat b geklickt: ueberholt a
+    assert w.queued_count() == 2
+    assert w._dequeue(timeout=0.01) == b
+    assert w._dequeue(timeout=0.01) == a
+    assert w._dequeue(timeout=0.01) is None   # die veraltete Hintergrund-Kopie von b
+    assert w.queued_count() == 0
+
+
+def test_worker_dequeue_after_analysis_allows_reanalysis(tmp_path):
+    w = PDFAnalysisWorker()
+    pdf = tmp_path / "a.pdf"
+    w.add_urgent(pdf)
+    assert w._dequeue(timeout=0.01) == pdf
+    w.add_urgent(pdf)        # z.B. Datei geaendert -> darf wieder rein
+    assert w._dequeue(timeout=0.01) == pdf
+
+
+# --- GUI: Wartezustand -------------------------------------------------------
+
+def _fake_pdf(folder: Path, name: str) -> Path:
+    folder.mkdir(parents=True, exist_ok=True)
+    p = folder / name
+    p.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    return p
+
+
+@pytest.fixture
+def window_with_pending_analysis(main_window, fresh_singletons, monkeypatch):  # noqa: F811
+    """Zwei PDFs im Scan-Ordner; request_analysis liefert nichts sofort, sondern
+    merkt sich den Callback (wie der Worker bei einer Scan-PDF)."""
+    from src.gui import pdf_thumbnail as th
+    monkeypatch.setattr(th.ThumbnailLoaderThread, "start", lambda self: None)
+
+    scan = fresh_singletons["tmp_path"] / "Scan"
+    a = _fake_pdf(scan, "a.pdf")
+    b = _fake_pdf(scan, "b.pdf")
+    main_window._navigate_to_folder(scan)
+    assert {w.pdf_path for w in main_window.pdf_widgets} == {a, b}
+
+    pending = {}
+    monkeypatch.setattr(
+        main_window.pdf_cache, "request_analysis",
+        lambda pdf_path, callback=None, urgent=False: pending.__setitem__(pdf_path, callback),
+    )
+    monkeypatch.setattr(main_window.pdf_cache, "get", lambda pdf_path: None)
+    monkeypatch.setattr(main_window.classifier, "is_model_ready", lambda: True)
+    yield main_window, a, b, pending
+    main_window._end_analysis_wait()
+    while QApplication.overrideCursor() is not None:
+        QApplication.restoreOverrideCursor()
+
+
+def test_first_click_shows_wait_state(window_with_pending_analysis):
+    win, a, b, pending = window_with_pending_analysis
+    win.on_pdf_clicked(a)
+
+    assert win._analysis_wait_pdf == a
+    assert QApplication.overrideCursor() is not None
+    assert win._pdf_widget_for(a).analyzing
+    assert win._pdf_widget_for(a).name_label.text() == "Analysiere…"
+    assert "Texterkennung" in win.statusbar.currentMessage()
+    assert a in pending
+
+
+def test_result_ends_wait_state_and_logs_async_click(window_with_pending_analysis, caplog, monkeypatch):
+    win, a, b, pending = window_with_pending_analysis
+    win.on_pdf_clicked(a)
+    monkeypatch.setattr(win, "display_suggestions", lambda s: None)
+
+    with caplog.at_level(logging.DEBUG, logger="pdf_sortier_meister.timing"):
+        pending[a](PDFAnalysisResult(pdf_path=a, extracted_text="Rechnung", keywords=["rechnung"]))
+
+    assert win._analysis_wait_pdf is None
+    assert QApplication.overrideCursor() is None
+    assert not win._pdf_widget_for(a).analyzing
+    assert win._pdf_widget_for(a).name_label.text() == "a"
+    assert any(r.message.startswith("Klick nach Analyse") for r in caplog.records)
+
+
+def test_result_for_deselected_pdf_still_resets_wait_state(window_with_pending_analysis):
+    """Reset VOR dem selected_pdf-Guard: Ergebnis kommt, Nutzer hat aber
+    inzwischen abgewaehlt -> Wartezeiger darf nicht haengen bleiben."""
+    win, a, b, pending = window_with_pending_analysis
+    win.on_pdf_clicked(a)
+    win.selected_pdf = None          # ohne _clear_selection, bewusst "roh"
+
+    pending[a](PDFAnalysisResult(pdf_path=a))
+
+    assert win._analysis_wait_pdf is None
+    assert QApplication.overrideCursor() is None
+    assert not win._pdf_widget_for(a).analyzing
+
+
+def test_new_click_moves_wait_state_to_new_pdf(window_with_pending_analysis):
+    win, a, b, pending = window_with_pending_analysis
+    win.on_pdf_clicked(a)
+    win.on_pdf_clicked(b)
+
+    assert win._analysis_wait_pdf == b
+    assert not win._pdf_widget_for(a).analyzing
+    assert win._pdf_widget_for(b).analyzing
+    # genau EIN Override-Cursor, nicht gestapelt
+    QApplication.restoreOverrideCursor()
+    assert QApplication.overrideCursor() is None
+    win._analysis_wait_pdf = None
+
+
+def test_clear_selection_ends_wait_state(window_with_pending_analysis):
+    win, a, b, pending = window_with_pending_analysis
+    win.on_pdf_clicked(a)
+    win._clear_selection()
+
+    assert win._analysis_wait_pdf is None
+    assert QApplication.overrideCursor() is None
+    assert not win._pdf_widget_for(a).analyzing
+
+
+def test_stale_result_for_other_pdf_does_not_end_wait(window_with_pending_analysis):
+    win, a, b, pending = window_with_pending_analysis
+    win.on_pdf_clicked(a)
+    win.on_pdf_clicked(b)
+    pending[a](PDFAnalysisResult(pdf_path=a))   # verspaetetes Ergebnis fuer a
+
+    assert win._analysis_wait_pdf == b
+    assert QApplication.overrideCursor() is not None

--- a/tests/test_detail_panel_category_follow_113_gui.py
+++ b/tests/test_detail_panel_category_follow_113_gui.py
@@ -1,0 +1,96 @@
+"""Issue #113: Eine Metadaten-Eingabe zieht den Dateinamen-Vorschlag sofort nach.
+
+Solange der Name aus der Liste stammt (oberste Zeile, Klick, KI-Ergebnis),
+folgt er der Eingabe in Kategorie/Korrespondent. Ein getippter Name bleibt.
+"""
+from PyQt6.QtTest import QTest
+
+from src.gui.rename_dialog import RenameSuggestion
+
+from tests.test_llm_metadata_extraction import provider  # noqa: F401 - Fixture
+
+from tests.test_detail_panel_pattern_suggestions_gui import (  # noqa: F401
+    RECHNUNGEN, _ki_suggestion, _panel, _reasons, _rows, _select,
+)
+
+
+def _ki_sonstiges():
+    return RenameSuggestion(
+        name="2024-01-31_Sonstiges_Noten.pdf", reason="KI-Vorschlag", confidence=0.9,
+        metadata={"subject": "Sonstiges", "korrespondent": "Musikverlag"},
+    )
+
+
+def test_category_edit_updates_ki_row_and_name(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
+    _select(panel, tmp_path, [_ki_sonstiges()])
+    assert panel.name_input.text() == "2024-01-31_Sonstiges_Noten"
+    assert panel._name_from_list
+
+    cat = panel._metadata_inputs["subject"]
+    cat.setText("")
+    QTest.keyClicks(cat, "Klaviernoten")
+
+    assert _rows(panel)[0].startswith("2024-01-31_Klaviernoten_Noten.pdf")
+    assert panel.name_input.text() == "2024-01-31_Klaviernoten_Noten"
+    assert not panel.has_user_edits() or panel._metadata_source == "user"
+    assert panel._auto_name == "2024-01-31_Klaviernoten_Noten"
+
+
+def test_pattern_row_follows_korrespondent_edit(qtbot, monkeypatch, tmp_path):
+    panel, cfg = _panel(qtbot, monkeypatch, tmp_path, filename_pattern=RECHNUNGEN)
+    _select(panel, tmp_path, [])            # nur Muster-Zeilen
+    assert _reasons(panel)[0].startswith("Muster")
+    assert panel.name_input.text() == "2024-01-31_Rechnung"
+
+    korr = panel._metadata_inputs["korrespondent"]
+    QTest.keyClicks(korr, "Beispiel AG")
+
+    assert panel.name_input.text() == "2024-01-31_Rechnung_Beispiel-AG"
+
+
+def test_typed_name_is_not_overwritten(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
+    _select(panel, tmp_path, [_ki_sonstiges()])
+
+    panel.name_input.clear()
+    QTest.keyClicks(panel.name_input, "Mein eigener Name")
+    assert not panel._name_from_list
+
+    QTest.keyClicks(panel._metadata_inputs["subject"], "X")
+
+    assert panel.name_input.text() == "Mein eigener Name"
+    # Liste rendert trotzdem neu
+    assert "SonstigesX" in _rows(panel)[0] or "X" in _rows(panel)[0]
+
+
+def test_clicked_row_stays_coupled_to_its_kind(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path, filename_pattern=RECHNUNGEN)
+    _select(panel, tmp_path, [_ki_suggestion()])
+    reasons = _reasons(panel)
+    idx = reasons.index("Muster: Rechnungen & Belege")
+    panel._on_suggestion_clicked(panel.suggestions_list.item(idx))
+    assert panel.name_input.text().startswith("2024-01-31_Rechnung_Testfirma-GmbH")
+    assert panel._name_from_list
+
+    korr = panel._metadata_inputs["korrespondent"]
+    korr.setText("")
+    QTest.keyClicks(korr, "Neue Firma")
+
+    # Folgt der MUSTER-Zeile, nicht der KI-Zeile
+    assert panel.name_input.text().startswith("2024-01-31_Rechnung_Neue-Firma")
+
+
+def test_clear_resets_coupling(qtbot, monkeypatch, tmp_path):
+    panel, _ = _panel(qtbot, monkeypatch, tmp_path)
+    _select(panel, tmp_path, [_ki_sonstiges()])
+    panel.clear()
+    assert not panel._name_from_list and panel._name_kind is None
+    # Kein Absturz bei Feld-Aenderung ohne PDF
+    panel._on_metadata_user_edit("x")
+    assert panel.name_input.text() == ""
+
+
+def test_prompt_contains_rule_against_meaningless_names(provider):  # noqa: F811
+    prompt = provider._build_filename_prompt(text="text", current_filename="scan.pdf")
+    assert "Sonstiges" in prompt and "nie im Dateinamen" in prompt

--- a/tests/test_first_start_wizard.py
+++ b/tests/test_first_start_wizard.py
@@ -56,3 +56,21 @@ def test_apply_wizard_result_calls_settings_changed_after_initial_load(qtbot, fr
     _apply_wizard_result(window, fresh_config)
 
     assert calls == ["initial_load", "settings_changed"]
+
+
+def test_schedule_startup_hints_shows_first_steps_before_backup(qtbot):
+    """Erststart-Reihenfolge: Erste Schritte vor dem Backup-Hinweis, und beide
+    erst nach der Verzoegerung (also nach dem Einrichtungsassistenten, der
+    vorher synchron per exec() lief)."""
+    from src.main import _schedule_startup_hints
+
+    calls = []
+    window = MagicMock()
+    window.show_first_steps_hint.side_effect = lambda: calls.append("first_steps")
+    window.show_backup_hint.side_effect = lambda: calls.append("backup")
+
+    _schedule_startup_hints(window, delay_ms=0)
+    assert calls == []  # nichts synchron
+
+    qtbot.waitUntil(lambda: len(calls) == 2, timeout=2000)
+    assert calls == ["first_steps", "backup"]

--- a/tests/test_llm_name_adapt.py
+++ b/tests/test_llm_name_adapt.py
@@ -1,0 +1,37 @@
+"""Issue #113: KI-Dateinamen an geaenderte Metadaten anpassen (ohne Qt)."""
+from src.core.llm_name_adapt import adapt_llm_filename, replace_token
+
+
+def test_replace_whole_token_only():
+    assert replace_token("2026-03-15_Rechnung_Muster.pdf", "Rechnung", "Mahnung") == "2026-03-15_Mahnung_Muster.pdf"
+    assert replace_token("2026-03-15_Rechnungen_Muster.pdf", "Rechnung", "Mahnung") == "2026-03-15_Rechnungen_Muster.pdf"
+
+
+def test_replace_is_case_insensitive_and_handles_multiword_values():
+    assert replace_token("Sonstiges_Muster-GmbH.pdf", "muster gmbh", "Beispiel AG") == "Sonstiges_Beispiel_AG.pdf"
+    assert replace_token("JK 2026-03-15-Muster GmbH.pdf", "Muster GmbH", "Beispiel AG") == "JK 2026-03-15-Beispiel AG.pdf"
+
+
+def test_adapt_replaces_old_category_and_fallback_tokens():
+    assert adapt_llm_filename(
+        "2026-03-15_Sonstiges_Noten.pdf", {"subject": "Sonstiges"}, {"subject": "Klaviernoten"}
+    ) == "2026-03-15_Klaviernoten_Noten.pdf"
+    # KI lieferte keine Kategorie (normalize_llm_metadata verwirft "Unbekannt")
+    assert adapt_llm_filename(
+        "2026-03-15_Unbekannt_Bach.pdf", {}, {"subject": "Klaviernoten"}
+    ) == "2026-03-15_Klaviernoten_Bach.pdf"
+
+
+def test_adapt_replaces_korrespondent_and_leaves_rest():
+    assert adapt_llm_filename(
+        "2026-03-15_Rechnung_Testfirma-GmbH.pdf",
+        {"subject": "Rechnung", "korrespondent": "Testfirma GmbH"},
+        {"subject": "Rechnung", "korrespondent": "Beispiel AG"},
+    ) == "2026-03-15_Rechnung_Beispiel_AG.pdf"
+
+
+def test_adapt_without_changes_or_fields_is_identity():
+    name = "2026-03-15_Rechnung_Testfirma.pdf"
+    assert adapt_llm_filename(name, {"subject": "Rechnung"}, {"subject": "Rechnung"}) == name
+    assert adapt_llm_filename(name, {"subject": "Rechnung"}, {}) == name
+    assert adapt_llm_filename("", {}, {"subject": "X"}) == ""

--- a/tests/test_mwst_no_default.py
+++ b/tests/test_mwst_no_default.py
@@ -1,0 +1,57 @@
+"""MwSt-Satz darf kein geratener Standardwert sein.
+
+Im Prompt-Schema stand ``"mwst": 7`` als Beispiel; kleine Modelle kopierten
+das in jede Antwort. Jetzt: Beispiel ohne feste Zahl, Prompt-Regel, und ein
+Satz, der im Dokumenttext nicht vorkommt, wird verworfen.
+"""
+import pytest
+
+from src.ml.llm_provider import drop_unsupported_mwst
+
+from tests.test_llm_metadata_extraction import provider  # noqa: F401 - Fixture
+
+
+@pytest.mark.parametrize("text", [
+    "Rechnung Nr. 12 ... zzgl. 19 % MwSt ... Gesamt 119,00 EUR",
+    "Umsatzsteuer 19%",
+    "Betrag 100,00 zzgl. USt (19,00 %)",
+    "enthaltene Mehrwertsteuer: 7 %",           # Steuer-Wort reicht
+])
+def test_rate_kept_when_document_mentions_tax(text):
+    assert drop_unsupported_mwst({"mwst_satz": 19}, text) == {"mwst_satz": 19}
+
+
+@pytest.mark.parametrize("text", [
+    "Klaviernoten Praeludium C-Dur, Seite 1 von 4",
+    "Befundbericht: Patient klagt ueber Kopfschmerzen. Termin in 7 Tagen.",
+    "Mietvertrag ueber die Wohnung, Miete 700 EUR monatlich",
+])
+def test_rate_dropped_when_document_has_no_tax(text):
+    for rate in (7, "7", "7 %", 19, "19%"):
+        out = drop_unsupported_mwst({"mwst_satz": rate, "subject": "Sonstiges"}, text)
+        assert "mwst_satz" not in out, (rate, text)
+        assert out["subject"] == "Sonstiges"
+
+
+def test_no_text_or_no_rate_is_untouched():
+    assert drop_unsupported_mwst({"mwst_satz": 7}, None) == {"mwst_satz": 7}
+    assert drop_unsupported_mwst({"subject": "Arzt"}, "kein steuertext") == {"subject": "Arzt"}
+    assert drop_unsupported_mwst("kein dict", "x") == "kein dict"
+
+
+def test_parse_json_response_applies_document_check(provider):  # noqa: F811
+    raw = '{"filename": "a.pdf", "metadata": {"category": "Arzt", "mwst": 7, "steuerjahr": 2025}}'
+    data, err = provider._parse_json_response(raw, document_text="Befund ohne Steuer")
+    assert err is None
+    assert data["metadata"] == {"subject": "Arzt", "steuerjahr": 2025}
+    data, _ = provider._parse_json_response(raw)   # ohne Text: unveraendert
+    assert data["metadata"]["mwst_satz"] == 7
+
+
+def test_prompts_have_no_example_rate(provider):  # noqa: F811
+    p1 = provider._build_filename_prompt(text="t", current_filename="s.pdf")
+    p2 = provider._build_classification_prompt("t", ["A", "B"])
+    for p in (p1, p2):
+        assert '"mwst": 7' not in p and '"steuerjahr": 2024' not in p
+        assert "UNBEKANNT" in p
+    assert "Niemals einen Standardwert" in p1

--- a/tests/test_nebenbefunde_verschieben_gui.py
+++ b/tests/test_nebenbefunde_verschieben_gui.py
@@ -1,0 +1,135 @@
+"""Nebenbefunde aus der Planungsrunde 09/2026 (Fahrplan v0.24).
+
+Vier kleine Fehler rund ums Verschieben, jeder mit eigenem Test:
+
+1. ``on_pdf_move`` benutzte ein undefiniertes ``folder_path`` und zeigte nach
+   erfolgreichem "Verschieben nach..." einen Fehlerdialog (NameError).
+2. Drop auf eine gruene Vorschlagskachel war ein stilles No-op, weil
+   ``pdf_dropped`` in ``display_suggestions`` nie verbunden wurde.
+3. "Aus Zielliste entfernen" auf Vorschlagskacheln war toter Code.
+4. Root-Ordner entfernen scannte den Zielbaum zweimal.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PyQt6 import sip
+
+from src.gui.folder_tree_widget import FolderTreeWidget
+from src.gui.folder_widget import FolderWidget
+from src.ml.classifier import Suggestion
+
+from tests.test_main_window_gui import fresh_singletons, main_window  # noqa: F401
+
+
+def _pdf(folder: Path, name: str = "scan.pdf") -> Path:
+    folder.mkdir(parents=True, exist_ok=True)
+    p = folder / name
+    p.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    return p
+
+
+# 1) "Verschieben nach..." ---------------------------------------------------
+
+
+def test_on_pdf_move_moves_without_error_dialog(main_window, fresh_singletons, monkeypatch):  # noqa: F811
+    from src.gui import main_window as mw_mod
+
+    tmp = fresh_singletons["tmp_path"]
+    pdf = _pdf(tmp / "Scan")
+    target = tmp / "Ziel" / "Ablage"
+    target.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        mw_mod.QFileDialog, "getExistingDirectory", staticmethod(lambda *a, **k: str(target))
+    )
+
+    def boom(*args, **kwargs):  # pragma: no cover - nur bei Regression
+        raise AssertionError(f"Fehlerdialog nach erfolgreichem Verschieben: {args[2:]}")
+
+    monkeypatch.setattr(mw_mod.QMessageBox, "critical", staticmethod(boom))
+
+    main_window.on_pdf_move(pdf)
+
+    assert not pdf.exists()
+    assert (target / "scan.pdf").exists()
+
+
+# 2) Drop auf Vorschlagskachel ----------------------------------------------
+
+
+def test_drop_on_suggestion_tile_is_wired(main_window, fresh_singletons, monkeypatch):  # noqa: F811
+    tmp = fresh_singletons["tmp_path"]
+    target = tmp / "Ziel" / "Rechnungen"
+    target.mkdir(parents=True)
+    pdf = _pdf(tmp / "Scan")
+
+    received = []
+    monkeypatch.setattr(
+        main_window, "on_pdf_dropped_on_folder", lambda p, f: received.append((p, f))
+    )
+
+    main_window.display_suggestions(
+        [Suggestion(folder_path=target, folder_name="Rechnungen", confidence=0.8, reason="Test")]
+    )
+    tile = main_window.suggestion_widgets[0]
+    assert tile.is_suggestion
+
+    tile.pdf_dropped.emit(pdf, target)
+
+    assert received == [(pdf, target)]
+
+
+# 3) Kontextmenue auf Kacheln ----------------------------------------------
+
+
+def test_suggestion_tile_has_no_remove_entry(qtbot, tmp_path):
+    w = FolderWidget(tmp_path, 0)
+    qtbot.addWidget(w)
+    w.is_suggestion = True
+
+    texts = [a.text() for a in w._build_context_menu().actions() if not a.isSeparator()]
+
+    assert texts and "Aus Zielliste entfernen" not in texts
+
+
+def test_target_tile_keeps_remove_entry(qtbot, tmp_path):
+    w = FolderWidget(tmp_path, 0)
+    qtbot.addWidget(w)
+
+    texts = [a.text() for a in w._build_context_menu().actions() if not a.isSeparator()]
+
+    assert "Aus Zielliste entfernen" in texts
+
+
+# 4) Root entfernen: ein Scan statt zwei ------------------------------------
+
+
+def test_remove_root_scans_tree_once(main_window, fresh_singletons, monkeypatch):  # noqa: F811
+    tmp = fresh_singletons["tmp_path"]
+    root_a = tmp / "Ziel A"
+    root_b = tmp / "Ziel B"
+    root_a.mkdir()
+    root_b.mkdir()
+    cfg = fresh_singletons["config"]
+    cfg.add_target_folder(root_a)
+    cfg.add_target_folder(root_b)
+    main_window.folder_manager.add_folder(root_a)
+    main_window.folder_manager.add_folder(root_b)
+
+    tree: FolderTreeWidget = main_window.folder_tree
+    tree.async_scan = False
+    main_window.load_folders()
+    assert tree.has_folder(root_a) and tree.has_folder(root_b)
+
+    scans = []
+    original = tree.refresh_tree
+    monkeypatch.setattr(tree, "refresh_tree", lambda: (scans.append(1), original())[1])
+
+    # Wie ueber das Kontextmenue "Aus Zielliste entfernen"
+    tree._remove_folder(root_a)
+
+    assert len(scans) == 1
+    assert not tree.has_folder(root_a) and tree.has_folder(root_b)
+    assert root_a not in main_window.folder_manager.target_folders

--- a/tests/test_rename_suggestions_cache_108.py
+++ b/tests/test_rename_suggestions_cache_108.py
@@ -1,0 +1,97 @@
+"""Issue #108: Dateinamen-Vorschlaege duerfen die PDF nicht erneut oeffnen,
+wenn Text, Stichwoerter und Datumsangaben schon aus dem Cache vorliegen.
+
+Vorher rief generate_rename_suggestions() trotz uebergebener Cache-Werte
+PDFAnalyzer.suggest_filename() auf, das alles neu extrahierte - bei
+Scan-PDFs inklusive Tesseract-OCR ueber 5 Seiten im GUI-Thread (7 s Freeze
+pro Klick im Log des Users vom 30.08.2026).
+"""
+from datetime import datetime
+from pathlib import Path
+
+import fitz
+import pytest
+
+from src.core.pdf_analyzer import PDFAnalyzer, coerce_date, coerce_dates
+from src.gui.rename_dialog import generate_rename_suggestions
+
+
+def _pdf(path: Path, text: str) -> Path:
+    d = fitz.open(); p = d.new_page(); p.insert_text((72, 72), text); d.save(str(path)); d.close()
+    return path
+
+
+# --- coerce_date ----------------------------------------------------------
+
+@pytest.mark.parametrize("value", [
+    "2026-05-12 00:00:00",          # so speichert der PDF-Cache (str(datetime))
+    "2026-05-12",
+    "12.05.2026",
+    datetime(2026, 5, 12),
+])
+def test_coerce_date_accepts_cache_formats(value):
+    assert coerce_date(value) == datetime(2026, 5, 12)
+
+
+def test_coerce_dates_drops_garbage():
+    assert coerce_dates(["2026-05-12 00:00:00", "kein datum", None]) == [datetime(2026, 5, 12)]
+    assert coerce_dates(None) == []
+
+
+# --- suggest_filename mit Cache-Werten --------------------------------------
+
+def test_suggest_filename_with_cache_values_does_not_open_pdf(tmp_path):
+    """Die Datei existiert nicht - jedes Oeffnen wuerde fliegen."""
+    analyzer = PDFAnalyzer(tmp_path / "gibt_es_nicht.pdf")
+    name = analyzer.suggest_filename(
+        text="Rechnung der Muster GmbH vom 15.03.2026",
+        keywords=["rechnung"],
+        dates=["2026-03-15 00:00:00"],
+    )
+    assert name == "Rechnung Muster 2026-03.pdf"
+
+
+def test_suggest_filename_without_args_still_extracts(tmp_path):
+    pdf = _pdf(tmp_path / "scan.pdf", "Rechnung Nr. 42 vom 15.03.2026, zahlbar sofort.")
+    with PDFAnalyzer(pdf) as a:
+        assert a.suggest_filename().startswith("Rechnung")
+
+
+# --- generate_rename_suggestions --------------------------------------------
+
+def test_generate_suggestions_from_cache_never_opens_pdf(tmp_path, monkeypatch):
+    opened = []
+    real_open = PDFAnalyzer.open
+    monkeypatch.setattr(PDFAnalyzer, "open", lambda self: opened.append(self.pdf_path) or real_open(self))
+
+    suggestions = generate_rename_suggestions(
+        pdf_path=tmp_path / "gibt_es_nicht.pdf",
+        extracted_text="Rechnung der Muster GmbH vom 15.03.2026",
+        keywords=["rechnung"],
+        dates=["2026-03-15 00:00:00"],
+    )
+
+    assert opened == []
+    reasons = {s.reason: s.name for s in suggestions}
+    assert reasons["Automatisch erkannt"] == "Rechnung Muster 2026-03.pdf"
+    assert reasons["Nur Datum"] == "2026-03-15.pdf"          # vorher "2026-03-15 00:00:00.pdf"
+    assert reasons["Datum + Kategorie (Rechnung)"] == "2026-03-15 Rechnung.pdf"
+
+
+def test_generate_suggestions_empty_cache_text_means_no_ocr_retry(tmp_path, monkeypatch):
+    """Leerer Text im Cache (OCR fand nichts) ist ein Ergebnis, kein Fehlen:
+    die PDF darf trotzdem nicht erneut geoeffnet werden."""
+    opened = []
+    monkeypatch.setattr(PDFAnalyzer, "open", lambda self: opened.append(1))
+
+    generate_rename_suggestions(
+        pdf_path=tmp_path / "scan.pdf", extracted_text="", keywords=[], dates=[]
+    )
+
+    assert opened == []
+
+
+def test_generate_suggestions_opens_pdf_only_when_something_is_missing(tmp_path):
+    pdf = _pdf(tmp_path / "scan.pdf", "Rechnung Nr. 42 vom 15.03.2026, zahlbar sofort.")
+    suggestions = generate_rename_suggestions(pdf_path=pdf, extracted_text=None)
+    assert any(s.reason == "Automatisch erkannt" for s in suggestions)


### PR DESCRIPTION
## Was

Sammel-Branch für Sprint D, vom User live getestet (EXE-Build vom 05.09., 902 Tests grün). Enthält die sechs Einzel-PRs plus den MwSt-Fix:

- #119 Nebenbefunde rund ums Verschieben
- #120 Lizenz-Konsistenz (GPL), LICENSE im Paket, Erststart-Hinweise nach dem Assistenten
- #121 #108 Teil A: Klick ohne Nach-OCR (2524 ms → 4.9 ms)
- #122 #108 Teil B: Wartezeiger, Worker-Dedupe, Analyse-Log
- #123 #113 Kategorie-Eingabe zieht den Dateinamen sofort nach
- #127 #112 Vergleich paperless-ngx neu, Doku-Drift, Folge-Issues #124–#126
- MwSt-Satz nicht mehr als Standardwert raten (`"mwst": 7` stand als Beispiel im Prompt; neue Regel + `drop_unsupported_mwst()`)

CHANGELOG-Unreleased ist zusammengeführt und nach Neu/Geaendert/Behoben sortiert.

Closes #108, closes #112, closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
