### PR TITLE
feat(#117): Kachelgroesse Klein/Mittel/Gross im Scan-Bereich + Hover-Vorschau

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   im Dokumenttext nicht vorkommt, wird verworfen. Das Feld bleibt dann leer.
 
 ### Neu
+- **Kleinere Kacheln im Scan-Bereich** (#117, Probelauf): Ueber der
+  PDF-Liste links steht jetzt „Ansicht: Klein / Mittel / Gross“, wie die
+  Symbolgroesse im Explorer. Standard ist „Klein“ (Kachel etwa halb so breit
+  wie bisher, Bild 56x64 statt 140x160); „Gross“ entspricht der bisherigen
+  Darstellung. Bei kleinen und mittleren Kacheln blendet der Mauszeiger auf
+  einer PDF nach kurzem Verweilen die grosse Vorschau neben der Kachel ein;
+  Ordner-Kacheln haben keine Vorschau. Die Wahl wird gespeichert
+  (`tile_view`). Das Thumbnail wird weiterhin in 140x160 gerendert und
+  gecacht, kleinere Ansichten skalieren nur herunter. Die wirkungslose
+  Einstellung „Thumbnail-Groesse“ unter Allgemein entfaellt; dort steht ein
+  Hinweis auf die neue Auswahl.
 - **Kategorie sofort im Dateinamen** (#113): Wer im Detail-Panel eine
   Kategorie, einen Korrespondenten oder ein anderes Metadaten-Feld
   eintraegt, sieht den Dateinamen-Vorschlag sofort nachziehen: Die

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 ### Neu
 - **Kleinere Kacheln im Scan-Bereich** (#117, Probelauf): Ueber der
   PDF-Liste links steht jetzt „Ansicht: Klein / Mittel / Gross“, wie die
-  Symbolgroesse im Explorer. Standard ist „Klein“ (Kachel etwa halb so breit
-  wie bisher, Bild 56x64 statt 140x160); „Gross“ entspricht der bisherigen
-  Darstellung. Bei kleinen und mittleren Kacheln blendet der Mauszeiger auf
+  Symbolgroesse im Explorer. Standard ist „Klein“: Kachel etwa halb so breit
+  wie bisher, das Bild fuellt die Kachelbreite und zeigt den Kopf der Seite
+  (unten abgeschnitten) statt einer winzigen Gesamtseite; „Mittel“ zeigt die
+  ganze Seite verkleinert, „Gross“ entspricht der bisherigen Darstellung.
+  Bei kleinen und mittleren Kacheln blendet der Mauszeiger auf
   einer PDF nach kurzem Verweilen die grosse Vorschau neben der Kachel ein;
   Ordner-Kacheln haben keine Vorschau. Die Wahl wird gespeichert
   (`tile_view`). Das Thumbnail wird weiterhin in 140x160 gerendert und

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Texterkennung (OCR, Tesseract) ist auch hier **enthalten**. Einstellungen und Le
 ## Was das Programm kann
 
 ### Sortieren wie im Explorer, nur mit Vorschlägen
-- **Scan-Ordner als Dateimanager**: Ordner-Kacheln, Breadcrumb, `Alt+↑`, Doppelklick in Unterordner
+- **Scan-Ordner als Dateimanager**: Ordner-Kacheln, Breadcrumb, `Alt+↑`, Doppelklick in Unterordner,
+  Kachelgröße Klein / Mittel / Groß wie im Explorer (kleine Kacheln zeigen beim Überfahren die große Vorschau)
 - **Zielordner-Vorschläge** aus dem PDF-Inhalt, lernend (TF-IDF, lokal, offline) — grün hervorgehoben.
   Erkennt das Jahr im Dokument, wird z. B. neben `Steuer 2025/Belege` auch `Steuer 2026/Belege` angeboten
 - **Ein Klick** auf den Zielordner verschiebt, benennt um und speichert die Metadaten in einem Rutsch;

--- a/src/gui/folder_tile.py
+++ b/src/gui/folder_tile.py
@@ -12,12 +12,18 @@ from pathlib import Path
 from typing import Optional
 
 from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QCursor, QDragEnterEvent, QDropEvent
+from PyQt6.QtGui import QCursor, QDragEnterEvent, QDropEvent, QFontMetrics
 from PyQt6.QtWidgets import QFrame, QLabel, QVBoxLayout
+
+from src.gui.tile_view import TileView, fit_text_lines, tile_view
 
 
 class FolderTileWidget(QFrame):
-    """Kachel für einen Ordner im Scan-Bereich."""
+    """Kachel für einen Ordner im Scan-Bereich.
+
+    Hat dieselben Masse wie die PDF-Kachel der jeweiligen Ansicht (Issue #117),
+    damit das Raster buendig bleibt - aber keine Hover-Vorschau.
+    """
 
     clicked = pyqtSignal(Path)  # Einfachklick (nur fuer ".." verbunden, Issue #50)
     double_clicked = pyqtSignal(Path)  # In den Ordner wechseln
@@ -42,42 +48,37 @@ class FolderTileWidget(QFrame):
         pdf_count: Optional[int] = None,
         is_parent: bool = False,
         parent=None,
+        view: Optional[TileView] = None,
     ):
         super().__init__(parent)
         self.folder_path = Path(folder_path)
         self.is_parent = is_parent
         self._pdf_count = pdf_count
+        self._view = view or tile_view(None)
         self._setup_ui()
 
     def _setup_ui(self):
-        # Gleiche Masse wie PDFThumbnailWidget, damit das Raster buendig bleibt
-        self.setMinimumSize(160, 230)
-        self.setMaximumSize(180, 260)
         self.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
         self.setAcceptDrops(True)
         self.setStyleSheet(self._STYLE_NORMAL)
 
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(8, 8, 8, 8)
-        layout.setSpacing(4)
-        layout.addStretch()
+        self._layout = QVBoxLayout(self)
+        self._layout.addStretch()
 
-        icon = QLabel("⬆📁" if self.is_parent else "📁")
-        icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        icon.setStyleSheet("font-size: 48px; background: transparent;")
-        layout.addWidget(icon)
+        self.icon_label = QLabel("⬆📁" if self.is_parent else "📁")
+        self.icon_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._layout.addWidget(self.icon_label)
 
-        self.name_label = QLabel(".." if self.is_parent else self.folder_path.name)
+        self.name_label = QLabel()
         self.name_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.name_label.setWordWrap(True)
-        self.name_label.setStyleSheet("font-size: 12px; font-weight: bold; background: transparent;")
-        layout.addWidget(self.name_label)
+        self._layout.addWidget(self.name_label)
 
         self.count_label = QLabel(self._count_text())
         self.count_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.count_label.setStyleSheet("font-size: 11px; color: #777; background: transparent;")
-        layout.addWidget(self.count_label)
-        layout.addStretch()
+        self._layout.addWidget(self.count_label)
+        self._layout.addStretch()
+
+        self._apply_view()
 
         if self.is_parent:
             self.setToolTip(
@@ -89,6 +90,51 @@ class FolderTileWidget(QFrame):
                 f"{self.folder_path}\n"
                 "Doppelklick öffnet den Ordner, PDFs hierher ziehen verschiebt sie."
             )
+
+    @property
+    def view(self) -> TileView:
+        """Aktuelle Kachelgroesse (Issue #117)."""
+        return self._view
+
+    def set_view(self, view: TileView):
+        """Schaltet die Kachelgroesse um (gleiche Masse wie die PDF-Kacheln)."""
+        if view.id == self._view.id:
+            return
+        self._view = view
+        self._apply_view()
+
+    def _apply_view(self):
+        v = self._view
+        # Gleiche Masse wie PDFThumbnailWidget, damit das Raster buendig bleibt
+        self.setMinimumSize(v.tile_w, v.tile_h)
+        self.setMaximumSize(v.tile_max_w, v.tile_max_h)
+        self._layout.setContentsMargins(v.margin, v.margin, v.margin, v.margin)
+        self._layout.setSpacing(v.spacing)
+        self.icon_label.setStyleSheet(
+            f"font-size: {v.folder_icon_px}px; background: transparent;"
+        )
+        # Schrift ueber QFont, damit QFontMetrics fuer den Umbruch stimmt
+        name_font = self.name_label.font()
+        name_font.setPixelSize(v.font_px + 1)
+        name_font.setBold(True)
+        self.name_label.setFont(name_font)
+        self.name_label.setStyleSheet("background: transparent;")
+        count_font = self.count_label.font()
+        count_font.setPixelSize(v.font_px)
+        self.count_label.setFont(count_font)
+        self.count_label.setStyleSheet("color: #777; background: transparent;")
+        # In den kompakten Ansichten fehlt der Platz fuer den Zaehler-Text
+        # unter langen Ordnernamen - er steht dann nur im Tooltip.
+        self.count_label.setVisible(v.id == "gross" or not self.is_parent)
+        self._update_name()
+
+    def _update_name(self):
+        """Ordnername pixelgenau auf die Kachelbreite umgebrochen."""
+        v = self._view
+        name = ".." if self.is_parent else self.folder_path.name
+        self.name_label.setText(
+            fit_text_lines(name, QFontMetrics(self.name_label.font()), v.text_width, v.name_lines)
+        )
 
     def _count_text(self) -> str:
         if self.is_parent:

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -42,6 +42,7 @@ from src.gui.folder_tile import FolderTileWidget
 from src.utils.timing import StepTimer
 from src.gui.folder_widget import FolderWidget
 from src.gui.folder_tree_widget import FolderTreeWidget
+from src.gui.tile_view import TILE_VIEWS, tile_view
 from src.gui.rename_dialog import RenameDialog, RenameSuggestion, generate_rename_suggestions
 from src.gui.detail_panel import DetailPanel
 from src.utils.update_check import UpdateCheckError, UpdateInfo, check_for_update
@@ -130,6 +131,8 @@ class MainWindow(QMainWindow):
         self._grid_relayout_timer.setInterval(150)
         self._grid_relayout_timer.timeout.connect(self._relayout_pdf_grid)
         self._grid_cols = 3
+        # Kachelgroesse im Scan-Bereich: Klein / Mittel / Gross (Issue #117)
+        self._tile_view = tile_view(self.config.get("tile_view"))
 
         self.setup_ui()
         self.setup_menu()
@@ -343,6 +346,22 @@ class MainWindow(QMainWindow):
             "color: #888; font-size: 12px; padding: 5px;"
         )
         header_layout.addWidget(self.pdf_folder_count_label)
+
+        # Kachelgroesse wie im Explorer umschalten (Issue #117)
+        self.tile_view_combo = QComboBox()
+        for view in TILE_VIEWS:
+            self.tile_view_combo.addItem(view.label, view.id)
+        self.tile_view_combo.setCurrentIndex(self.tile_view_combo.findData(self._tile_view.id))
+        self.tile_view_combo.setToolTip(
+            "Größe der Kacheln im Scan-Bereich.\n"
+            "Bei kleinen und mittleren Kacheln zeigt der Mauszeiger auf einer PDF\n"
+            "kurz darauf die große Vorschau."
+        )
+        self.tile_view_combo.currentIndexChanged.connect(self._on_tile_view_combo_changed)
+        view_label = QLabel("Ansicht:")
+        view_label.setStyleSheet("color: #888; font-size: 12px;")
+        header_layout.addWidget(view_label)
+        header_layout.addWidget(self.tile_view_combo)
 
         layout.addLayout(header_layout)
 
@@ -664,6 +683,7 @@ class MainWindow(QMainWindow):
                 folder,
                 pdf_count=None if is_parent else self.folder_manager.count_pdfs(folder),
                 is_parent=is_parent,
+                view=self._tile_view,
             )
             tile.double_clicked.connect(self.on_folder_tile_double_clicked)
             if is_parent:
@@ -689,7 +709,7 @@ class MainWindow(QMainWindow):
 
         # Widgets erstellen
         for i, pdf_path in enumerate(pdf_files):
-            widget = PDFThumbnailWidget(pdf_path)
+            widget = PDFThumbnailWidget(pdf_path, view=self._tile_view)
             widget.clicked.connect(self.on_pdf_clicked)
             widget.ctrl_clicked.connect(self.on_pdf_ctrl_clicked)
             widget.shift_clicked.connect(self.on_pdf_shift_clicked)
@@ -1551,21 +1571,46 @@ class MainWindow(QMainWindow):
     def _pdf_grid_columns(self) -> int:
         """Spaltenzahl fürs PDF-Raster aus der sichtbaren Panelbreite.
 
-        Kacheln und Thumbnails sind max. 180 px breit plus 10 px Abstand.
+        Die Rasterbreite pro Kachel (max. Kachelbreite plus 10 px Abstand)
+        haengt von der gewaehlten Kachelgroesse ab (Issue #117).
         """
         width = self.pdf_scroll_area.viewport().width()
-        return max(1, width // 190)
+        return max(1, width // self._tile_view.slot_width)
 
-    def _relayout_pdf_grid(self):
+    def _relayout_pdf_grid(self, force: bool = False):
         """Ordnet Ordner-Kacheln und Thumbnails neu an, wenn sich die
         nutzbare Spaltenzahl geändert hat (Issue #50)."""
         cols = self._pdf_grid_columns()
-        if cols == self._grid_cols:
+        if cols == self._grid_cols and not force:
             return
         self._grid_cols = cols
         widgets = getattr(self, "folder_tiles", []) + self.pdf_widgets
         for i, widget in enumerate(widgets):
             self.pdf_layout.addWidget(widget, i // cols, i % cols)
+
+    def set_tile_view(self, view_id: str):
+        """Schaltet die Kachelgroesse im Scan-Bereich um (Issue #117).
+
+        Wirkt sofort auf alle Ordner-Kacheln und PDF-Thumbnails, ordnet das
+        Raster neu und merkt sich die Wahl in der Konfiguration.
+        """
+        view = tile_view(view_id)
+        if view.id != self._tile_view.id:
+            self._tile_view = view
+            self.config.set("tile_view", view.id)
+            for widget in getattr(self, "folder_tiles", []) + self.pdf_widgets:
+                widget.set_view(view)
+            self._relayout_pdf_grid(force=True)
+        combo = getattr(self, "tile_view_combo", None)
+        if combo is not None and combo.currentData() != view.id:
+            combo.blockSignals(True)
+            combo.setCurrentIndex(combo.findData(view.id))
+            combo.blockSignals(False)
+
+    def _on_tile_view_combo_changed(self, index: int):
+        view_id = self.tile_view_combo.itemData(index)
+        if view_id:
+            self.set_tile_view(view_id)
 
     # === PDF-Aktionen ===
 

--- a/src/gui/pdf_thumbnail.py
+++ b/src/gui/pdf_thumbnail.py
@@ -189,18 +189,38 @@ class PDFThumbnailWidget(QFrame):
         self.thumbnail_ready.emit()
 
     def _apply_thumbnail_pixmap(self):
-        """Zeigt das Original-Thumbnail, auf die Bildflaeche der Ansicht verkleinert."""
+        """Zeigt das Original-Thumbnail, auf die Bildflaeche der Ansicht angepasst."""
         pixmap = self._original_pixmap
         if pixmap is None or pixmap.isNull():
             return
-        v = self._view
-        if pixmap.width() > v.thumb_w or pixmap.height() > v.thumb_h:
-            pixmap = pixmap.scaled(
-                v.thumb_w, v.thumb_h,
-                Qt.AspectRatioMode.KeepAspectRatio,
+        self.thumbnail_label.setPixmap(self._fit_pixmap(pixmap, self._view))
+
+    @staticmethod
+    def _fit_pixmap(pixmap: QPixmap, view: TileView) -> QPixmap:
+        """Passt das Original in die Bildflaeche der Ansicht ein.
+
+        thumb_crop: Bild fuellt die Breite, unten wird abgeschnitten - die
+        Kachel zeigt den Kopf der Seite (Briefkopf, Betreff) statt einer
+        winzigen Gesamtseite mit leerem Rand. Sonst wird die ganze Seite
+        eingepasst (nur verkleinert, nie vergroessert).
+        """
+        if view.thumb_crop:
+            scaled = pixmap.scaled(
+                view.thumb_w, view.thumb_h,
+                Qt.AspectRatioMode.KeepAspectRatioByExpanding,
                 Qt.TransformationMode.SmoothTransformation,
             )
-        self.thumbnail_label.setPixmap(pixmap)
+            w = min(view.thumb_w, scaled.width())
+            h = min(view.thumb_h, scaled.height())
+            x = (scaled.width() - w) // 2  # horizontal mittig, oben buendig
+            return scaled.copy(x, 0, w, h)
+        if pixmap.width() <= view.thumb_w and pixmap.height() <= view.thumb_h:
+            return pixmap
+        return pixmap.scaled(
+            view.thumb_w, view.thumb_h,
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
+        )
 
     # --- Hover-Vorschau (Issue #117) --------------------------------------
 

--- a/src/gui/pdf_thumbnail.py
+++ b/src/gui/pdf_thumbnail.py
@@ -7,8 +7,8 @@ Zeigt eine Miniaturansicht einer PDF-Datei mit Dateinamen und Aktionen.
 from pathlib import Path
 from typing import Optional
 
-from PyQt6.QtCore import Qt, pyqtSignal, QThread, QSize, QMimeData, QUrl, QPoint
-from PyQt6.QtGui import QPixmap, QMouseEvent, QCursor, QDrag
+from PyQt6.QtCore import Qt, pyqtSignal, QThread, QSize, QMimeData, QUrl, QPoint, QTimer
+from PyQt6.QtGui import QPixmap, QMouseEvent, QCursor, QDrag, QFontMetrics
 from PyQt6.QtWidgets import (
     QFrame,
     QVBoxLayout,
@@ -17,6 +17,8 @@ from PyQt6.QtWidgets import (
     QApplication,
     QToolTip,
 )
+
+from src.gui.tile_view import TileView, fit_text_lines, tile_view
 
 
 class ThumbnailLoaderThread(QThread):
@@ -66,14 +68,27 @@ class PDFThumbnailWidget(QFrame):
     )
     AI_TOOLTIP_SUFFIX = "\n\nKI-Vorschlag vorhanden (grün hinterlegt)."
 
-    def __init__(self, pdf_path: Path, parent=None):
+    # Wartezeit, bis der Mauszeiger ueber einer kompakten Kachel die grosse
+    # Vorschau einblendet (Issue #117)
+    HOVER_PREVIEW_DELAY_MS = 350
+
+    def __init__(self, pdf_path: Path, parent=None, view: Optional[TileView] = None):
         super().__init__(parent)
         self.pdf_path = pdf_path
+        self._view = view or tile_view(None)
         self._selected = False
         self._has_ai_suggestion = False  # Issue #81: KI-Vorschlag im Cache
         self._analyzing = False  # Issue #108: Erst-Analyse (OCR) laeuft gerade
         self._loader_thread: Optional[ThumbnailLoaderThread] = None
         self._drag_start_position: Optional[QPoint] = None
+        # Original-Thumbnail (140x160-Render); die Kachel zeigt je nach
+        # Ansicht eine verkleinerte Kopie, die Hover-Vorschau das Original
+        self._original_pixmap: Optional[QPixmap] = None
+        self._hover_popup: Optional[QLabel] = None
+        self._hover_timer = QTimer(self)
+        self._hover_timer.setSingleShot(True)
+        self._hover_timer.setInterval(self.HOVER_PREVIEW_DELAY_MS)
+        self._hover_timer.timeout.connect(self._show_hover_preview)
 
         self.setup_ui()
         self.load_thumbnail()
@@ -82,8 +97,6 @@ class PDFThumbnailWidget(QFrame):
         """Initialisiert die UI-Komponenten."""
         self.setFrameStyle(QFrame.Shape.Box | QFrame.Shadow.Raised)
         self.setLineWidth(1)
-        self.setMinimumSize(160, 230)
-        self.setMaximumSize(180, 260)
         self.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
 
         # Hover-Effekt
@@ -91,37 +104,72 @@ class PDFThumbnailWidget(QFrame):
         self._update_style()
         self.setToolTip(self._BASE_TOOLTIP)
 
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(8, 8, 8, 8)
-        layout.setSpacing(5)
+        self._layout = QVBoxLayout(self)
 
         # Thumbnail-Bereich
         self.thumbnail_label = QLabel()
         self.thumbnail_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.thumbnail_label.setMinimumSize(140, 160)
-        self.thumbnail_label.setMaximumSize(160, 180)
         self.thumbnail_label.setStyleSheet(
             "background-color: #f5f5f5; border: 1px solid #ddd; border-radius: 3px;"
         )
         self.thumbnail_label.setText("Laden...")
-        layout.addWidget(self.thumbnail_label)
+        self._layout.addWidget(self.thumbnail_label, 0, Qt.AlignmentFlag.AlignHCenter)
 
-        # Dateiname (zweizeilig mit Tooltip für vollständigen Namen)
+        # Dateiname (mehrzeilig, pixelgenau umgebrochen; voller Name im Tooltip)
         self.name_label = QLabel()
         self.name_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.name_label.setWordWrap(True)
-        self.name_label.setMaximumHeight(55)  # Mehr Platz für 2 Zeilen
-        self.name_label.setStyleSheet("font-size: 11px; line-height: 1.2;")
+        self._layout.addWidget(self.name_label)
 
-        self.update_name_display()
-        layout.addWidget(self.name_label)
+        self._apply_view()
+
+    @property
+    def view(self) -> TileView:
+        """Aktuelle Kachelgroesse (Issue #117)."""
+        return self._view
+
+    def set_view(self, view: TileView):
+        """Schaltet die Kachelgroesse um; das Bild wird passend neu skaliert."""
+        if view.id == self._view.id:
+            return
+        self._view = view
+        self._hide_hover_preview()
+        self._apply_view()
+
+    def _apply_view(self):
+        """Wendet Masse und Schriftgroessen der aktuellen Ansicht an."""
+        v = self._view
+        self.setMinimumSize(v.tile_w, v.tile_h)
+        self.setMaximumSize(v.tile_max_w, v.tile_max_h)
+        self._layout.setContentsMargins(v.margin, v.margin, v.margin, v.margin)
+        self._layout.setSpacing(v.spacing)
+        self.thumbnail_label.setFixedSize(v.thumb_w, v.thumb_h)
+        self.name_label.setMaximumHeight(v.name_max_height)
+        self._apply_name_style()
+        if self._original_pixmap is not None:
+            self._apply_thumbnail_pixmap()
+        if self._analyzing:
+            self.name_label.setText(self.ANALYZING_TEXT)
+        else:
+            self.update_name_display()
+
+    def _apply_name_style(self):
+        """Schrift ueber QFont (nicht Stylesheet), damit QFontMetrics fuer den
+        Umbruch dieselbe Schrift misst, die gezeichnet wird."""
+        font = self.name_label.font()
+        font.setPixelSize(self._view.font_px)
+        self.name_label.setFont(font)
+        if self._analyzing:
+            self.name_label.setStyleSheet("color: #b8860b; font-style: italic;")
+        else:
+            self.name_label.setStyleSheet("")
 
     def update_name_display(self):
-        """Befuellt name_label mit gekuerztem stem + setzt vollen Namen als Tooltip."""
-        name = self.pdf_path.stem
-        if len(name) > 45:
-            name = name[:35] + "..." + name[-7:]
-        self.name_label.setText(name)
+        """Befuellt name_label mit dem umgebrochenen stem + vollem Namen als Tooltip."""
+        v = self._view
+        text = fit_text_lines(
+            self.pdf_path.stem, QFontMetrics(self.name_label.font()), v.text_width, v.name_lines
+        )
+        self.name_label.setText(text)
         self.name_label.setToolTip(self.pdf_path.name)
 
     def load_thumbnail(self):
@@ -133,11 +181,81 @@ class PDFThumbnailWidget(QFrame):
 
     def _on_thumbnail_loaded(self, pixmap: QPixmap):
         """Wird aufgerufen wenn das Thumbnail geladen wurde."""
-        self.thumbnail_label.setPixmap(pixmap)
+        self._original_pixmap = pixmap
+        self._apply_thumbnail_pixmap()
         self.thumbnail_label.setStyleSheet(
             "background-color: white; border: 1px solid #ddd; border-radius: 3px;"
         )
         self.thumbnail_ready.emit()
+
+    def _apply_thumbnail_pixmap(self):
+        """Zeigt das Original-Thumbnail, auf die Bildflaeche der Ansicht verkleinert."""
+        pixmap = self._original_pixmap
+        if pixmap is None or pixmap.isNull():
+            return
+        v = self._view
+        if pixmap.width() > v.thumb_w or pixmap.height() > v.thumb_h:
+            pixmap = pixmap.scaled(
+                v.thumb_w, v.thumb_h,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+        self.thumbnail_label.setPixmap(pixmap)
+
+    # --- Hover-Vorschau (Issue #117) --------------------------------------
+
+    def _show_hover_preview(self):
+        """Blendet das Original-Thumbnail neben der Kachel ein.
+
+        Nur bei kompakten Ansichten und nur, wenn das Bild schon geladen ist;
+        Ordner-Kacheln haben keine solche Vorschau.
+        """
+        pixmap = self._original_pixmap
+        if not self._view.hover_preview or pixmap is None or pixmap.isNull():
+            return
+        if self._hover_popup is None:
+            popup = QLabel(
+                self,
+                Qt.WindowType.ToolTip
+                | Qt.WindowType.FramelessWindowHint
+                | Qt.WindowType.WindowTransparentForInput,
+            )
+            popup.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
+            popup.setStyleSheet(
+                "QLabel { background-color: white; border: 1px solid #999; padding: 4px; }"
+            )
+            self._hover_popup = popup
+        popup = self._hover_popup
+        popup.setPixmap(pixmap)
+        popup.adjustSize()
+
+        # Rechts neben der Kachel; passt es nicht auf den Bildschirm, links davon
+        top_right = self.mapToGlobal(self.rect().topRight())
+        pos = QPoint(top_right.x() + 6, top_right.y())
+        screen = QApplication.screenAt(top_right) or QApplication.primaryScreen()
+        if screen is not None:
+            area = screen.availableGeometry()
+            if pos.x() + popup.width() > area.right():
+                left = self.mapToGlobal(self.rect().topLeft()).x()
+                pos.setX(max(area.left(), left - popup.width() - 6))
+            if pos.y() + popup.height() > area.bottom():
+                pos.setY(max(area.top(), area.bottom() - popup.height()))
+        popup.move(pos)
+        popup.show()
+
+    def _hide_hover_preview(self):
+        self._hover_timer.stop()
+        if self._hover_popup is not None:
+            self._hover_popup.hide()
+
+    def enterEvent(self, event):
+        if self._view.hover_preview and self._original_pixmap is not None:
+            self._hover_timer.start()
+        super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        self._hide_hover_preview()
+        super().leaveEvent(event)
 
     def _on_thumbnail_error(self, error: str):
         """Wird aufgerufen wenn ein Fehler beim Laden auftrat."""
@@ -196,11 +314,10 @@ class PDFThumbnailWidget(QFrame):
         if value == self._analyzing:
             return
         self._analyzing = value
+        self._apply_name_style()
         if value:
             self.name_label.setText(self.ANALYZING_TEXT)
-            self.name_label.setStyleSheet("font-size: 11px; line-height: 1.2; color: #b8860b; font-style: italic;")
         else:
-            self.name_label.setStyleSheet("font-size: 11px; line-height: 1.2;")
             self.update_name_display()
 
     @property
@@ -216,6 +333,7 @@ class PDFThumbnailWidget(QFrame):
 
     def mousePressEvent(self, event: QMouseEvent):
         """Behandelt Mausklicks und startet Drag-Vorbereitung."""
+        self._hide_hover_preview()
         if event.button() == Qt.MouseButton.LeftButton:
             self._drag_start_position = event.pos()
             # Shift+Klick für Bereichsauswahl
@@ -314,12 +432,14 @@ class PDFThumbnailWidget(QFrame):
 
     def cleanup(self):
         """Bereinigt Ressourcen."""
+        self._hide_hover_preview()
         if self._loader_thread and self._loader_thread.isRunning():
             self._loader_thread.quit()
             self._loader_thread.wait(1000)
 
     def _start_drag(self):
         """Startet den Drag & Drop Vorgang."""
+        self._hide_hover_preview()
         drag = QDrag(self)
 
         # MIME-Daten mit Datei-URL erstellen
@@ -344,9 +464,10 @@ class PDFThumbnailWidget(QFrame):
 
         drag.setMimeData(mime_data)
 
-        # Thumbnail als Drag-Pixmap verwenden (verkleinert)
-        if self.thumbnail_label.pixmap() and not self.thumbnail_label.pixmap().isNull():
-            scaled_pixmap = self.thumbnail_label.pixmap().scaled(
+        # Thumbnail als Drag-Pixmap verwenden (verkleinert, aus dem Original)
+        source = self._original_pixmap or self.thumbnail_label.pixmap()
+        if source and not source.isNull():
+            scaled_pixmap = source.scaled(
                 80, 100,
                 Qt.AspectRatioMode.KeepAspectRatio,
                 Qt.TransformationMode.SmoothTransformation

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -774,11 +774,13 @@ class SettingsDialog(QDialog):
         display_group = QGroupBox("Darstellung")
         display_layout = QFormLayout(display_group)
 
-        self.thumbnail_size_spin = QSpinBox()
-        self.thumbnail_size_spin.setRange(80, 300)
-        self.thumbnail_size_spin.setValue(150)
-        self.thumbnail_size_spin.setSuffix(" px")
-        display_layout.addRow("Thumbnail-Größe:", self.thumbnail_size_spin)
+        tile_hint = QLabel(
+            "Die Größe der Kacheln (Klein / Mittel / Groß) stellen Sie direkt "
+            "über dem Scan-Bereich unter „Ansicht“ ein."
+        )
+        tile_hint.setStyleSheet("color: gray;")
+        tile_hint.setWordWrap(True)
+        display_layout.addRow(tile_hint)
 
         self.max_suggestions_spin = QSpinBox()
         self.max_suggestions_spin.setRange(1, 10)
@@ -1426,7 +1428,6 @@ class SettingsDialog(QDialog):
         self.cloud_consent_check.setChecked(llm_config.get("cloud_consent", False))
 
         # Allgemeine Einstellungen
-        self.thumbnail_size_spin.setValue(self.config.get("thumbnail_size", 150))
         self.max_suggestions_spin.setValue(self.config.get("max_suggestions", 5))
 
         # Persönliche Daten
@@ -1511,7 +1512,6 @@ class SettingsDialog(QDialog):
         self.config.set("llm", llm_config)
 
         # Allgemeine Einstellungen
-        self.config.set("thumbnail_size", self.thumbnail_size_spin.value())
         self.config.set("max_suggestions", self.max_suggestions_spin.value())
 
         # Cache-Einstellungen

--- a/src/gui/tile_view.py
+++ b/src/gui/tile_view.py
@@ -1,0 +1,120 @@
+"""
+Kachelgroessen fuer den Scan-Bereich (Issue #117)
+
+Der linke Bereich zeigt PDFs und Unterordner als Kacheln. Wie im
+Windows-Explorer laesst sich die Groesse umschalten (Klein / Mittel / Gross).
+Das Thumbnail wird weiterhin in 140x160 gerendert und auf Platte gecacht;
+kleinere Ansichten skalieren nur dieses Bild herunter. Bei den kompakten
+Ansichten zeigt der Mauszeiger ueber einer PDF-Kachel das Original.
+
+GPL-3.0-or-later - Copyright (c) 2026
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QFontMetrics
+
+
+@dataclass(frozen=True)
+class TileView:
+    """Masse einer Kachelgroesse. Alle Werte in Pixeln."""
+
+    id: str
+    label: str
+    thumb_w: int  # Bildflaeche in der PDF-Kachel
+    thumb_h: int
+    tile_w: int  # Mindestbreite/-hoehe der Kachel (PDF und Ordner gleich)
+    tile_h: int
+    tile_max_w: int
+    tile_max_h: int
+    margin: int  # Innenabstand der Kachel
+    spacing: int  # Abstand Bild -> Name
+    font_px: int  # Schriftgroesse des Dateinamens
+    name_lines: int  # Zeilen fuer den Namen; die letzte wird mittig gekuerzt
+    name_max_height: int  # Hoehe des Namensfelds
+    folder_icon_px: int  # Schriftgroesse des Ordner-Symbols
+    hover_preview: bool  # Mauszeiger ueber PDF zeigt das Original-Thumbnail
+
+    @property
+    def slot_width(self) -> int:
+        """Rasterbreite pro Kachel inkl. Abstand - bestimmt die Spaltenzahl."""
+        return self.tile_max_w + 10
+
+    @property
+    def text_width(self) -> int:
+        """Nutzbare Textbreite in der Kachel (Mindestbreite minus Rand/Rahmen)."""
+        return self.tile_w - 2 * self.margin - 2
+
+
+# Reihenfolge = Reihenfolge in der Auswahl. "gross" entspricht den Massen
+# vor Issue #117 (Kachel 160-180 x 230-260, Bild 140x160).
+TILE_VIEWS: tuple[TileView, ...] = (
+    TileView(
+        id="klein", label="Klein",
+        thumb_w=56, thumb_h=64,
+        tile_w=92, tile_h=104, tile_max_w=102, tile_max_h=126,
+        margin=4, spacing=3, font_px=10,
+        name_lines=2, name_max_height=30,
+        folder_icon_px=22, hover_preview=True,
+    ),
+    TileView(
+        id="mittel", label="Mittel",
+        thumb_w=84, thumb_h=96,
+        tile_w=104, tile_h=142, tile_max_w=114, tile_max_h=166,
+        margin=6, spacing=4, font_px=10,
+        name_lines=2, name_max_height=30,
+        folder_icon_px=32, hover_preview=True,
+    ),
+    TileView(
+        id="gross", label="Groß",
+        thumb_w=140, thumb_h=160,
+        tile_w=160, tile_h=230, tile_max_w=180, tile_max_h=260,
+        margin=8, spacing=5, font_px=11,
+        name_lines=3, name_max_height=55,
+        folder_icon_px=48, hover_preview=False,
+    ),
+)
+
+DEFAULT_TILE_VIEW_ID = "klein"
+
+_BY_ID = {view.id: view for view in TILE_VIEWS}
+
+
+def tile_view(view_id: Optional[str]) -> TileView:
+    """Liefert die Kachelgroesse zu einer Konfigurations-ID; unbekannt -> Standard."""
+    return _BY_ID.get(view_id or "", _BY_ID[DEFAULT_TILE_VIEW_ID])
+
+
+def fit_text_lines(text: str, fm: QFontMetrics, width: int, max_lines: int) -> str:
+    """Bricht ``text`` auf hoechstens ``max_lines`` Zeilen der Breite ``width`` um.
+
+    QLabel bricht nur an Leerzeichen um; Dateinamen wie
+    ``Stadtwerke_Jahresabrechnung_2023`` liefen deshalb seitlich aus der
+    Kachel. Hier wird bevorzugt an Leerzeichen getrennt, zu lange Woerter
+    werden zeichenweise geteilt, und die letzte Zeile wird bei Bedarf in der
+    Mitte gekuerzt ("Stadtwerke_Jah…ng_2023").
+    """
+    def fits(s: str) -> bool:
+        return fm.horizontalAdvance(s) <= width
+
+    rest = text.strip()
+    if max_lines <= 0 or fits(rest):
+        return rest
+    lines: list[str] = []
+    while rest and len(lines) < max_lines - 1:
+        if fits(rest):
+            break
+        cut = len(rest)
+        while cut > 1 and not fits(rest[:cut]):
+            cut -= 1
+        # Lieber am letzten Leerzeichen innerhalb des passenden Stuecks trennen
+        space = rest.rfind(" ", 1, cut + 1)
+        if space > 0:
+            cut = space
+        lines.append(rest[:cut].rstrip())
+        rest = rest[cut:].lstrip()
+    if rest:
+        lines.append(fm.elidedText(rest, Qt.TextElideMode.ElideMiddle, width))
+    return "\n".join(lines)

--- a/src/gui/tile_view.py
+++ b/src/gui/tile_view.py
@@ -25,6 +25,9 @@ class TileView:
     label: str
     thumb_w: int  # Bildflaeche in der PDF-Kachel
     thumb_h: int
+    # True: Bild fuellt die Flaeche in der Breite, unten wird abgeschnitten
+    # (Kopf der Seite). False: ganze Seite eingepasst, Rest bleibt frei.
+    thumb_crop: bool
     tile_w: int  # Mindestbreite/-hoehe der Kachel (PDF und Ordner gleich)
     tile_h: int
     tile_max_w: int
@@ -53,7 +56,9 @@ class TileView:
 TILE_VIEWS: tuple[TileView, ...] = (
     TileView(
         id="klein", label="Klein",
-        thumb_w=56, thumb_h=64,
+        # Bild so breit wie der Text, Seite unten abgeschnitten: Bei 56x64
+        # blieb um die A4-Seite (45 px breit) zu viel leere Kachel (#117-Feedback)
+        thumb_w=82, thumb_h=64, thumb_crop=True,
         tile_w=92, tile_h=104, tile_max_w=102, tile_max_h=126,
         margin=4, spacing=3, font_px=10,
         name_lines=2, name_max_height=30,
@@ -61,7 +66,7 @@ TILE_VIEWS: tuple[TileView, ...] = (
     ),
     TileView(
         id="mittel", label="Mittel",
-        thumb_w=84, thumb_h=96,
+        thumb_w=84, thumb_h=96, thumb_crop=False,
         tile_w=104, tile_h=142, tile_max_w=114, tile_max_h=166,
         margin=6, spacing=4, font_px=10,
         name_lines=2, name_max_height=30,
@@ -69,7 +74,7 @@ TILE_VIEWS: tuple[TileView, ...] = (
     ),
     TileView(
         id="gross", label="Groß",
-        thumb_w=140, thumb_h=160,
+        thumb_w=140, thumb_h=160, thumb_crop=False,
         tile_w=160, tile_h=230, tile_max_w=180, tile_max_h=260,
         margin=8, spacing=5, font_px=11,
         name_lines=3, name_max_height=55,

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -50,7 +50,8 @@ class Config:
         "window_width": 1200,
         "window_height": 800,
         "window_maximized": True,
-        "thumbnail_size": 150,
+        # Kachelgroesse im Scan-Bereich: "klein" / "mittel" / "gross" (Issue #117)
+        "tile_view": "klein",
         "backup_check_days": 7,
         "language": "de",
         "theme": "light",

--- a/tests/test_folder_tile_gui.py
+++ b/tests/test_folder_tile_gui.py
@@ -32,7 +32,8 @@ def test_tile_shows_name_and_count(qtbot, tmp_path):
     folder.mkdir()
     tile = FolderTileWidget(folder, pdf_count=3)
     qtbot.addWidget(tile)
-    assert tile.name_label.text() == "Steuer 2026"
+    # Der Name darf je nach Kachelbreite umgebrochen sein (Issue #117)
+    assert tile.name_label.text().replace("\n", " ") == "Steuer 2026"
     assert tile.count_label.text() == "3 PDFs"
 
 

--- a/tests/test_main_window_gui.py
+++ b/tests/test_main_window_gui.py
@@ -242,7 +242,8 @@ def test_load_pdfs_shows_parent_and_subfolder_tiles(main_window, fresh_singleton
     main_window._navigate_to_folder(scan)
 
     tiles = main_window.folder_tiles
-    assert [t.name_label.text() for t in tiles] == ["..", "Banken", "Steuer 2026"]
+    # Namen koennen je nach Kachelbreite umgebrochen sein (Issue #117)
+    assert [t.name_label.text().replace("\n", " ") for t in tiles] == ["..", "Banken", "Steuer 2026"]
     assert tiles[0].is_parent and tiles[0].folder_path == scan.parent
     assert tiles[1].count_label.text() == "1 PDF"
     assert main_window.pdf_scroll_area.isVisibleTo(main_window)  # trotz 0 PDFs sichtbar

--- a/tests/test_tile_view_117_gui.py
+++ b/tests/test_tile_view_117_gui.py
@@ -64,17 +64,52 @@ def test_default_widget_uses_small_view(thumbnail_factory):
     assert widget.view.id == "klein"
 
 
-def test_small_view_scales_thumbnail_and_keeps_original(thumbnail_factory):
+def _two_tone_pixmap(w: int = 113, h: int = 160) -> QPixmap:
+    """Obere Haelfte rot, untere blau - zeigt, welcher Teil der Seite bleibt."""
+    from PyQt6.QtGui import QPainter
+    p = QPixmap(w, h)
+    p.fill(Qt.GlobalColor.red)
+    painter = QPainter(p)
+    painter.fillRect(0, h // 2, w, h - h // 2, Qt.GlobalColor.blue)
+    painter.end()
+    return p
+
+
+def test_small_view_fills_width_and_crops_bottom(thumbnail_factory):
+    """#117-Feedback: In Klein blieb um die winzige Seite zu viel leere Kachel.
+    Jetzt fuellt das Bild die Textbreite, unten wird abgeschnitten."""
     widget = thumbnail_factory("klein")
     view = tile_view("klein")
+    assert view.thumb_crop and view.thumb_w == view.text_width
     assert widget.thumbnail_label.height() == view.thumb_h
     assert widget.maximumWidth() == view.tile_max_w
 
-    widget._on_thumbnail_loaded(_pixmap())
+    widget._on_thumbnail_loaded(_two_tone_pixmap())
+    shown = widget.thumbnail_label.pixmap()
+    assert (shown.width(), shown.height()) == (view.thumb_w, view.thumb_h)
+    img = shown.toImage()
+    assert img.pixelColor(view.thumb_w // 2, 2).red() > 200  # Kopf der Seite oben
+    assert img.pixelColor(view.thumb_w // 2, view.thumb_h - 2).blue() > 200  # Mitte der Seite unten
+    assert widget._original_pixmap.size() == _two_tone_pixmap().size()
+
+
+def test_crop_keeps_landscape_pages_centered():
+    from src.gui.pdf_thumbnail import PDFThumbnailWidget
+    view = tile_view("klein")
+    shown = PDFThumbnailWidget._fit_pixmap(_pixmap(140, 70), view)
+    assert (shown.width(), shown.height()) == (view.thumb_w, view.thumb_h)
+
+
+def test_medium_view_scales_whole_page(thumbnail_factory):
+    widget = thumbnail_factory("mittel")
+    view = tile_view("mittel")
+    assert not view.thumb_crop
+    widget._on_thumbnail_loaded(_two_tone_pixmap())
     shown = widget.thumbnail_label.pixmap()
     assert shown.height() == view.thumb_h
-    assert shown.width() <= view.thumb_w
-    assert widget._original_pixmap.size() == _pixmap().size()
+    assert shown.width() < view.thumb_w  # ganze A4-Seite, schmaler als die Flaeche
+    img = shown.toImage()
+    assert img.pixelColor(shown.width() // 2, shown.height() - 2).blue() > 200  # Seitenende sichtbar
 
 
 def test_large_view_shows_original_unscaled(thumbnail_factory):
@@ -96,6 +131,9 @@ def test_switching_view_rescales_and_resizes(thumbnail_factory):
     assert widget.thumbnail_label.pixmap().height() == tile_view("mittel").thumb_h
     assert widget.maximumHeight() == tile_view("mittel").tile_max_h
     assert widget.name_label.font().pixelSize() == 10
+
+    widget.set_view(tile_view("klein"))
+    assert widget.thumbnail_label.pixmap().width() == tile_view("klein").thumb_w  # wieder zugeschnitten
 
 
 def _line_widths(label):

--- a/tests/test_tile_view_117_gui.py
+++ b/tests/test_tile_view_117_gui.py
@@ -1,0 +1,344 @@
+"""Issue #117: Kachelgroesse im Scan-Bereich (Klein / Mittel / Gross) + Hover-Vorschau.
+
+Das Thumbnail wird weiterhin in 140x160 gerendert; die Kachel zeigt je nach
+Ansicht eine verkleinerte Kopie. Bei den kompakten Ansichten blendet der
+Mauszeiger ueber einer PDF-Kachel das Original ein - Ordner-Kacheln nicht.
+"""
+from PyQt6.QtCore import QEvent, Qt
+from PyQt6.QtGui import QPixmap
+
+import pytest
+
+from src.gui.tile_view import DEFAULT_TILE_VIEW_ID, TILE_VIEWS, tile_view
+from tests.test_main_window_gui import fresh_singletons, main_window, _scan_tree  # noqa: F401 - Fixtures
+
+
+def _pixmap(w: int = 113, h: int = 160) -> QPixmap:
+    """Wie ein gerendertes A4-Thumbnail im 140x160-Rahmen."""
+    p = QPixmap(w, h)
+    p.fill(Qt.GlobalColor.gray)
+    return p
+
+
+@pytest.fixture
+def thumbnail_factory(qtbot, monkeypatch, tmp_path):
+    from src.gui import pdf_thumbnail as th
+    monkeypatch.setattr(th.ThumbnailLoaderThread, "start", lambda self: None)
+
+    def make(view_id=None, name="a.pdf"):
+        pdf = tmp_path / name
+        pdf.write_bytes(b"%PDF-1.4")
+        widget = th.PDFThumbnailWidget(pdf, view=tile_view(view_id) if view_id else None)
+        qtbot.addWidget(widget)
+        return widget
+
+    return make
+
+
+# --------------------------------------------------------------------- #
+# Presets
+# --------------------------------------------------------------------- #
+
+
+def test_views_and_fallback():
+    assert [v.id for v in TILE_VIEWS] == ["klein", "mittel", "gross"]
+    assert tile_view(None).id == DEFAULT_TILE_VIEW_ID == "klein"
+    assert tile_view("gibt-es-nicht").id == DEFAULT_TILE_VIEW_ID
+    # "gross" = Masse vor #117, damit sich fuer diese Ansicht nichts aendert
+    gross = tile_view("gross")
+    assert (gross.thumb_w, gross.thumb_h) == (140, 160)
+    assert (gross.tile_w, gross.tile_h, gross.tile_max_w, gross.tile_max_h) == (160, 230, 180, 260)
+    assert gross.slot_width == 190
+    # Kompakte Ansichten sind deutlich schmaler
+    assert tile_view("klein").tile_max_w < gross.tile_w // 1.5
+    assert tile_view("mittel").tile_max_w < gross.tile_w
+
+
+# --------------------------------------------------------------------- #
+# PDF-Kachel
+# --------------------------------------------------------------------- #
+
+
+def test_default_widget_uses_small_view(thumbnail_factory):
+    widget = thumbnail_factory()
+    assert widget.view.id == "klein"
+
+
+def test_small_view_scales_thumbnail_and_keeps_original(thumbnail_factory):
+    widget = thumbnail_factory("klein")
+    view = tile_view("klein")
+    assert widget.thumbnail_label.height() == view.thumb_h
+    assert widget.maximumWidth() == view.tile_max_w
+
+    widget._on_thumbnail_loaded(_pixmap())
+    shown = widget.thumbnail_label.pixmap()
+    assert shown.height() == view.thumb_h
+    assert shown.width() <= view.thumb_w
+    assert widget._original_pixmap.size() == _pixmap().size()
+
+
+def test_large_view_shows_original_unscaled(thumbnail_factory):
+    widget = thumbnail_factory("gross")
+    widget._on_thumbnail_loaded(_pixmap())
+    assert widget.thumbnail_label.pixmap().size() == _pixmap().size()
+
+
+def test_switching_view_rescales_and_resizes(thumbnail_factory):
+    widget = thumbnail_factory("klein")
+    widget._on_thumbnail_loaded(_pixmap())
+
+    widget.set_view(tile_view("gross"))
+    assert widget.thumbnail_label.pixmap().height() == 160
+    assert widget.minimumWidth() == tile_view("gross").tile_w
+    assert widget.name_label.font().pixelSize() == 11
+
+    widget.set_view(tile_view("mittel"))
+    assert widget.thumbnail_label.pixmap().height() == tile_view("mittel").thumb_h
+    assert widget.maximumHeight() == tile_view("mittel").tile_max_h
+    assert widget.name_label.font().pixelSize() == 10
+
+
+def _line_widths(label):
+    from PyQt6.QtGui import QFontMetrics
+    fm = QFontMetrics(label.font())
+    return [fm.horizontalAdvance(line) for line in label.text().split("\n")]
+
+
+def test_long_name_is_wrapped_to_tile_width_and_elided(thumbnail_factory):
+    """Namen ohne Leerzeichen liefen seitlich aus der Kachel (Screenshot-Befund)."""
+    long_name = "Stadtwerke_Jahresabrechnung_2023_Strom_und_Gas_Kundennummer_4711.pdf"
+    widget = thumbnail_factory("klein", name=long_name)
+    view = tile_view("klein")
+    lines = widget.name_label.text().split("\n")
+    assert len(lines) == view.name_lines
+    assert all(w <= view.text_width for w in _line_widths(widget.name_label))
+    assert "…" in lines[-1]  # letzte Zeile in der Mitte gekuerzt, Ende bleibt sichtbar
+    assert lines[-1].endswith("11")
+    assert widget.name_label.toolTip() == long_name
+
+    widget.set_view(tile_view("gross"))
+    lines = widget.name_label.text().split("\n")
+    assert len(lines) <= tile_view("gross").name_lines
+    assert all(w <= tile_view("gross").text_width for w in _line_widths(widget.name_label))
+    # Gross bietet mehr Platz: mindestens so viel vom Namen sichtbar wie in Klein
+    assert len(widget.name_label.text().replace("\n", "")) >= len("".join(lines[:1]))
+
+
+def test_short_name_is_not_elided(thumbnail_factory):
+    """Kurze Namen bleiben vollstaendig (offscreen misst die Schrift breiter,
+    deshalb ist hier nur der Umbruch, nicht die Zeilenzahl festgelegt)."""
+    from PyQt6.QtGui import QFontMetrics
+    widget = thumbnail_factory("klein", name="Scan_0001.pdf")
+    assert widget.name_label.text().replace("\n", "") == "Scan_0001"
+    fm = QFontMetrics(widget.name_label.font())
+    if fm.horizontalAdvance("Scan_0001") <= tile_view("klein").text_width:
+        assert widget.name_label.text() == "Scan_0001"
+
+
+def test_fit_text_lines_prefers_spaces():
+    from PyQt6.QtGui import QFont, QFontMetrics
+    from src.gui.tile_view import fit_text_lines
+    font = QFont()
+    font.setPixelSize(10)
+    fm = QFontMetrics(font)
+    width = fm.horizontalAdvance("Rechnung Telekom") + 2
+    text = fit_text_lines("Rechnung Telekom Mai 2026", fm, width, 2)
+    lines = text.split("\n")
+    assert lines[0] == "Rechnung Telekom"
+    assert lines[1].startswith("Mai")
+    # Passt alles in eine Zeile, bleibt der Text unveraendert
+    assert fit_text_lines("Kurz", fm, width, 2) == "Kurz"
+
+
+def test_analyzing_style_uses_view_font(thumbnail_factory):
+    widget = thumbnail_factory("klein")
+    widget.analyzing = True
+    assert widget.name_label.text() == widget.ANALYZING_TEXT
+    assert widget.name_label.font().pixelSize() == 10
+    assert "italic" in widget.name_label.styleSheet()
+    widget.set_view(tile_view("gross"))
+    assert widget.name_label.text() == widget.ANALYZING_TEXT
+    assert widget.name_label.font().pixelSize() == 11
+    assert "italic" in widget.name_label.styleSheet()
+    widget.analyzing = False
+    assert "italic" not in widget.name_label.styleSheet()
+    assert widget.name_label.text() == "a"
+
+
+# --------------------------------------------------------------------- #
+# Hover-Vorschau
+# --------------------------------------------------------------------- #
+
+
+def test_hover_preview_shows_original_and_hides_on_leave(thumbnail_factory):
+    widget = thumbnail_factory("klein")
+    widget._on_thumbnail_loaded(_pixmap())
+
+    widget._show_hover_preview()
+    popup = widget._hover_popup
+    assert popup is not None and popup.isVisible()
+    assert popup.pixmap().size() == _pixmap().size()
+    assert popup.isWindow()  # eigenes schwebendes Fenster, nicht in der Kachel
+
+    widget.leaveEvent(QEvent(QEvent.Type.Leave))
+    assert not popup.isVisible()
+
+
+def test_hover_preview_hidden_on_press_and_cleanup(thumbnail_factory):
+    widget = thumbnail_factory("mittel")
+    widget._on_thumbnail_loaded(_pixmap())
+    widget._show_hover_preview()
+    assert widget._hover_popup.isVisible()
+
+    widget._hide_hover_preview()
+    assert not widget._hover_popup.isVisible()
+
+    widget._show_hover_preview()
+    widget.cleanup()
+    assert not widget._hover_popup.isVisible()
+
+
+def test_no_hover_preview_in_large_view_or_before_loading(thumbnail_factory):
+    big = thumbnail_factory("gross")
+    big._on_thumbnail_loaded(_pixmap())
+    big._show_hover_preview()
+    assert big._hover_popup is None
+
+    unloaded = thumbnail_factory("klein", name="b.pdf")
+    unloaded._show_hover_preview()
+    assert unloaded._hover_popup is None
+
+
+def test_enter_starts_timer_only_in_compact_view(thumbnail_factory):
+    from PyQt6.QtCore import QPointF
+    from PyQt6.QtGui import QEnterEvent
+    enter = QEnterEvent(QPointF(1, 1), QPointF(1, 1), QPointF(1, 1))
+
+    small = thumbnail_factory("klein")
+    small.enterEvent(enter)
+    assert not small._hover_timer.isActive()  # Bild noch nicht geladen
+    small._on_thumbnail_loaded(_pixmap())
+    small.enterEvent(enter)
+    assert small._hover_timer.isActive()
+    small.leaveEvent(QEvent(QEvent.Type.Leave))
+    assert not small._hover_timer.isActive()
+
+    big = thumbnail_factory("gross", name="b.pdf")
+    big._on_thumbnail_loaded(_pixmap())
+    big.enterEvent(enter)
+    assert not big._hover_timer.isActive()
+
+
+def test_switch_to_large_view_hides_preview(thumbnail_factory):
+    widget = thumbnail_factory("klein")
+    widget._on_thumbnail_loaded(_pixmap())
+    widget._show_hover_preview()
+    widget.set_view(tile_view("gross"))
+    assert not widget._hover_popup.isVisible()
+
+
+# --------------------------------------------------------------------- #
+# Ordner-Kachel
+# --------------------------------------------------------------------- #
+
+
+def test_folder_tile_matches_pdf_tile_size(qtbot, tmp_path):
+    from src.gui.folder_tile import FolderTileWidget
+    view = tile_view("klein")
+    tile = FolderTileWidget(tmp_path, pdf_count=2, view=view)
+    qtbot.addWidget(tile)
+    assert (tile.minimumWidth(), tile.maximumWidth()) == (view.tile_w, view.tile_max_w)
+    assert (tile.minimumHeight(), tile.maximumHeight()) == (view.tile_h, view.tile_max_h)
+    assert tile.count_label.text() == "2 PDFs"
+    assert "22px" in tile.icon_label.styleSheet()
+    assert tile.name_label.font().pixelSize() == 11 and tile.name_label.font().bold()
+
+    tile.set_view(tile_view("gross"))
+    assert tile.minimumWidth() == tile_view("gross").tile_w
+    assert "48px" in tile.icon_label.styleSheet()
+    assert tile.name_label.font().pixelSize() == 12
+
+
+def test_folder_tile_wraps_long_name(qtbot, tmp_path):
+    from src.gui.folder_tile import FolderTileWidget
+    folder = tmp_path / "Versicherungen_und_Altersvorsorge_Unterlagen"
+    folder.mkdir()
+    view = tile_view("klein")
+    tile = FolderTileWidget(folder, pdf_count=0, view=view)
+    qtbot.addWidget(tile)
+    assert len(tile.name_label.text().split("\n")) == view.name_lines
+    assert all(w <= view.text_width for w in _line_widths(tile.name_label))
+    assert tile.toolTip().startswith(str(folder))
+
+
+def test_folder_tile_default_view_is_small(qtbot, tmp_path):
+    from src.gui.folder_tile import FolderTileWidget
+    tile = FolderTileWidget(tmp_path)
+    qtbot.addWidget(tile)
+    assert tile.view.id == "klein"
+    assert not hasattr(tile, "_hover_popup")  # keine Vorschau fuer Ordner
+
+
+def test_parent_tile_hides_count_text_in_compact_views(qtbot, tmp_path):
+    from src.gui.folder_tile import FolderTileWidget
+    tile = FolderTileWidget(tmp_path, is_parent=True, view=tile_view("klein"))
+    qtbot.addWidget(tile)
+    assert tile.count_label.isHidden()
+    tile.set_view(tile_view("gross"))
+    assert not tile.count_label.isHidden()
+
+
+# --------------------------------------------------------------------- #
+# Hauptfenster
+# --------------------------------------------------------------------- #
+
+
+def test_main_window_defaults_to_small_tiles_and_switch_persists(main_window, fresh_singletons):
+    scan = _scan_tree(fresh_singletons["tmp_path"])
+    main_window._navigate_to_folder(scan / "Banken")
+    assert main_window.tile_view_combo.currentData() == "klein"
+    (widget,) = main_window.pdf_widgets
+    assert widget.view.id == "klein"
+    assert all(t.view.id == "klein" for t in main_window.folder_tiles)
+
+    main_window.tile_view_combo.setCurrentIndex(main_window.tile_view_combo.findData("gross"))
+    assert fresh_singletons["config"].get("tile_view") == "gross"
+    assert widget.view.id == "gross"
+    assert widget.maximumWidth() == tile_view("gross").tile_max_w
+    assert all(t.view.id == "gross" for t in main_window.folder_tiles)
+
+
+def test_grid_columns_follow_tile_view(main_window, fresh_singletons):
+    scan = _scan_tree(fresh_singletons["tmp_path"])
+    main_window._navigate_to_folder(scan)
+    viewport_w = main_window.pdf_scroll_area.viewport().width()
+    assert main_window._grid_cols == max(1, viewport_w // tile_view("klein").slot_width)
+
+    main_window.set_tile_view("gross")
+    assert main_window._grid_cols == max(1, viewport_w // tile_view("gross").slot_width)
+    assert main_window.tile_view_combo.currentData() == "gross"
+
+    # Raster-Positionen folgen der neuen Spaltenzahl
+    cols = main_window._grid_cols
+    widgets = main_window.folder_tiles + main_window.pdf_widgets
+    for i, w in enumerate(widgets):
+        idx = main_window.pdf_layout.indexOf(w)
+        row, col, _, _ = main_window.pdf_layout.getItemPosition(idx)
+        assert (row, col) == (i // cols, i % cols)
+
+
+def test_stored_view_is_used_at_startup(qtbot, fresh_singletons, monkeypatch):
+    fresh_singletons["config"].set("tile_view", "mittel")
+    from src.gui import main_window as mw_mod
+    monkeypatch.setattr(mw_mod.QMainWindow, "showMaximized", lambda self: None)
+    monkeypatch.setattr(mw_mod.MainWindow, "show", lambda self: None)
+    win = mw_mod.MainWindow()
+    qtbot.addWidget(win)
+    assert win._tile_view.id == "mittel"
+    assert win.tile_view_combo.currentData() == "mittel"
+
+
+def test_settings_dialog_has_no_dead_thumbnail_size_setting(fresh_singletons):
+    from src.utils.config import Config
+    assert "thumbnail_size" not in Config.DEFAULTS
+    assert Config.DEFAULTS["tile_view"] == "klein"


### PR DESCRIPTION
Closes #117

## Was neu ist

- **Ansicht: Klein / Mittel / Groß** über der PDF-Liste links, wie die Symbolgröße im Explorer. Die Wahl wird gespeichert (`tile_view`, Standard „Klein“).
- **Klein**: Kachel etwa halb so breit wie bisher, das Bild füllt die Kachelbreite und zeigt den Seitenkopf (unten abgeschnitten). **Mittel**: ganze Seite verkleinert. **Groß**: exakt die bisherige Darstellung.
- **Hover-Vorschau nur bei PDFs**: Bei Klein und Mittel erscheint nach 350 ms neben der Kachel das Original-Thumbnail; verschwindet beim Verlassen, Klick oder Drag. Ordner-Kacheln schrumpfen mit, haben aber keine Vorschau.
- Thumbnails bleiben der 140x160-Render aus dem Disk-Cache, kleinere Ansichten skalieren nur herunter.
- **Nebenbefund behoben**: Dateinamen ohne Leerzeichen liefen seitlich aus der Kachel (QLabel bricht nur an Leerzeichen). Jetzt pixelgenauer Umbruch mit Kürzung in der Mitte, voller Name im Tooltip.
- Die nie gelesene Einstellung „Thumbnail-Größe“ unter Allgemein entfällt, dort steht ein Hinweis auf den Umschalter.

## Dateien

- neu: `src/gui/tile_view.py` (Presets, `fit_text_lines`), `tests/test_tile_view_117_gui.py`
- `pdf_thumbnail.py`, `folder_tile.py`, `main_window.py`, `settings_dialog.py`, `config.py`, CHANGELOG, README

## Geprüft

- 924 Tests grün (offscreen)
- Live mit den Demo-PDFs in allen drei Ansichten und mit Hover-Vorschau angesehen, Feedback-Runde zu „Klein“ eingearbeitet

Hinweis: Baumansicht aus dem Issue-Kommentar bleibt bei #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
