### PR TITLE
fix(ollama): HTTP-Fehler nennen den Grund aus der Ollama-Antwort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   die KI konkret benennen, worum es geht.
 
 ### Geaendert
+- **Ollama-Fehler nennen den Grund:** Antwortet Ollama mit einem
+  HTTP-Fehler, steht im Log und in Fehlermeldungen jetzt der Text aus der
+  Antwort, z. B. `Ollama HTTP 500: llama runner process has terminated:
+  exit status 0xc0000409` (Modell beim Laden abgestuerzt) statt nur
+  `Ollama HTTP 500`. Gilt fuer KI-Anfragen und den Modell-Download im
+  Assistenten.
 - **Erst-Klick auf eine noch nicht analysierte PDF** (#108, Teil 2): Waehrend
   die Texterkennung laeuft, zeigt die Kachel „Analysiere…“, der Mauszeiger
   wird zum Wartezeiger und die Statusleiste erklaert, dass OCR einige

--- a/src/ml/ollama_launcher.py
+++ b/src/ml/ollama_launcher.py
@@ -110,11 +110,38 @@ def pull_model(
         with urllib.request.urlopen(req, timeout=60) as resp:
             return _consume_pull_stream(resp, progress_cb, should_cancel)
     except urllib.error.HTTPError as e:
-        return False, f"Ollama HTTP {e.code}"
+        return False, http_error_text(e)
     except urllib.error.URLError as e:
         return False, f"Keine Verbindung zu Ollama ({base_url}): {e.reason}"
     except Exception as e:
         return False, f"Download-Fehler: {e}"
+
+
+def http_error_text(error: urllib.error.HTTPError, limit: int = 300) -> str:
+    """Lesbarer Fehlertext fuer eine HTTP-Fehlerantwort von Ollama.
+
+    Ollama antwortet bei 4xx/5xx mit ``{"error": "..."}``, und dieser Text
+    nennt den eigentlichen Grund - etwa ``llama runner process has
+    terminated: exit status 0xc0000409``, wenn das Modell beim Laden
+    abstuerzt. Nur ``Ollama HTTP 500`` zu loggen zwang bisher zum Blick in
+    den Ollama-Server-Log. Ohne JSON wird der rohe Body genommen; leer bleibt
+    es beim Statuscode.
+    """
+    try:
+        raw = error.read().decode("utf-8", errors="replace").strip()
+    except Exception:
+        raw = ""
+    if raw:
+        try:
+            data = json.loads(raw)
+            if isinstance(data, dict) and data.get("error"):
+                raw = str(data["error"]).strip()
+        except ValueError:
+            pass
+        raw = " ".join(raw.split())
+        if len(raw) > limit:
+            raw = raw[:limit] + "…"
+    return f"Ollama HTTP {error.code}: {raw}" if raw else f"Ollama HTTP {error.code}"
 
 
 def _consume_pull_stream(stream, progress_cb, should_cancel) -> tuple[bool, str]:

--- a/src/ml/ollama_provider.py
+++ b/src/ml/ollama_provider.py
@@ -27,6 +27,7 @@ import urllib.request
 from typing import Optional, Any
 
 from src.ml.llm_provider import LLMProvider, LLMConfig, LLMResponse
+from src.ml.ollama_launcher import http_error_text
 
 
 class OllamaProvider(LLMProvider):
@@ -235,7 +236,7 @@ class OllamaProvider(LLMProvider):
             with urllib.request.urlopen(req, timeout=self.REQUEST_TIMEOUT) as resp:
                 return json.loads(resp.read().decode("utf-8")), None
         except urllib.error.HTTPError as e:
-            return None, f"Ollama HTTP {e.code}"
+            return None, http_error_text(e)
         except urllib.error.URLError as e:
             return None, f"Keine Verbindung zu Ollama ({self._get_base_url()}). Details: {e.reason}"
         except Exception as e:

--- a/tests/test_ollama_pull_and_cloud.py
+++ b/tests/test_ollama_pull_and_cloud.py
@@ -89,3 +89,57 @@ def test_cloud_chat_does_not_autostart_local_server(monkeypatch):
     import src.ml.ollama_launcher as launcher
     monkeypatch.setattr(launcher, "ensure_running", lambda *a, **k: (_ for _ in ()).throw(AssertionError("darf nicht")))
     assert p._chat("s", "u") == (None, "Keine Verbindung zu Ollama (x)")
+
+
+# --------------------------------------------------------------------- #
+# HTTP-Fehler: Grund aus der Ollama-Antwort mitnehmen
+# --------------------------------------------------------------------- #
+
+
+def _http_error(code: int, body: bytes):
+    import io
+    import urllib.error
+    return urllib.error.HTTPError("http://localhost:11434/api/chat", code, "Error", {}, io.BytesIO(body))
+
+
+def test_http_error_text_uses_ollama_error_field():
+    from src.ml.ollama_launcher import http_error_text
+    body = json.dumps({"error": "llama runner process has terminated: exit status 0xc0000409"}).encode()
+    assert http_error_text(_http_error(500, body)) == (
+        "Ollama HTTP 500: llama runner process has terminated: exit status 0xc0000409"
+    )
+
+
+def test_http_error_text_falls_back_to_raw_body_or_code_only():
+    from src.ml.ollama_launcher import http_error_text
+    assert http_error_text(_http_error(502, b"<html>\n  Bad Gateway\n</html>")) == (
+        "Ollama HTTP 502: <html> Bad Gateway </html>"
+    )
+    assert http_error_text(_http_error(500, b"")) == "Ollama HTTP 500"
+    assert http_error_text(_http_error(500, b"x" * 400), limit=20) == "Ollama HTTP 500: " + "x" * 20 + "…"
+
+
+def test_post_chat_reports_ollama_reason(monkeypatch):
+    import urllib.request
+
+    def boom(*a, **k):
+        raise _http_error(500, json.dumps({"error": "model requires more system memory"}).encode())
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    p = OllamaProvider(LLMConfig(api_key="", model="llama3.1"))
+    data, error = p._post_chat("http://localhost:11434/api/chat", {"model": "llama3.1"})
+    assert data is None
+    assert error == "Ollama HTTP 500: model requires more system memory"
+
+
+def test_pull_model_reports_ollama_reason(monkeypatch):
+    import urllib.request
+    from src.ml.ollama_launcher import pull_model
+
+    def boom(*a, **k):
+        raise _http_error(404, json.dumps({"error": "pull model manifest: file does not exist"}).encode())
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    ok, message = pull_model("http://localhost:11434", "gibtsnicht:latest", lambda *a: None, lambda: False)
+    assert ok is False
+    assert message == "Ollama HTTP 404: pull model manifest: file does not exist"


### PR DESCRIPTION
## Anlass

Im Log stand `LLM-Pre-Cache Fehler für 2023-02-17-0001.pdf: Ollama HTTP 500`. Den Grund verriet erst der Ollama-Server-Log: die llama-server.exe war beim Laden von `gpt-oss-64k` mit 0xc0000409 abgestürzt, der zweite Ladeversuch lief durch.

## Änderung

- Neue Hilfsfunktion `http_error_text()` in `src/ml/ollama_launcher.py`: liest das `error`-Feld aus der Ollama-Antwort (Fallback: roher Body, gekürzt auf 300 Zeichen, leer -> nur Statuscode).
- `OllamaProvider._post_chat` und `pull_model` (Modell-Download im Assistenten) nutzen sie.
- Beispiel im Log jetzt: `Ollama HTTP 500: llama runner process has terminated: exit status 0xc0000409`.
- 4 neue Tests, CHANGELOG-Eintrag unter Unreleased.

Unabhängig vom Probe-Branch `feat/117-kompakte-kacheln`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
