### PR TITLE
feat(#132): Feld „Datum“ im Detail-Panel + Dokumentdatum statt jüngstem Datum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 ## [Unreleased]
 
 ### Behoben
+- **Falsches Jahr im Dateinamen und Steuerjahr** (#132): Als Dokumentdatum
+  galt bisher das *juengste* Datum im Text - eine Frist, ein Eingangsstempel
+  oder ein OCR-Lesefehler mit spaeterem Jahr machte aus einem Brief von 2004
+  ein Dokument von 2006, und das Steuerjahr folgte. Fand die Texterkennung
+  gar kein Datum, nahm die KI stillschweigend das Scandatum der Datei. Jetzt
+  zaehlt ein beschriftetes Datum („Datum:“, „Rechnungsdatum“, „Ort, den“)
+  zuerst, danach das erste Datum in Lesereihenfolge (Briefkopf); Daten hinter
+  „geboren“, „gueltig bis“, „faellig“, „Frist“ oder „Eingang“ nur als
+  Notnagel. Der KI-Prompt erklaert Fristen und Scandatum ausdruecklich als
+  Nicht-Dokumentdatum, verlangt das Datum als eigenes Metadatum und bekommt
+  den Namen des Quellordners („Briefe 2004“) als Hinweis mit.
 - **MwSt-Satz 7 % wurde staendig vorgeschlagen**, auch bei Dokumenten ohne
   jede Steuerangabe: Im KI-Prompt stand „7“ als Beispielwert, den viele
   Modelle einfach uebernahmen. Die Beispiele heissen jetzt „19 oder 7 oder
@@ -16,6 +27,18 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
   im Dokumenttext nicht vorkommt, wird verworfen. Das Feld bleibt dann leer.
 
 ### Neu
+- **Feld „Datum“ im Detail-Panel** (#132): Das Dokumentdatum steht jetzt als
+  eigenes Metadaten-Feld (JJJJ-MM-TT) neben dem Steuerjahr und wird in die
+  PDF geschrieben (`Buchungsdatum`). Es ist die eine Quelle fuer `{datum}` in
+  den Dateinamen-Mustern und belegt das Steuerjahr vor - solange das
+  Steuerjahr nicht bewusst anders gesetzt wurde, folgt es dem Datum. Eingabe
+  auch als „12.3.2004“ oder „12. Maerz 2004“ (wird beim Verlassen des Felds
+  normalisiert); Unlesbares wird rot markiert und nicht gespeichert. In der
+  Vorschau: Datum markieren, Rechtsklick, „Als Datum uebernehmen“ - kann die
+  Texterkennung auch die Markierung nicht lesen, steht der Text rot im Feld
+  und wird durch die eigene Eingabe ersetzt. Bereits sortierte PDFs mit
+  Metadaten, aber ohne Datum, zeigen das Feld leer (kein „teilweise
+  gespeichert“ nur wegen des Analyse-Datums).
 - **Kleinere Kacheln im Scan-Bereich** (#117, Probelauf): Ueber der
   PDF-Liste links steht jetzt „Ansicht: Klein / Mittel / Gross“, wie die
   Symbolgroesse im Explorer. Standard ist „Klein“: Kachel etwa halb so breit

--- a/src/core/document_date.py
+++ b/src/core/document_date.py
@@ -1,0 +1,174 @@
+"""Dokumentdatum: finden, auswaehlen und Nutzereingaben parsen (Issue #132).
+
+Bis v0.24 nahm ``PDFAnalyzer.extract_dates()`` das *juengste* Datum im Text
+als Dokumentdatum - eine Frist, ein Eingangsstempel oder ein OCR-Lesefehler
+mit spaeterem Jahr ueberschrieb damit das Briefdatum, und daraus wurde das
+Steuerjahr abgeleitet. Hier steht die Auswahl an einer Stelle:
+
+- :func:`find_dates` liefert alle Datumsangaben mit Position im Text.
+- :func:`pick_document_date` waehlt das wahrscheinlichste Dokumentdatum:
+  ein Datum hinter "Datum:", "Rechnungsdatum", ", den" oder "Stand" schlaegt
+  alle anderen; Daten hinter "geboren", "gueltig bis", "faellig", "Frist",
+  "Eingang" u.ae. zaehlen nur als Notnagel; bei Gleichstand gewinnt das erste
+  Datum in Lesereihenfolge (Briefkopf), nicht das juengste.
+- :func:`parse_user_date` macht aus markiertem oder getipptem Text
+  ("12.3.2004", "12. Maerz 2004", "2004-03-12") ein ISO-Datum fuer das
+  Feld "Datum" im Detail-Panel.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+# Jahresbereich fuer Daten aus dem Dokumenttext (filtert OCR-Rauschen wie
+# "1.2.1234"); Nutzereingaben duerfen aelter sein
+MIN_TEXT_YEAR = 1990
+MIN_USER_YEAR = 1900
+MAX_YEAR = 2100
+
+_MONTHS: dict[str, int] = {
+    "januar": 1, "jan": 1,
+    "februar": 2, "feb": 2,
+    "märz": 3, "maerz": 3, "marz": 3, "mrz": 3, "mar": 3,
+    "april": 4, "apr": 4,
+    "mai": 5,
+    "juni": 6, "jun": 6,
+    "juli": 7, "jul": 7,
+    "august": 8, "aug": 8,
+    "september": 9, "sep": 9, "sept": 9,
+    "oktober": 10, "okt": 10,
+    "november": 11, "nov": 11,
+    "dezember": 12, "dez": 12,
+}
+_MONTH_ALT = "|".join(sorted(_MONTHS, key=len, reverse=True))
+
+# TT.MM.JJJJ, TT.MM.JJ, TT/MM/JJJJ - nicht mitten in laengeren Ziffernfolgen
+_NUMERIC_RE = re.compile(r"(?<!\d)(\d{1,2})[./](\d{1,2})[./](\d{4}|\d{2})(?!\d)")
+# JJJJ-MM-TT (ISO, auch am Anfang von "2004-03-12 00:00:00" aus dem Cache)
+_ISO_RE = re.compile(r"(?<!\d)(\d{4})-(\d{1,2})-(\d{1,2})(?!\d)")
+# 15. Januar 2025, 15 Jan 2025, 15. Maerz 2004
+_TEXT_RE = re.compile(
+    r"(?<!\d)(\d{1,2})\.?\s*(" + _MONTH_ALT + r")\.?\s+(\d{4})(?!\d)",
+    re.IGNORECASE,
+)
+
+# Beschriftungen unmittelbar vor dem Datum (Fenster von _LABEL_WINDOW Zeichen)
+_LABEL_WINDOW = 30
+_POSITIVE_LABEL_RE = re.compile(
+    r"(datum|,\s*den|stand)\s*:?\s*$",
+    re.IGNORECASE,
+)
+_NEGATIVE_LABEL_RE = re.compile(
+    r"(geboren|geb\.|geburtsdatum|g[üue]+ltig|bis(\s+zum)?|frist|f[äae]+llig|zahlbar|"
+    r"zahlungsziel|sp[äae]+testens|termin|eingang|eingegangen)\s*(am|zum)?\s*:?\s*$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class FoundDate:
+    """Ein im Text gefundenes Datum mit seiner Position."""
+
+    pos: int
+    end: int
+    value: datetime
+
+
+def _year(raw: str, min_year: int) -> Optional[int]:
+    year = int(raw)
+    if len(raw) == 2:
+        year += 2000 if year < 50 else 1900
+    if min_year <= year <= MAX_YEAR:
+        return year
+    return None
+
+
+def _make(year: Optional[int], month: int, day: int) -> Optional[datetime]:
+    if year is None:
+        return None
+    try:
+        return datetime(year, month, day)
+    except ValueError:
+        return None
+
+
+def find_dates(text: str, min_year: int = MIN_TEXT_YEAR) -> list[FoundDate]:
+    """Alle Datumsangaben im Text, nach Position sortiert (ungueltige fallen weg)."""
+    if not text:
+        return []
+    found: list[FoundDate] = []
+    for m in _NUMERIC_RE.finditer(text):
+        value = _make(_year(m.group(3), min_year), int(m.group(2)), int(m.group(1)))
+        if value:
+            found.append(FoundDate(m.start(), m.end(), value))
+    for m in _ISO_RE.finditer(text):
+        value = _make(_year(m.group(1), min_year), int(m.group(2)), int(m.group(3)))
+        if value:
+            found.append(FoundDate(m.start(), m.end(), value))
+    for m in _TEXT_RE.finditer(text):
+        month = _MONTHS.get(m.group(2).lower())
+        if month:
+            value = _make(_year(m.group(3), min_year), month, int(m.group(1)))
+            if value:
+                found.append(FoundDate(m.start(), m.end(), value))
+    found.sort(key=lambda f: f.pos)
+    return found
+
+
+def _label_score(text: str, found: FoundDate) -> int:
+    """+2 fuer eine Dokumentdatum-Beschriftung davor, -2 fuer Frist/Geburt & Co."""
+    before = text[max(0, found.pos - _LABEL_WINDOW):found.pos]
+    if _POSITIVE_LABEL_RE.search(before):
+        return 2
+    if _NEGATIVE_LABEL_RE.search(before):
+        return -2
+    return 0
+
+
+def pick_document_date(text: str, found: list[FoundDate] | None = None) -> Optional[datetime]:
+    """Wahrscheinlichstes Dokumentdatum aus dem Text (None, wenn keins gefunden)."""
+    if found is None:
+        found = find_dates(text)
+    if not found:
+        return None
+    best = max(found, key=lambda f: (_label_score(text, f), -f.pos))
+    return best.value
+
+
+def ordered_dates(text: str) -> list[datetime]:
+    """Dokumentdatum zuerst, danach die uebrigen (ohne Doppelte) absteigend.
+
+    Das ist die Reihenfolge, die ``PDFAnalyzer.extract_dates()`` liefert und
+    ueber ``dates[0]`` ueberall als "erkanntes Datum" benutzt wird.
+    """
+    found = find_dates(text)
+    best = pick_document_date(text, found)
+    if best is None:
+        return []
+    others = sorted({f.value for f in found} - {best}, reverse=True)
+    return [best] + others
+
+
+def parse_user_date(text: str) -> Optional[str]:
+    """Markierten/getippten Text als ISO-Datum ``JJJJ-MM-TT`` (oder None).
+
+    Nimmt das erste Datum im Text; "01.03.2004 bis 31.03.2004" ergibt also
+    den 1. Maerz. Jahre ab 1900 sind erlaubt, zweistellige werden ergaenzt.
+    """
+    found = find_dates(text or "", min_year=MIN_USER_YEAR)
+    if not found:
+        return None
+    return found[0].value.strftime("%Y-%m-%d")
+
+
+def is_iso_date(text: str) -> bool:
+    """True fuer genau ``JJJJ-MM-TT`` (gueltiges Datum)."""
+    if not text or len(text) != 10:
+        return False
+    try:
+        datetime.strptime(text, "%Y-%m-%d")
+        return True
+    except ValueError:
+        return False

--- a/src/core/metadata_choices.py
+++ b/src/core/metadata_choices.py
@@ -71,9 +71,13 @@ def normalize_for_field(field_key: str, text: str) -> str:
 
     Leerraum wird immer zusammengefasst; je nach Feld faellt Beiwerk weg:
     IBAN ohne Leerzeichen, Betraege ohne Waehrungszeichen, MwSt ohne "%",
-    Steuerjahr als vierstellige Jahreszahl.
+    Steuerjahr als vierstellige Jahreszahl, Datum als JJJJ-MM-TT (Issue #132;
+    unlesbares bleibt stehen, damit das Feld die Eingabe zeigt).
     """
     text = " ".join((text or "").split())
+    if field_key == "buchungsdatum":
+        from src.core.document_date import parse_user_date
+        return parse_user_date(text) or text
     if field_key == "iban":
         return text.replace(" ", "").upper()
     if field_key in ("betrag_netto", "betrag_brutto"):

--- a/src/core/pdf_analyzer.py
+++ b/src/core/pdf_analyzer.py
@@ -220,66 +220,19 @@ class PDFAnalyzer:
 
     def extract_dates(self) -> list[datetime]:
         """
-        Versucht, Datumsangaben aus dem PDF-Text zu extrahieren.
+        Datumsangaben aus dem PDF-Text - Dokumentdatum zuerst (Issue #132).
+
+        ``dates[0]`` ist das wahrscheinlichste Dokumentdatum (Briefkopf,
+        "Datum:", "Rechnungsdatum", ", den"), nicht mehr das juengste Datum im
+        Text; danach folgen die uebrigen Daten absteigend. Muster und Auswahl
+        stehen in :mod:`src.core.document_date`.
 
         Returns:
             Liste gefundener Datumsangaben
         """
-        text = self.extract_text()
-        dates = []
+        from src.core.document_date import ordered_dates
 
-        # Deutsche Datumsformate
-        patterns = [
-            # DD.MM.YYYY oder DD.MM.YY
-            r'(\d{1,2})\.(\d{1,2})\.(\d{2,4})',
-            # DD/MM/YYYY
-            r'(\d{1,2})/(\d{1,2})/(\d{2,4})',
-            # YYYY-MM-DD (ISO)
-            r'(\d{4})-(\d{1,2})-(\d{1,2})',
-            # Monat ausgeschrieben: 15. Januar 2025
-            r'(\d{1,2})\.\s*(Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\s*(\d{4})',
-        ]
-
-        month_names = {
-            'Januar': 1, 'Februar': 2, 'März': 3, 'April': 4,
-            'Mai': 5, 'Juni': 6, 'Juli': 7, 'August': 8,
-            'September': 9, 'Oktober': 10, 'November': 11, 'Dezember': 12
-        }
-
-        for pattern in patterns[:3]:  # Numerische Patterns
-            matches = re.findall(pattern, text)
-            for match in matches:
-                try:
-                    if pattern.startswith(r'(\d{4})'):  # ISO Format
-                        year, month, day = int(match[0]), int(match[1]), int(match[2])
-                    else:
-                        day, month, year = int(match[0]), int(match[1]), int(match[2])
-
-                    if year < 100:
-                        year += 2000 if year < 50 else 1900
-
-                    if 1 <= day <= 31 and 1 <= month <= 12 and 1990 <= year <= 2100:
-                        dates.append(datetime(year, month, day))
-                except (ValueError, IndexError):
-                    continue
-
-        # Ausgeschriebene Monate
-        matches = re.findall(patterns[3], text, re.IGNORECASE)
-        for match in matches:
-            try:
-                day = int(match[0])
-                month = month_names.get(match[1].capitalize(), 0)
-                year = int(match[2])
-                if month > 0 and 1 <= day <= 31:
-                    dates.append(datetime(year, month, day))
-            except (ValueError, IndexError):
-                continue
-
-        # Duplikate entfernen und sortieren
-        unique_dates = list(set(dates))
-        unique_dates.sort(reverse=True)
-
-        return unique_dates
+        return ordered_dates(self.extract_text())
 
     def extract_keywords(self) -> list[str]:
         """

--- a/src/core/pdf_cache.py
+++ b/src/core/pdf_cache.py
@@ -241,6 +241,7 @@ class LLMSuggestionWorker(QThread):
 
                     # LLM-Vorschläge abrufen
                     from datetime import datetime as dt
+                    from src.ml.hybrid_classifier import source_folder_hint
                     file_mtime = pdf_path.stat().st_mtime
                     file_date = dt.fromtimestamp(file_mtime).strftime("%Y-%m-%d")
 
@@ -262,6 +263,7 @@ class LLMSuggestionWorker(QThread):
                             detected_date=detected_date,
                             use_llm=True,
                             file_date=file_date,
+                            source_folder=source_folder_hint(pdf_path),
                         )
                         llm_ok = True
                     finally:

--- a/src/gui/detail_panel.py
+++ b/src/gui/detail_panel.py
@@ -36,6 +36,7 @@ from PyQt6.QtWidgets import (
 
 logger = logging.getLogger(__name__)
 
+from src.core.document_date import is_iso_date, parse_user_date
 from src.core.llm_activity import (
     KIND_SUGGEST,
     format_elapsed,
@@ -91,6 +92,8 @@ class _LLMMetadataWorker(QThread):
         self._file_date = file_date
 
     def run(self):
+        from src.ml.hybrid_classifier import source_folder_hint
+
         activity = get_llm_activity()
         token = activity.begin(KIND_SUGGEST, self._pdf_path.name)
         ok = False
@@ -102,6 +105,7 @@ class _LLMMetadataWorker(QThread):
                 detected_date=self._detected_date,
                 use_llm=True,
                 file_date=self._file_date,
+                source_folder=source_folder_hint(self._pdf_path),
             )
             ok = True
         except Exception as e:  # noqa: BLE001 - Fehler an die GUI melden
@@ -202,6 +206,10 @@ class DetailPanel(QWidget):
         self._pdf_field_keys: set = set()
         # Flag um textChanged-Signale während des programmatischen Füllens zu ignorieren
         self._loading_metadata: bool = False
+        # Feld "Datum" (Issue #132): letzter lesbarer Wert (fuer "Steuerjahr
+        # folgt dem Datum") und ob der aktuelle Text unlesbar ist
+        self._date_prev_iso: Optional[str] = None
+        self._date_invalid: bool = False
         # KI-Aufruf "Metadaten neu generieren" laeuft im Hintergrund (Issue #68)
         self._llm_worker: Optional[_LLMMetadataWorker] = None
         self._llm_started: Optional[float] = None
@@ -355,6 +363,8 @@ class DetailPanel(QWidget):
         # Grundstil je Feld - fuer die gruene Hervorhebung "neu gegenueber PDF"
         self._field_base_styles: dict[str, str] = {}
         metadata_fields = [
+            ("buchungsdatum", "Datum"),  # Issue #132
+            ("steuerjahr", "Steuerjahr"),
             ("subject", "Kategorie"),
             ("korrespondent", "Korrespondent"),
             ("betrag_netto", "Betrag Netto"),
@@ -362,12 +372,13 @@ class DetailPanel(QWidget):
             ("waehrung", "Währung"),
             ("mwst_satz", "MwSt-Satz"),
             ("iban", "IBAN"),
-            ("steuerjahr", "Steuerjahr"),
             ("description", "Zusammenfassung"),
         ]
+        single_count = len(metadata_fields) - 1  # alle ausser der Zusammenfassung
         # Kurze Erklärung je Feld (Issue #51) - hilft neuen Nutzern, die
         # Bedeutung der Metadaten-Felder ohne Nachfragen zu verstehen.
         field_tooltips = {
+            "buchungsdatum": self._DATE_TOOLTIP,
             "subject": "Kategorie des Dokuments (z.B. Rechnung, Vertrag).",
             "korrespondent": "Absender oder Firma des Dokuments.",
             "betrag_netto": "Rechnungsbetrag ohne MwSt.",
@@ -380,8 +391,8 @@ class DetailPanel(QWidget):
         }
 
         # Zweispaltig, damit unten mehr Platz fuer die PDF-Vorschau bleibt:
-        # Kategorie|Korrespondent, Netto|Brutto, Waehrung|MwSt, IBAN|Steuerjahr;
-        # die Zusammenfassung laeuft ueber die volle Breite.
+        # Datum|Steuerjahr, Kategorie|Korrespondent, Netto|Brutto, Waehrung|MwSt,
+        # IBAN (allein, volle Breite); die Zusammenfassung laeuft ueber die volle Breite.
         grid = QGridLayout()
         grid.setHorizontalSpacing(6)
         grid.setVerticalSpacing(3)
@@ -409,9 +420,16 @@ class DetailPanel(QWidget):
                     input_field = QLineEdit()
                 input_field.setPlaceholderText(f"{field_label}...")
                 input_field.setStyleSheet("font-size: 10px; padding: 2px;")
+                if field_key == "buchungsdatum":
+                    input_field.setPlaceholderText("JJJJ-MM-TT")
+                    # Vor dem allgemeinen textChanged-Handler: Steuerjahr nachziehen
+                    input_field.textChanged.connect(self._on_date_field_changed)
+                    input_field.editingFinished.connect(self._normalize_date_field)
                 row_idx, col = divmod(idx, 2)
+                # Letztes einzelnes Feld ohne Partner (IBAN) ueber die volle Breite
+                span = 3 if (col == 0 and idx == single_count - 1) else 1
                 grid.addWidget(label, row_idx, col * 2)
-                grid.addWidget(input_field, row_idx, col * 2 + 1)
+                grid.addWidget(input_field, row_idx, col * 2 + 1, 1, span)
 
             tooltip = field_tooltips.get(field_key)
             if tooltip:
@@ -558,13 +576,10 @@ class DetailPanel(QWidget):
         if not pdf_had_data:
             if keywords:
                 self._metadata["subject"] = keywords[0].capitalize()
-            if detected_date:
-                try:
-                    year = detected_date[:4]
-                    if year.isdigit():
-                        self._metadata["steuerjahr"] = year
-                except Exception:
-                    pass
+            # Erkanntes Datum ins Feld "Datum" (Issue #132); die KI darf es
+            # mit ihrem "datum" ueberschreiben, das Steuerjahr folgt unten
+            if detected_date and is_iso_date(str(detected_date)[:10]):
+                self._metadata["buchungsdatum"] = str(detected_date)[:10]
 
             # LLM-Metadaten
             for s in self._suggestions:
@@ -589,6 +604,10 @@ class DetailPanel(QWidget):
                         self._has_learned_overrides = True
                 except Exception:
                     pass
+
+            # Steuerjahr = Jahr des Dokumentdatums, solange weder KI noch
+            # Gelerntes ein Jahr gesetzt haben (Issue #132)
+            self._derive_steuerjahr_into(self._metadata)
 
             # Metadaten-Felder befüllen und Quelle setzen
             self._loading_metadata = True
@@ -714,6 +733,8 @@ class DetailPanel(QWidget):
         self._name_from_list = False
         self._name_kind = None
         self._auto_name = ""
+        self._date_prev_iso = None
+        self._date_invalid = False
         self.preview.clear()
 
         self.name_input.clear()
@@ -744,9 +765,19 @@ class DetailPanel(QWidget):
                 value = input_field.toPlainText().strip()
             else:
                 value = input_field.text().strip()
+            if field_key == "buchungsdatum":
+                # Nur ein lesbares Datum wird gespeichert - als JJJJ-MM-TT
+                value = parse_user_date(value) or ""
             if value:
                 metadata[field_key] = value
         return metadata
+
+    def current_date(self) -> Optional[str]:
+        """Datum aus dem Feld "Datum" als JJJJ-MM-TT (None, wenn leer oder unlesbar)."""
+        widget = self._metadata_inputs.get("buchungsdatum")
+        if widget is None:
+            return None
+        return parse_user_date(widget.text())
 
     def has_user_edits(self) -> bool:
         """True, wenn der Nutzer Dateiname oder Metadaten selbst geaendert hat.
@@ -801,6 +832,7 @@ class DetailPanel(QWidget):
 
         # Felder aus PDFMetadata in _metadata-Dict übertragen
         field_map = {
+            "buchungsdatum": pdf_meta.buchungsdatum,
             "subject": pdf_meta.subject,
             "korrespondent": pdf_meta.korrespondent,
             "betrag_netto": pdf_meta.betrag_netto,
@@ -816,6 +848,13 @@ class DetailPanel(QWidget):
             if value:
                 self._metadata[key] = value
                 pdf_keys.add(key)
+        if pdf_keys and "buchungsdatum" not in pdf_keys:
+            # Gespeicherte Metadaten ohne Datum: das Analyse-Datum war nur ein
+            # Vorschlag und soll die PDF nicht als "teilweise gespeichert"
+            # erscheinen lassen (Issue #132). Fuer {datum} in den Mustern
+            # bleibt _detected_date der Rueckfall.
+            if self._metadata.get("buchungsdatum") == str(self._detected_date or "")[:10]:
+                self._metadata.pop("buchungsdatum", None)
         if not pdf_keys:
             # Nur Felder vorhanden, die das Panel nicht anzeigt (z.B. Titel)
             self._saved_metadata_snapshot = {}
@@ -864,6 +903,68 @@ class DetailPanel(QWidget):
             if self._name_from_list:
                 self._apply_name_from_kind()
         self._refresh_save_btn()
+
+    # --- Feld "Datum" (Issue #132) -------------------------------------- #
+
+    _DATE_TOOLTIP = (
+        "Datum des Dokuments (JJJJ-MM-TT) - Quelle für {datum} im Dateinamen\n"
+        "und Vorlage für das Steuerjahr.\n"
+        "Eingabe auch als TT.MM.JJJJ möglich; oder das Datum in der Vorschau\n"
+        "markieren und per Rechtsklick „Als Datum übernehmen“."
+    )
+    _DATE_INVALID_HINT = "\n\nKein Datum erkannt - bitte als JJJJ-MM-TT oder TT.MM.JJJJ eingeben."
+    _INVALID_FIELD_STYLE = " border: 1px solid #d32f2f; background-color: #fdecea; border-radius: 3px;"
+
+    @staticmethod
+    def _derive_steuerjahr_into(metadata: dict) -> None:
+        """Steuerjahr aus dem Datum, wenn noch keins gesetzt ist."""
+        if metadata.get("steuerjahr"):
+            return
+        year = str(metadata.get("buchungsdatum") or "")[:4]
+        if year.isdigit():
+            metadata["steuerjahr"] = year
+
+    def _derive_steuerjahr_from_field(self) -> None:
+        """Leeres Steuerjahr-Feld aus dem Datum-Feld fuellen (nach KI-Ergebnis)."""
+        steuerjahr = self._metadata_inputs.get("steuerjahr")
+        iso = self.current_date()
+        if steuerjahr is not None and iso and not steuerjahr.text().strip():
+            steuerjahr.setText(iso[:4])
+
+    def _on_date_field_changed(self, text: str):
+        """Datum geaendert: Steuerjahr folgt, solange es nicht eigenstaendig gesetzt war.
+
+        "Eigenstaendig" heisst: das Steuerjahr entspricht weder dem Jahr des
+        bisherigen Datums noch ist es leer - dann bleibt es unangetastet.
+        """
+        new_iso = parse_user_date(text)
+        prev_year = (self._date_prev_iso or "")[:4]
+        self._date_prev_iso = new_iso
+        invalid = bool(text.strip()) and new_iso is None
+        if invalid != self._date_invalid:
+            self._date_invalid = invalid
+            widget = self._metadata_inputs.get("buchungsdatum")
+            if widget is not None:
+                widget.setToolTip(self._DATE_TOOLTIP + (self._DATE_INVALID_HINT if invalid else ""))
+            self._highlight_new_fields()
+        if self._loading_metadata or not new_iso:
+            return
+        year = new_iso[:4]
+        steuerjahr = self._metadata_inputs.get("steuerjahr")
+        if steuerjahr is None:
+            return
+        current = steuerjahr.text().strip()
+        if current in ("", prev_year) and current != year:
+            steuerjahr.setText(year)
+
+    def _normalize_date_field(self):
+        """Nach der Eingabe: "12.3.2004" -> "2004-03-12"; Unlesbares bleibt stehen."""
+        widget = self._metadata_inputs.get("buchungsdatum")
+        if widget is None:
+            return
+        iso = parse_user_date(widget.text())
+        if iso and widget.text().strip() != iso:
+            widget.setText(iso)
 
     def _on_name_typed(self, _text: str):
         """Nutzer tippt im Namensfeld: ab jetzt keine automatische Nachfuehrung."""
@@ -968,6 +1069,8 @@ class DetailPanel(QWidget):
                 value = widget.text().strip()
             is_new = compare and bool(value) and value != self._saved_metadata_snapshot.get(key)
             style = self._field_base_styles.get(key, "") + (self._NEW_FIELD_STYLE if is_new else "")
+            if key == "buchungsdatum" and self._date_invalid:
+                style = self._field_base_styles.get(key, "") + self._INVALID_FIELD_STYLE
             if widget.styleSheet() != style:
                 widget.setStyleSheet(style)
             if isinstance(widget, _CategoryCombo):
@@ -1133,6 +1236,10 @@ class DetailPanel(QWidget):
         else:
             widget.setText(text)
         widget.setFocus()
+        if field_key == "buchungsdatum" and not is_iso_date(text):
+            # Kein Datum erkannt: Feld zeigt die Markierung rot mit Hinweis,
+            # die naechste Eingabe ersetzt sie (Issue #132)
+            widget.selectAll()
         if field_key == "korrespondent":
             self._learn_korrespondent(text)
 
@@ -1250,7 +1357,8 @@ class DetailPanel(QWidget):
         except Exception:
             pass
 
-        doc_date = self._detected_date
+        # Feld "Datum" ist die Quelle fuer {datum} (Issue #132), dann Analyse
+        doc_date = self.current_date() or self._detected_date
         if not doc_date:
             # Rueckfall: fuehrendes Datum eines KI-Vorschlags (YYYY-MM-DD)
             for s in self._suggestions:
@@ -1427,7 +1535,7 @@ class DetailPanel(QWidget):
             if not classifier.is_llm_available():
                 return
 
-            detected_date = self._metadata.get("buchungsdatum")
+            detected_date = self.current_date() or self._detected_date
 
             from datetime import datetime
             file_date = None
@@ -1535,6 +1643,7 @@ class DetailPanel(QWidget):
                                             w.setText(str(lv))
                         except Exception:
                             pass
+                    self._derive_steuerjahr_from_field()
                     self._loading_metadata = False
                     self._metadata_source = "llm"
                     self._couple_name_to_llm(s.filename)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -53,9 +53,21 @@ from src.gui.setup_wizard import SetupWizard
 from src.gui.korrespondent_sidebar import KorrespondentSidebar
 from src.core.file_manager import FileManager, FolderManager
 from src.core.folder_naming import DEFAULT_TEMPLATE, build_folder_based_name, coerce_date
+
+
+def _iso_to_date(value):
+    """"JJJJ-MM-TT" -> date (None bei leer/unlesbar), Issue #132."""
+    from datetime import date as _date
+
+    if not value:
+        return None
+    try:
+        return _date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
 from src.core.pdf_cache import get_pdf_cache, PDFAnalysisResult
 from src.ml.classifier import get_classifier, Suggestion
-from src.ml.hybrid_classifier import get_hybrid_classifier
+from src.ml.hybrid_classifier import get_hybrid_classifier, source_folder_hint
 from src.gui.chat_view import ChatView
 
 
@@ -2026,10 +2038,11 @@ class MainWindow(QMainWindow):
         # Dateiname aus Ordnerstruktur aufbauen (Issue #42, Opt-in)
         if self.config.get("folder_naming_enabled", False):
             folder_naming_applied = True
-            fallback_date = (
-                coerce_date(self.selected_pdf_dates[0])
-                if self.selected_pdf_dates else None
-            )
+            # Datum aus dem Feld "Datum" des Detail-Panels (Issue #132),
+            # sonst das erkannte Datum der Analyse
+            fallback_date = _iso_to_date(metadata.get("buchungsdatum") if metadata else None)
+            if fallback_date is None and self.selected_pdf_dates:
+                fallback_date = coerce_date(self.selected_pdf_dates[0])
             new_name = build_folder_based_name(
                 new_name or pdf_path.name,
                 folder_path,
@@ -2104,8 +2117,9 @@ class MainWindow(QMainWindow):
 
             # Umbenennung lernen (falls Name geändert)
             if name_changed:
-                detected_date = None
-                if self.selected_pdf_dates:
+                # Vom Nutzer bestaetigtes/korrigiertes Datum (Issue #132) vor dem erkannten
+                detected_date = metadata.get("buchungsdatum") if metadata else None
+                if not detected_date and self.selected_pdf_dates:
                     try:
                         d = self.selected_pdf_dates[0]
                         detected_date = d.strftime("%Y-%m-%d") if hasattr(d, 'strftime') else str(d)
@@ -2377,6 +2391,8 @@ class MainWindow(QMainWindow):
             if dialog_metadata:
                 if dialog_metadata.get("subject"):
                     metadata.subject = dialog_metadata["subject"]
+                if dialog_metadata.get("buchungsdatum"):
+                    metadata.buchungsdatum = dialog_metadata["buchungsdatum"]
                 if dialog_metadata.get("korrespondent"):
                     metadata.korrespondent = dialog_metadata["korrespondent"]
                 if dialog_metadata.get("betrag_netto"):
@@ -2602,6 +2618,7 @@ class MainWindow(QMainWindow):
                     detected_date=detected_date_str,
                     use_llm=True,
                     file_date=file_date,
+                    source_folder=source_folder_hint(pdf_path),
                 )
 
                 # LLM-Vorschläge zu den Suggestions hinzufügen
@@ -3127,6 +3144,7 @@ class MainWindow(QMainWindow):
                     detected_date=detected_date,
                     use_llm=True,
                     file_date=file_date,
+                    source_folder=source_folder_hint(pdf_path),
                 )
 
                 # Besten LLM-Vorschlag finden
@@ -3914,6 +3932,7 @@ class MainWindow(QMainWindow):
                             detected_date=detected_date,
                             use_llm=True,
                             file_date=file_date,
+                            source_folder=source_folder_hint(pdf_path),
                         )
                         for s in suggestions:
                             if s.source == "llm" and s.metadata:

--- a/src/gui/pdf_preview_widget.py
+++ b/src/gui/pdf_preview_widget.py
@@ -54,6 +54,7 @@ SELECTION_TARGETS: tuple[tuple[str, str], ...] = (
     ("waehrung", "Als Währung übernehmen"),
     ("mwst_satz", "Als MwSt-Satz übernehmen"),
     ("iban", "Als IBAN übernehmen"),
+    ("buchungsdatum", "Als Datum übernehmen"),  # Issue #132
     ("steuerjahr", "Als Steuerjahr übernehmen"),
 )
 
@@ -237,7 +238,7 @@ class PdfPreviewWidget(QWidget):
         self._view.viewport().installEventFilter(self)
         self._view.setToolTip(
             "Text mit der Maus markieren, dann Rechtsklick: "
-            "in ein Metadaten-Feld übernehmen (Korrespondent, Betrag, IBAN, ...)."
+            "in ein Metadaten-Feld übernehmen (Datum, Korrespondent, Betrag, IBAN, ...)."
         )
         self._stack.addWidget(self._view)
 

--- a/src/gui/rename_dialog.py
+++ b/src/gui/rename_dialog.py
@@ -65,8 +65,9 @@ class RenameDialog(QDialog):
         if keywords:
             self._metadata["subject"] = keywords[0].capitalize()
         if detected_date:
-            # Steuerjahr aus Datum ableiten
+            # Datum ins Feld, Steuerjahr aus Datum ableiten (Issue #132)
             try:
+                self._metadata["buchungsdatum"] = str(detected_date)[:10]
                 year = detected_date[:4]
                 if year.isdigit():
                     self._metadata["steuerjahr"] = year
@@ -181,6 +182,7 @@ class RenameDialog(QDialog):
         # Metadaten-Felder als editierbare Eingabefelder
         self._metadata_inputs = {}
         metadata_field_labels = [
+            ("buchungsdatum", "Datum"),
             ("subject", "Kategorie"),
             ("korrespondent", "Korrespondent"),
             ("betrag", "Betrag"),
@@ -428,8 +430,8 @@ class RenameDialog(QDialog):
             self.llm_metadata_btn.setText("KI arbeitet...")
             QApplication.processEvents()
 
-            # Datum ermitteln
-            detected_date = self._metadata.get("buchungsdatum")
+            # Datum ermitteln - Feld "Datum" vor dem Analyse-Wert (Issue #132)
+            detected_date = self.get_metadata().get("buchungsdatum") or self._metadata.get("buchungsdatum")
 
             # Datei-Änderungsdatum als Fallback
             from datetime import datetime
@@ -441,6 +443,7 @@ class RenameDialog(QDialog):
                 pass
 
             # LLM aufrufen
+            from src.ml.hybrid_classifier import source_folder_hint
             llm_suggestions = classifier.suggest_filename(
                 text=self.extracted_text or "",
                 current_filename=self.pdf_path.name,
@@ -448,6 +451,7 @@ class RenameDialog(QDialog):
                 detected_date=detected_date,
                 use_llm=True,
                 file_date=file_date,
+                source_folder=source_folder_hint(self.pdf_path),
             )
 
             # Metadaten aus LLM-Antwort übernehmen
@@ -503,11 +507,14 @@ class RenameDialog(QDialog):
         """Gibt die eingegebenen/bestätigten Metadaten zurück."""
         from PyQt6.QtWidgets import QPlainTextEdit
         metadata = {}
+        from src.core.document_date import parse_user_date
         for field_key, input_field in self._metadata_inputs.items():
             if isinstance(input_field, QPlainTextEdit):
                 value = input_field.toPlainText().strip()
             else:
                 value = input_field.text().strip()
+            if field_key == "buchungsdatum":
+                value = parse_user_date(value) or ""  # nur ein echtes Datum wird gespeichert
             if value:
                 metadata[field_key] = value
         return metadata

--- a/src/ml/claude_provider.py
+++ b/src/ml/claude_provider.py
@@ -181,6 +181,7 @@ class ClaudeProvider(LLMProvider):
         target_folder: str = None,
         file_date: str = None,
         examples: list[str] | None = None,
+        source_folder: str | None = None,
     ) -> LLMResponse:
         """
         Schlägt einen Dateinamen mit Claude vor.
@@ -204,7 +205,7 @@ class ClaudeProvider(LLMProvider):
 
         prompt = self._build_filename_prompt(
             text, current_filename, keywords, detected_date, target_folder, file_date,
-            examples=examples,
+            examples=examples, source_folder=source_folder,
         )
 
         try:

--- a/src/ml/hybrid_classifier.py
+++ b/src/ml/hybrid_classifier.py
@@ -26,6 +26,22 @@ from src.utils.database import get_database
 logger = logging.getLogger(__name__)
 
 
+def source_folder_hint(pdf_path) -> Optional[str]:
+    """Name des Ordners, in dem die PDF liegt - als Hinweis fuer den KI-Prompt (Issue #132).
+
+    "Briefe 2004" verraet das Jahr, wenn OCR das Datum nicht lesen konnte.
+    Fuer den Scan-Ordner selbst (Posteingang) gibt es keinen Hinweis.
+    """
+    try:
+        parent = Path(pdf_path).parent
+        scan_root = get_config().get_scan_folder()
+        if scan_root and parent.resolve() == Path(scan_root).resolve():
+            return None
+        return parent.name or None
+    except Exception:
+        return None
+
+
 @dataclass
 class HybridSuggestion:
     """Ein Sortiervorschlag aus dem Hybrid-System."""
@@ -370,6 +386,7 @@ class HybridClassifier:
         target_folder: str = None,
         use_llm: bool = None,
         file_date: str = None,
+        source_folder: str = None,
     ) -> list[HybridFilename]:
         """
         Schlägt Dateinamen für ein Dokument vor.
@@ -382,6 +399,7 @@ class HybridClassifier:
             target_folder: Zielordner
             use_llm: LLM verwenden?
             file_date: Änderungsdatum der Datei (Fallback)
+            source_folder: Name des Quellordners als Hinweis fuer die KI (Issue #132)
 
         Returns:
             Liste von Dateinamenvorschlägen
@@ -403,7 +421,8 @@ class HybridClassifier:
         # 2. LLM-Vorschlag wenn gewünscht
         if (use_llm or use_llm is None) and self.llm_enabled:
             llm_suggestion = self._get_llm_filename_suggestion(
-                text, current_filename, keywords, detected_date, target_folder, file_date
+                text, current_filename, keywords, detected_date, target_folder, file_date,
+                source_folder,
             )
             if llm_suggestion:
                 # LLM-Vorschlag an erster Stelle wenn Konfidenz hoch
@@ -480,6 +499,7 @@ class HybridClassifier:
         detected_date: str,
         target_folder: str,
         file_date: str = None,
+        source_folder: str = None,
     ) -> Optional[HybridFilename]:
         """Holt einen Dateinamenvorschlag vom LLM."""
         if not self.llm_provider:
@@ -494,6 +514,7 @@ class HybridClassifier:
             target_folder=target_folder,
             file_date=file_date,
             examples=self._rename_examples(text, keywords),
+            source_folder=source_folder,
         )
 
         self.total_tokens_used += response.tokens_used

--- a/src/ml/llm_provider.py
+++ b/src/ml/llm_provider.py
@@ -84,6 +84,12 @@ METADATA_KEY_ALIASES: dict[str, str] = {
     "steuerjahr": "steuerjahr",
     "jahr": "steuerjahr",
     "year": "steuerjahr",
+    # Dokumentdatum (Issue #132) - Feld "Datum" im Detail-Panel
+    "datum": "buchungsdatum",
+    "buchungsdatum": "buchungsdatum",
+    "dokumentdatum": "buchungsdatum",
+    "date": "buchungsdatum",
+    "document_date": "buchungsdatum",
 }
 
 # Platzhalter, die Modelle fuer "nicht vorhanden" liefern - werden verworfen
@@ -116,6 +122,25 @@ def drop_unsupported_mwst(metadata: dict, document_text: str | None) -> dict:
         return metadata
     result = dict(metadata)
     del result["mwst_satz"]
+    return result
+
+
+def normalize_metadata_date(metadata: dict) -> dict:
+    """Bringt ``buchungsdatum`` auf ``JJJJ-MM-TT``; Unlesbares faellt weg (Issue #132).
+
+    Modelle liefern das Datum mal als "12.03.2004", mal als "2004-03-12" -
+    das Feld "Datum" und die Platzhalter erwarten ISO.
+    """
+    if not isinstance(metadata, dict) or "buchungsdatum" not in metadata:
+        return metadata
+    from src.core.document_date import parse_user_date
+
+    result = dict(metadata)
+    iso = parse_user_date(str(result.get("buchungsdatum") or ""))
+    if iso:
+        result["buchungsdatum"] = iso
+    else:
+        del result["buchungsdatum"]
     return result
 
 
@@ -256,6 +281,7 @@ class LLMProvider(ABC):
         target_folder: str = None,
         file_date: str = None,
         examples: list[str] | None = None,
+        source_folder: str | None = None,
     ) -> LLMResponse:
         """
         Schlägt einen Dateinamen für das Dokument vor.
@@ -268,6 +294,7 @@ class LLMProvider(ABC):
             target_folder: Zielordner (falls bekannt)
             file_date: Änderungsdatum der Datei (Fallback wenn kein Datum im Dokument)
             examples: Dateinamen, die der Nutzer fuer aehnliche Dokumente gewaehlt hat
+            source_folder: Name des Ordners, in dem die PDF liegt (Hinweis, Issue #132)
 
         Returns:
             LLMResponse mit Dateinamenvorschlag und Begründung
@@ -413,6 +440,7 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
         target_folder: str = None,
         file_date: str = None,
         examples: list[str] | None = None,
+        source_folder: str | None = None,
     ) -> str:
         """
         Erstellt den Prompt für Dateinamenvorschläge.
@@ -425,6 +453,7 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
             target_folder: Zielordner (falls bekannt)
             file_date: Änderungsdatum der Datei (Fallback wenn kein Datum im Dokument)
             examples: Dateinamen aehnlicher Dokumente aus der Historie (Stil-Beispiele)
+            source_folder: Name des Quellordners (z.B. "Briefe 2004") als Hinweis
 
         Returns:
             Formatierter Prompt (JSON Format gefordert)
@@ -435,15 +464,27 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
 
         date_info = ""
         if detected_date:
-            date_info = f"\nErkanntes Datum im Dokument: {detected_date}"
+            date_info = (
+                "\nErkanntes Datum im Dokument (Hinweis aus der Texterkennung, "
+                f"bitte am Text pruefen): {detected_date}"
+            )
 
         file_date_info = ""
         if file_date:
-            file_date_info = f"\nÄnderungsdatum der Datei (Scandatum): {file_date}"
+            file_date_info = (
+                "\nÄnderungsdatum der Datei (Scandatum; nur Notloesung, falls das "
+                f"Dokument selbst kein Datum nennt): {file_date}"
+            )
 
         folder_info = ""
         if target_folder:
             folder_info = f"\nZielordner: {target_folder}"
+
+        # Issue #132: "Briefe 2004" verraet oft das Jahr, wenn OCR das Datum
+        # nicht lesen konnte - nur ein Hinweis, der Dokumenttext hat Vorrang
+        source_info = ""
+        if source_folder:
+            source_info = f"\nQuellordner (kann auf Zeitraum oder Thema hinweisen): {source_folder}"
 
         owner_info = self._build_owner_info()
         pattern_info = self._build_filename_pattern_info()
@@ -456,7 +497,7 @@ AKTUELLER DATEINAME: {current_filename}
 
 DOKUMENTINHALT:
 {self._truncate_text(text)}
-{keyword_info}{date_info}{file_date_info}{folder_info}
+{keyword_info}{date_info}{file_date_info}{folder_info}{source_info}
 {pattern_info}{examples_info}
 
 REGELN FÜR DEN DATEINAMEN:
@@ -465,7 +506,11 @@ REGELN FÜR DEN DATEINAMEN:
    Leerzeichen nur dort, wo das Muster eines vorgibt.
    Kein Punkt ausser vor .pdf, kein @-Zeichen: keine E-Mail-Adressen, URLs oder Versionsnummern wie 1.2.
 3. Maximal 80 Zeichen (ohne .pdf).
-4. Datum aus dem Dokument verwenden! Wenn kein Datum vorhanden, nutze das Scandatum.
+4. Datum = Datum des Dokuments selbst (Briefdatum, Rechnungs- oder Ausstellungsdatum),
+   nicht Fristen, Faelligkeits-, Gueltigkeits- oder Geburtsdaten. Das erkannte Datum ist
+   nur ein Hinweis. Erst wenn das Dokument gar kein Datum nennt, nutze das Scandatum.
+   Steuerjahr = Jahr des Dokumentdatums, ausser das Dokument betrifft ausdruecklich ein
+   anderes Jahr (z.B. Steuerbescheid fuer 2003).
 5. Kontakt/Absender/Korrespondent ist immer der NAME einer Person oder Organisation
    (z.B. Kathrin_Haerle, Agentur_fuer_Arbeit, HUK-Coburg), niemals eine E-Mail-Adresse,
    Telefonnummer, IBAN oder Web-Adresse. Steht nur eine E-Mail-Adresse im Dokument,
@@ -492,6 +537,7 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
     "waehrung": "EUR/USD oder UNBEKANNT",
     "mwst": "19 oder 7 oder UNBEKANNT",
     "iban": "IBAN oder UNBEKANNT",
+    "datum": "JJJJ-MM-TT (Datum des Dokuments) oder UNBEKANNT",
     "steuerjahr": "JJJJ oder UNBEKANNT",
     "beschreibung": "Zusammenfassung in einem Satz"
   }}
@@ -630,9 +676,9 @@ Antworte AUSSCHLIESSLICH mit einem validen JSON-Objekt im folgenden Format:
 
             # Metadaten-Schluessel vereinheitlichen (beschreibung -> description, ...)
             if "metadata" in data:
-                data["metadata"] = drop_unsupported_mwst(
+                data["metadata"] = normalize_metadata_date(drop_unsupported_mwst(
                     normalize_llm_metadata(data.get("metadata")), document_text
-                )
+                ))
 
             return data, None
         except json.JSONDecodeError as e:

--- a/src/ml/ollama_provider.py
+++ b/src/ml/ollama_provider.py
@@ -299,13 +299,14 @@ class OllamaProvider(LLMProvider):
         target_folder: str = None,
         file_date: str = None,
         examples: list[str] | None = None,
+        source_folder: str | None = None,
     ) -> LLMResponse:
         if not self.is_available():
             return LLMResponse(success=False, error_message="Ollama-Provider nicht konfiguriert.")
 
         prompt = self._build_filename_prompt(
             text, current_filename, keywords, detected_date, target_folder, file_date,
-            examples=examples,
+            examples=examples, source_folder=source_folder,
         )
         system_prompt = "Du bist ein Assistent zum Benennen von Dokumenten. Antworte AUSSCHLIESSLICH mit einem validem JSON-Objekt."
 

--- a/src/ml/openai_provider.py
+++ b/src/ml/openai_provider.py
@@ -192,6 +192,7 @@ class OpenAIProvider(LLMProvider):
         target_folder: str = None,
         file_date: str = None,
         examples: list[str] | None = None,
+        source_folder: str | None = None,
     ) -> LLMResponse:
         """
         Schlägt einen Dateinamen mit OpenAI vor.
@@ -215,7 +216,7 @@ class OpenAIProvider(LLMProvider):
 
         prompt = self._build_filename_prompt(
             text, current_filename, keywords, detected_date, target_folder, file_date,
-            examples=examples,
+            examples=examples, source_folder=source_folder,
         )
 
         try:

--- a/src/ml/poe_provider.py
+++ b/src/ml/poe_provider.py
@@ -226,6 +226,7 @@ class PoeProvider(LLMProvider):
         target_folder: str = None,
         file_date: str = None,
         examples: list[str] | None = None,
+        source_folder: str | None = None,
     ) -> LLMResponse:
         """
         Schlägt einen Dateinamen mit Poe vor.
@@ -249,7 +250,7 @@ class PoeProvider(LLMProvider):
 
         prompt = self._build_filename_prompt(
             text, current_filename, keywords, detected_date, target_folder, file_date,
-            examples=examples,
+            examples=examples, source_folder=source_folder,
         )
 
         try:

--- a/tests/test_detail_panel_datum_gui.py
+++ b/tests/test_detail_panel_datum_gui.py
@@ -1,0 +1,172 @@
+"""Issue #132: Feld "Datum" im Detail-Panel.
+
+Das Datum ist die eine Quelle fuer {datum} in den Mustern, belegt das
+Steuerjahr vor und laesst sich aus der Vorschau uebernehmen oder tippen.
+"""
+from PyQt6.QtWidgets import QLineEdit
+
+from src.gui.rename_dialog import RenameSuggestion
+
+MUSTER = "{datum}_{kategorie}_{kontakt}"
+
+
+def _panel(qtbot, monkeypatch, tmp_path, pdf_meta=None, **config_values):
+    """Panel mit eigener Config/DB. ``pdf_meta``: PDFMetadata, die der
+    XMP-Reader (echter Thread, wie in der App nach set_pdf) liefern soll."""
+    from src.utils import config as cfg_mod
+    from src.utils.config import Config
+    cfg = Config.__new__(Config)
+    cfg.config_path = tmp_path / "config.json"
+    cfg._config = {}
+    cfg.load()
+    for key, value in config_values.items():
+        cfg.set(key, value, auto_save=False)
+    monkeypatch.setattr(cfg_mod, "get_config", lambda: cfg)
+    from src.utils.database import Database
+    db = Database(db_path=tmp_path / "panel.db")
+    monkeypatch.setattr("src.utils.database.get_database", lambda: db)
+    cfg._db = db
+
+    from src.gui import detail_panel as dp
+    monkeypatch.setattr("src.core.pdf_metadata.read_metadata", lambda p: pdf_meta)
+    if pdf_meta is None:
+        # Kein Hintergrund-Thread noetig: synchron ohne Ergebnis
+        monkeypatch.setattr(dp._PdfMetadataReader, "start", lambda self: self.run())
+    monkeypatch.setattr(dp.PdfPreviewWidget, "load_pdf", lambda self, path: None)
+    panel = dp.DetailPanel()
+    qtbot.addWidget(panel)
+    return panel
+
+
+def _show(panel, tmp_path, suggestions=None, detected_date="2004-03-12"):
+    pdf = tmp_path / "brief.pdf"
+    pdf.write_bytes(b"%PDF")
+    panel.set_pdf(pdf_path=pdf, suggestions=suggestions or [], extracted_text="Brief",
+                  keywords=["rechnung"], detected_date=detected_date)
+    return pdf
+
+
+def _rows(panel):
+    lst = panel.suggestions_list
+    return [lst.item(i).text() for i in range(lst.count())]
+
+
+def test_datum_feld_wird_aus_analyse_vorbelegt_und_steuerjahr_folgt(qtbot, monkeypatch, tmp_path):
+    panel = _panel(qtbot, monkeypatch, tmp_path)
+    _show(panel, tmp_path)
+    datum = panel._metadata_inputs["buchungsdatum"]
+    assert isinstance(datum, QLineEdit)
+    assert datum.text() == "2004-03-12"
+    assert panel._metadata_inputs["steuerjahr"].text() == "2004"
+    assert panel.get_metadata()["buchungsdatum"] == "2004-03-12"
+    assert panel.current_date() == "2004-03-12"
+
+
+def test_ki_datum_schlaegt_analyse_datum(qtbot, monkeypatch, tmp_path):
+    panel = _panel(qtbot, monkeypatch, tmp_path)
+    ki = RenameSuggestion("2004-03-12_Brief_Finanzamt.pdf", "KI-Vorschlag", 0.9,
+                          metadata={"buchungsdatum": "2004-03-12", "subject": "Brief"})
+    # Analyse hat das juengere Datum (Frist) erwischt, die KI das Briefdatum
+    _show(panel, tmp_path, suggestions=[ki], detected_date="2006-06-30")
+    assert panel._metadata_inputs["buchungsdatum"].text() == "2004-03-12"
+    assert panel._metadata_inputs["steuerjahr"].text() == "2004"
+
+
+def test_steuerjahr_folgt_dem_datum_solange_es_nicht_eigenstaendig_ist(qtbot, monkeypatch, tmp_path):
+    panel = _panel(qtbot, monkeypatch, tmp_path)
+    _show(panel, tmp_path)
+    datum = panel._metadata_inputs["buchungsdatum"]
+    steuerjahr = panel._metadata_inputs["steuerjahr"]
+
+    datum.setText("2005-01-31")
+    assert steuerjahr.text() == "2005"
+
+    # Nutzer setzt das Steuerjahr bewusst anders (Bescheid fuer ein Vorjahr)
+    steuerjahr.setText("2003")
+    datum.setText("2006-02-02")
+    assert steuerjahr.text() == "2003"
+
+    # Leeres Steuerjahr wird wieder gefuellt
+    steuerjahr.setText("")
+    datum.setText("2007-07-07")
+    assert steuerjahr.text() == "2007"
+
+
+def test_eingabe_in_anderem_format_wird_beim_verlassen_normalisiert(qtbot, monkeypatch, tmp_path):
+    panel = _panel(qtbot, monkeypatch, tmp_path)
+    _show(panel, tmp_path)
+    datum = panel._metadata_inputs["buchungsdatum"]
+    datum.setText("12.3.2005")
+    # Schon vor dem Verlassen liefert get_metadata ISO
+    assert panel.get_metadata()["buchungsdatum"] == "2005-03-12"
+    datum.editingFinished.emit()
+    assert datum.text() == "2005-03-12"
+    assert panel._metadata_inputs["steuerjahr"].text() == "2005"
+
+
+def test_unlesbares_datum_wird_nicht_gespeichert_und_rot_markiert(qtbot, monkeypatch, tmp_path):
+    panel = _panel(qtbot, monkeypatch, tmp_path)
+    _show(panel, tmp_path)
+    datum = panel._metadata_inputs["buchungsdatum"]
+    datum.setText("Rechnung Nr. 12")
+    assert "buchungsdatum" not in panel.get_metadata()
+    assert panel.current_date() is None
+    assert "#d32f2f" in datum.styleSheet()
+    assert "Kein Datum erkannt" in datum.toolTip()
+    # Steuerjahr bleibt vom letzten lesbaren Datum
+    assert panel._metadata_inputs["steuerjahr"].text() == "2004"
+
+    datum.setText("2004-04-04")
+    assert "#d32f2f" not in datum.styleSheet()
+    assert "Kein Datum erkannt" not in datum.toolTip()
+
+
+def test_markierter_text_aus_der_vorschau_wird_als_datum_uebernommen(qtbot, monkeypatch, tmp_path):
+    panel = _panel(qtbot, monkeypatch, tmp_path)
+    _show(panel, tmp_path)
+    panel.apply_preview_text("buchungsdatum", "München, den 12. März 2004")
+    assert panel._metadata_inputs["buchungsdatum"].text() == "2004-03-12"
+
+    # Kein Datum in der Markierung: Text steht rot im Feld, Eingabe ersetzt ihn
+    panel.apply_preview_text("buchungsdatum", "Sehr geehrte Damen")
+    datum = panel._metadata_inputs["buchungsdatum"]
+    assert datum.text() == "Sehr geehrte Damen"
+    assert datum.selectedText() == "Sehr geehrte Damen"
+    assert "#d32f2f" in datum.styleSheet()
+    assert "buchungsdatum" not in panel.get_metadata()
+
+
+def test_muster_vorschlag_nimmt_das_datum_aus_dem_feld(qtbot, monkeypatch, tmp_path):
+    panel = _panel(qtbot, monkeypatch, tmp_path, filename_pattern=MUSTER)
+    _show(panel, tmp_path)
+    panel._metadata_inputs["korrespondent"].setText("Finanzamt")
+    assert any(row.startswith("2004-03-12_Rechnung_Finanzamt") for row in _rows(panel)), _rows(panel)
+
+    panel._metadata_inputs["buchungsdatum"].setText("1999-12-31")
+    rows = _rows(panel)
+    assert any(row.startswith("1999-12-31_Rechnung_Finanzamt") for row in rows), rows
+    assert not any(row.startswith("2004-03-12_") for row in rows)
+
+
+def test_pdf_metadaten_ohne_datum_verwerfen_das_analyse_datum(qtbot, monkeypatch, tmp_path):
+    """Bereits sortierte PDFs sollen nicht wegen des Analyse-Datums als
+    'teilweise gespeichert' erscheinen; {datum} faellt auf die Analyse zurueck."""
+    from src.core.pdf_metadata import PDFMetadata
+    meta = PDFMetadata(); meta.subject = "Brief"; meta.steuerjahr = "2004"; meta.korrespondent = "Amt"
+    panel = _panel(qtbot, monkeypatch, tmp_path, pdf_meta=meta, filename_pattern=MUSTER)
+    _show(panel, tmp_path, detected_date="2006-06-30")
+    qtbot.waitUntil(lambda: panel._metadata_source == "pdf", timeout=5000)
+    assert panel._metadata_inputs["buchungsdatum"].text() == ""
+    assert panel._metadata_inputs["steuerjahr"].text() == "2004"
+    assert not panel.save_metadata_btn.isEnabled()
+    assert any(row.startswith("2006-06-30_Brief_Amt") for row in _rows(panel)), _rows(panel)
+
+
+def test_gespeichertes_datum_kommt_aus_der_pdf(qtbot, monkeypatch, tmp_path):
+    from src.core.pdf_metadata import PDFMetadata
+    meta = PDFMetadata(); meta.buchungsdatum = "2004-03-12"; meta.steuerjahr = "2004"; meta.subject = "Brief"
+    panel = _panel(qtbot, monkeypatch, tmp_path, pdf_meta=meta)
+    _show(panel, tmp_path, detected_date="2006-06-30")
+    qtbot.waitUntil(lambda: panel._metadata_source == "pdf", timeout=5000)
+    assert panel._metadata_inputs["buchungsdatum"].text() == "2004-03-12"
+    assert "buchungsdatum" in panel._saved_metadata_snapshot

--- a/tests/test_document_date.py
+++ b/tests/test_document_date.py
@@ -1,0 +1,107 @@
+"""Issue #132: Dokumentdatum finden, auswaehlen und Nutzereingaben parsen.
+
+Vorher galt "das juengste Datum im Text ist das Dokumentdatum" - eine Frist
+oder ein Eingangsstempel machte aus einem Brief von 2004 ein Dokument von
+2006, und das Steuerjahr folgte.
+"""
+from datetime import datetime
+
+import pytest
+
+from src.core.document_date import (
+    find_dates,
+    is_iso_date,
+    ordered_dates,
+    parse_user_date,
+    pick_document_date,
+)
+
+
+# --- find_dates -----------------------------------------------------------
+
+def test_find_dates_liefert_alle_formate_in_lesereihenfolge():
+    text = "Stand 2004-03-12, Brief vom 15.03.2004, Frist 1. April 2004, alt 31/12/99"
+    values = [f.value for f in find_dates(text)]
+    assert values == [
+        datetime(2004, 3, 12), datetime(2004, 3, 15), datetime(2004, 4, 1), datetime(1999, 12, 31),
+    ]
+
+
+def test_find_dates_ignoriert_unmoegliche_und_zu_alte_daten():
+    assert find_dates("31.02.2004 und 12.13.2004 und 01.01.1234 und 1.2.1985") == []
+
+
+def test_find_dates_nicht_mitten_in_ziffernfolgen():
+    # Telefonnummern / Aktenzeichen sollen keine Daten liefern
+    assert find_dates("Az. 4711.03.2004567") == []
+
+
+# --- pick_document_date ---------------------------------------------------
+
+def test_erstes_datum_schlaegt_juengeres_datum():
+    text = "Muenchen, 12.03.2004\n\nSehr geehrte Damen und Herren,\nbitte antworten Sie bis 30.06.2006."
+    assert pick_document_date(text) == datetime(2004, 3, 12)
+
+
+def test_beschriftetes_datum_schlaegt_frueheres_datum():
+    text = "Ihr Schreiben vom 02.01.2004\nRechnungsdatum: 20.02.2004\nLieferung bis 15.03.2004"
+    assert pick_document_date(text) == datetime(2004, 2, 20)
+
+
+def test_ort_komma_den_gilt_als_briefdatum():
+    text = "Vertrag Nr. 7 gueltig ab 01.01.2003\nBerlin, den 5. Maerz 2004\nMit freundlichen Gruessen"
+    assert pick_document_date(text) == datetime(2004, 3, 5)
+
+
+@pytest.mark.parametrize("label", ["geboren am", "geb.", "gueltig bis", "faellig am", "Frist:", "Eingang", "bis zum"])
+def test_negative_beschriftung_zaehlt_nur_als_notnagel(label):
+    text = f"{label} 01.02.2005 ... Rechnung ... 15.03.2004"
+    assert pick_document_date(text) == datetime(2004, 3, 15)
+
+
+def test_negativ_beschriftetes_datum_bleibt_wenn_es_das_einzige_ist():
+    assert pick_document_date("Frist: 01.02.2005") == datetime(2005, 2, 1)
+
+
+def test_kein_datum():
+    assert pick_document_date("Kein Datum hier") is None
+    assert ordered_dates("") == []
+
+
+def test_ordered_dates_dokumentdatum_zuerst_dann_absteigend_ohne_doppelte():
+    text = "12.03.2004 ... bis 30.06.2006 ... 12.03.2004 ... 01.01.2005"
+    assert ordered_dates(text) == [
+        datetime(2004, 3, 12), datetime(2006, 6, 30), datetime(2005, 1, 1),
+    ]
+
+
+# --- parse_user_date / is_iso_date ------------------------------------------
+
+@pytest.mark.parametrize("text, iso", [
+    ("12.03.2004", "2004-03-12"),
+    ("12.3.04", "2004-03-12"),
+    ("1.1.99", "1999-01-01"),
+    ("2004-03-12", "2004-03-12"),
+    ("2004-03-12 00:00:00", "2004-03-12"),
+    ("12. März 2004", "2004-03-12"),
+    ("12 Maerz 2004", "2004-03-12"),
+    ("3. Jan. 2025", "2025-01-03"),
+    ("Muenchen, den 12.03.2004", "2004-03-12"),
+    ("01.03.2004 bis 31.03.2004", "2004-03-01"),
+    ("15.08.1975", "1975-08-15"),  # Nutzereingaben duerfen vor 1990 liegen
+])
+def test_parse_user_date(text, iso):
+    assert parse_user_date(text) == iso
+
+
+@pytest.mark.parametrize("text", ["", "   ", "Rechnung Nr. 12", "31.02.2004", "12.03", None])
+def test_parse_user_date_unlesbar(text):
+    assert parse_user_date(text) is None
+
+
+def test_is_iso_date():
+    assert is_iso_date("2004-03-12")
+    assert not is_iso_date("2004-02-30")
+    assert not is_iso_date("12.03.2004")
+    assert not is_iso_date("2004-03-12 00:00:00")
+    assert not is_iso_date("")

--- a/tests/test_document_date_llm.py
+++ b/tests/test_document_date_llm.py
@@ -1,0 +1,104 @@
+"""Issue #132: Dokumentdatum in KI-Antwort und Prompt.
+
+- "datum"/"date"/"dokumentdatum" aus der KI-Antwort landen als
+  ``buchungsdatum`` (Feld "Datum"), egal in welchem Format.
+- Der Prompt nennt den Quellordner als Hinweis, verlangt "datum" im Schema
+  und erklaert, dass Fristen und Scandatum nicht das Dokumentdatum sind.
+"""
+import pytest
+
+from src.ml.llm_provider import (
+    LLMConfig,
+    LLMProvider,
+    normalize_llm_metadata,
+    normalize_metadata_date,
+)
+
+
+class _StubProvider(LLMProvider):
+    def _initialize_client(self): pass
+    def classify_document(self, *a, **kw): pass
+    def suggest_filename(self, *a, **kw): pass
+    def is_available(self): return True
+    def answer_with_context(self, *a, **kw): return ""
+
+
+@pytest.fixture
+def provider():
+    return _StubProvider(LLMConfig(api_key="dummy", model="dummy"))
+
+
+@pytest.mark.parametrize("key", ["datum", "date", "dokumentdatum", "document_date", "buchungsdatum"])
+def test_datum_aliasse_werden_zu_buchungsdatum(key):
+    assert normalize_llm_metadata({key: "2004-03-12"}) == {"buchungsdatum": "2004-03-12"}
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("12.03.2004", "2004-03-12"),
+    ("2004-03-12", "2004-03-12"),
+    ("12. Maerz 2004", "2004-03-12"),
+])
+def test_normalize_metadata_date_bringt_datum_auf_iso(raw, expected):
+    assert normalize_metadata_date({"buchungsdatum": raw, "subject": "Brief"}) == {
+        "buchungsdatum": expected, "subject": "Brief",
+    }
+
+
+def test_normalize_metadata_date_verwirft_unlesbares():
+    assert normalize_metadata_date({"buchungsdatum": "Fruehjahr 2004"}) == {}
+    assert normalize_metadata_date({"subject": "Brief"}) == {"subject": "Brief"}
+    assert normalize_metadata_date("kein dict") == "kein dict"
+
+
+def test_parse_json_response_liefert_iso_datum(provider):
+    text = '{"filename":"x.pdf","metadata":{"datum":"12.03.2004","steuerjahr":"2004"}}'
+    data, err = provider._parse_json_response(text)
+    assert err is None
+    assert data["metadata"] == {"buchungsdatum": "2004-03-12", "steuerjahr": "2004"}
+
+
+def test_parse_json_response_verwirft_unbekanntes_datum(provider):
+    text = '{"filename":"x.pdf","metadata":{"datum":"UNBEKANNT","steuerjahr":"UNBEKANNT"}}'
+    data, _err = provider._parse_json_response(text)
+    assert data["metadata"] == {}
+
+
+def test_prompt_enthaelt_quellordner_und_datum_im_schema(provider):
+    prompt = provider._build_filename_prompt(
+        text="Sehr geehrte Damen und Herren", current_filename="scan.pdf",
+        detected_date="2006-06-30", file_date="2006-07-01", source_folder="Briefe 2004",
+    )
+    assert "Quellordner (kann auf Zeitraum oder Thema hinweisen): Briefe 2004" in prompt
+    assert '"datum": "JJJJ-MM-TT (Datum des Dokuments) oder UNBEKANNT"' in prompt
+    assert "nicht Fristen, Faelligkeits-, Gueltigkeits- oder Geburtsdaten" in prompt
+    assert "Hinweis aus der Texterkennung" in prompt
+    assert "nur Notloesung" in prompt
+    assert "Steuerjahr = Jahr des Dokumentdatums" in prompt
+
+
+def test_prompt_ohne_quellordner(provider):
+    prompt = provider._build_filename_prompt(text="Text", current_filename="scan.pdf")
+    assert "Quellordner" not in prompt
+
+
+def test_source_folder_hint_nicht_fuer_den_scan_ordner(tmp_path, monkeypatch):
+    from src.ml import hybrid_classifier as hc
+
+    class _Cfg:
+        def get_scan_folder(self):
+            return tmp_path / "Scans"
+
+    monkeypatch.setattr(hc, "get_config", lambda: _Cfg())
+    assert hc.source_folder_hint(tmp_path / "Scans" / "a.pdf") is None
+    assert hc.source_folder_hint(tmp_path / "Archiv" / "Briefe 2004" / "a.pdf") == "Briefe 2004"
+
+
+def test_source_folder_hint_ohne_scan_ordner(tmp_path, monkeypatch):
+    from src.ml import hybrid_classifier as hc
+
+    class _Cfg:
+        def get_scan_folder(self):
+            return None
+
+    monkeypatch.setattr(hc, "get_config", lambda: _Cfg())
+    assert hc.source_folder_hint(tmp_path / "Briefe 2004" / "a.pdf") == "Briefe 2004"


### PR DESCRIPTION
Schließt #132 (Ersatz für das gelöschte #130: Dateiname und Steuerjahr zeigten 2006 statt 2004).

## Ursache
- `extract_dates()` nahm das *jüngste* Datum im Text als Dokumentdatum; Fristen, Eingangsstempel oder OCR-Lesefehler mit späterem Jahr gewannen.
- Ohne erkanntes Datum nutzte die KI stillschweigend das Scandatum der Datei (Prompt-Regel 4).

## Änderungen
- **`src/core/document_date.py`** (neu): `find_dates`, `pick_document_date` (beschriftetes Datum > erstes Datum in Lesereihenfolge; „geboren“, „gültig bis“, „fällig“, „Frist“, „Eingang“ nur als Notnagel), `parse_user_date` für Eingaben wie „12.3.2004“ oder „12. März 2004“. `extract_dates()` liefert das Dokumentdatum an Position 0.
- **Detail-Panel**: Feld „Datum“ (`buchungsdatum`, XMP `/Buchungsdatum`) in der ersten Zeile neben dem Steuerjahr, IBAN allein über die volle Breite. Quelle für `{datum}` in den Mustern; Steuerjahr folgt dem Datum, solange es nicht eigenständig gesetzt ist; Unlesbares rot markiert und nicht gespeichert. PDFs mit Metadaten ohne Datum bleiben „gespeichert“ (Analyse-Datum wird verworfen).
- **Vorschau**: „Als Datum übernehmen“ im Rechtsklick-Menü der Textauswahl (#109).
- **KI**: „datum“ im Antwortschema (Alias → `buchungsdatum`, auf ISO normalisiert), Regel 4 erklärt Fristen und Scandatum als Nicht-Dokumentdatum, Quellordner-Name („Briefe 2004“) als Hinweis via `source_folder` durch Hybrid und alle Provider (nicht für den Scan-Ordner selbst).
- Verschieben und Historie nutzen das Datum aus dem Feld vor dem erkannten; alter Umbenennen-Dialog bekommt dasselbe Feld.

Keine neue Datenbankspalte (Suchindex ist FTS5 ohne ALTER; Historie nutzt `detected_date`).

## Tests
984 Tests grün, davon 58 neue (`test_document_date.py`, `test_document_date_llm.py`, `test_detail_panel_datum_gui.py`). Live-Test mit echter KI/OCR steht aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
